### PR TITLE
Refactor error simulation and NestedRNS helper reuse

### DIFF
--- a/src/bench_estimator/mod.rs
+++ b/src/bench_estimator/mod.rs
@@ -981,8 +981,9 @@ mod tests {
     #[sequential]
     fn test_estimate_circuit_bench_reuses_cached_subcircuit_summary_across_param_bindings() {
         let mut sub_circuit = PolyCircuit::<DCRTPoly>::new();
-        let scalar_param = sub_circuit
-            .register_sub_circuit_param(crate::circuit::SubCircuitParamKind::SmallScalarMul);
+        let scalar_param = sub_circuit.register_sub_circuit_param(
+            crate::circuit::SubCircuitParamSpec::SmallScalarMul { max_scalar: 3 },
+        );
         let sub_inputs = sub_circuit.input(1).to_vec();
         let scaled = sub_circuit.small_scalar_mul_param(sub_inputs[0], scalar_param);
         sub_circuit.output(vec![scaled]);

--- a/src/circuit/gate.rs
+++ b/src/circuit/gate.rs
@@ -40,7 +40,6 @@ pub enum SubCircuitParamKind {
     SmallScalarMul,
     LargeScalarMul,
     SlotTransfer,
-    PubLut,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -142,6 +141,16 @@ impl SlotTransferSpec {
             _ => None,
         }
     }
+
+    pub fn max_scalar_bound(&self) -> u32 {
+        match self {
+            Self::Explicit(values) => {
+                values.iter().map(|(_, scalar)| scalar.unwrap_or(1)).max().unwrap_or(1)
+            }
+            Self::Rotation { .. } => 1,
+            Self::Repeated { prefix_scalar, .. } => prefix_scalar.map_or(1, |scalar| scalar.max(1)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -149,7 +158,70 @@ pub enum SubCircuitParamValue {
     SmallScalarMul(Vec<u32>),
     LargeScalarMul(Vec<BigUint>),
     SlotTransfer(SlotTransferSpec),
-    PubLut(usize),
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SubCircuitParamSpec {
+    SmallScalarMul { max_scalar: u32 },
+    LargeScalarMul { max_scalar: BigUint },
+    SlotTransfer { max_scalar: u32 },
+}
+
+impl SubCircuitParamSpec {
+    pub fn kind(&self) -> SubCircuitParamKind {
+        match self {
+            Self::SmallScalarMul { .. } => SubCircuitParamKind::SmallScalarMul,
+            Self::LargeScalarMul { .. } => SubCircuitParamKind::LargeScalarMul,
+            Self::SlotTransfer { .. } => SubCircuitParamKind::SlotTransfer,
+        }
+    }
+
+    pub fn simulator_binding(&self) -> SubCircuitParamValue {
+        match self {
+            Self::SmallScalarMul { max_scalar } => {
+                SubCircuitParamValue::SmallScalarMul(vec![*max_scalar])
+            }
+            Self::LargeScalarMul { max_scalar } => {
+                SubCircuitParamValue::LargeScalarMul(vec![max_scalar.clone()])
+            }
+            Self::SlotTransfer { max_scalar } => SubCircuitParamValue::SlotTransfer(
+                SlotTransferSpec::explicit(vec![(0, Some(*max_scalar))]),
+            ),
+        }
+    }
+
+    pub fn validate_binding(&self, binding: &SubCircuitParamValue, param_id: usize) {
+        match (self, binding) {
+            (Self::SmallScalarMul { max_scalar }, SubCircuitParamValue::SmallScalarMul(values)) => {
+                if let Some(actual_max) = values.iter().copied().max() {
+                    assert!(
+                        actual_max <= *max_scalar,
+                        "sub-circuit SmallScalarMul binding {param_id} exceeds declared max: actual={actual_max}, max={max_scalar}"
+                    );
+                }
+            }
+            (Self::LargeScalarMul { max_scalar }, SubCircuitParamValue::LargeScalarMul(values)) => {
+                if let Some(actual_max) = values.iter().max() {
+                    assert!(
+                        actual_max <= max_scalar,
+                        "sub-circuit LargeScalarMul binding {param_id} exceeds declared max: actual={actual_max}, max={max_scalar}"
+                    );
+                }
+            }
+            (Self::SlotTransfer { max_scalar }, SubCircuitParamValue::SlotTransfer(value)) => {
+                let actual_max = value.max_scalar_bound();
+                assert!(
+                    actual_max <= *max_scalar,
+                    "sub-circuit SlotTransfer binding {param_id} exceeds declared max: actual={actual_max}, max={max_scalar}"
+                );
+            }
+            (expected, actual) => panic!(
+                "sub-circuit parameter kind mismatch for param {param_id}: expected {:?}, got {:?}",
+                expected.kind(),
+                actual.kind()
+            ),
+        }
+    }
 }
 
 impl SubCircuitParamValue {
@@ -158,7 +230,6 @@ impl SubCircuitParamValue {
             Self::SmallScalarMul(_) => SubCircuitParamKind::SmallScalarMul,
             Self::LargeScalarMul(_) => SubCircuitParamKind::LargeScalarMul,
             Self::SlotTransfer(_) => SubCircuitParamKind::SlotTransfer,
-            Self::PubLut(_) => SubCircuitParamKind::PubLut,
         }
     }
 }
@@ -227,18 +298,12 @@ impl GateParamSource<SlotTransferSpec> {
 }
 
 impl GateParamSource<usize> {
-    pub fn resolve_public_lookup(&self, bindings: &[SubCircuitParamValue]) -> usize {
+    pub fn resolve_public_lookup(&self, _bindings: &[SubCircuitParamValue]) -> usize {
         match self {
-            Self::Const(value) => *value,
-            Self::Param(param_id) => match bindings.get(*param_id) {
-                Some(SubCircuitParamValue::PubLut(value)) => *value,
-                Some(other) => panic!(
-                    "sub-circuit parameter kind mismatch for PubLut: expected {:?}, got {:?}",
-                    SubCircuitParamKind::PubLut,
-                    other.kind()
-                ),
-                None => panic!("missing sub-circuit parameter binding {param_id}"),
-            },
+            Self::Const(lut_id) => *lut_id,
+            Self::Param(param_id) => {
+                panic!("parameterized public lookup id {param_id} is not supported")
+            }
         }
     }
 }

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -6,6 +6,6 @@ pub mod serde;
 pub use evaluable::*;
 pub use gate::{
     GateParamSource, PolyGate, PolyGateKind, PolyGateType, SlotTransferSpec, SubCircuitParamKind,
-    SubCircuitParamValue,
+    SubCircuitParamSpec, SubCircuitParamValue,
 };
 pub use poly_circuit::*;

--- a/src/circuit/poly_circuit/construction.rs
+++ b/src/circuit/poly_circuit/construction.rs
@@ -17,6 +17,7 @@ impl<P: Poly> PolyCircuit<P> {
             sub_circuit_calls: BTreeMap::new(),
             summed_sub_circuit_calls: BTreeMap::new(),
             sub_circuit_params: vec![],
+            sub_circuit_input_max_plaintext_norm_ranges: None,
             output_ids: vec![],
             num_input: 0,
             gate_counts,
@@ -369,20 +370,6 @@ impl<P: Poly> PolyCircuit<P> {
         BatchedWire::single(self.new_gate_generic(
             vec![input.as_single_wire()],
             PolyGateType::PubLut { lut_id: GateParamSource::Const(lut_id) },
-        ))
-    }
-
-    pub fn public_lookup_gate_param<I: Into<BatchedWire>>(
-        &mut self,
-        input: I,
-        param_id: usize,
-    ) -> BatchedWire {
-        let input = input.into();
-        debug_assert!(input.is_single_wire());
-        self.expect_sub_circuit_param_kind(param_id, SubCircuitParamKind::PubLut);
-        BatchedWire::single(self.new_gate_generic(
-            vec![input.as_single_wire()],
-            PolyGateType::PubLut { lut_id: GateParamSource::Param(param_id) },
         ))
     }
 

--- a/src/circuit/poly_circuit/mod.rs
+++ b/src/circuit/poly_circuit/mod.rs
@@ -18,7 +18,7 @@ use crate::poly::dcrt::gpu::detected_gpu_device_ids;
 use crate::{
     circuit::{
         Evaluable, GateParamSource, PolyGate, PolyGateKind, PolyGateType, SlotTransferSpec,
-        SubCircuitParamKind, SubCircuitParamValue, gate::GateId,
+        SubCircuitParamKind, SubCircuitParamSpec, SubCircuitParamValue, gate::GateId,
     },
     lookup::{PltEvaluator, PublicLut},
     poly::Poly,
@@ -371,6 +371,7 @@ pub(crate) struct SubCircuitCall {
     pub(crate) shared_input_prefix_set_id: Option<usize>,
     pub(crate) input_suffix: Vec<BatchedWire>,
     pub(crate) binding_set_id: usize,
+    pub(crate) input_max_plaintext_norm_ranges: Option<Arc<[SubCircuitInputMaxPlaintextNormRange]>>,
     pub(crate) scoped_call_id: usize,
     pub(crate) output_gate_ids: Vec<GateId>,
     pub(crate) num_outputs: usize,
@@ -381,6 +382,7 @@ pub(crate) struct SubCircuitCallInfo {
     pub(crate) sub_circuit_id: usize,
     pub(crate) inputs: Vec<BatchedWire>,
     pub(crate) param_bindings: Arc<[SubCircuitParamValue]>,
+    pub(crate) input_max_plaintext_norm_ranges: Option<Arc<[SubCircuitInputMaxPlaintextNormRange]>>,
     pub(crate) output_gate_ids: Vec<GateId>,
 }
 
@@ -389,6 +391,7 @@ pub(crate) struct SummedSubCircuitCall {
     pub(crate) sub_circuit_id: usize,
     pub(crate) call_input_set_ids: Vec<usize>,
     pub(crate) call_binding_set_ids: Vec<usize>,
+    pub(crate) input_max_plaintext_norm_ranges: Option<Arc<[SubCircuitInputMaxPlaintextNormRange]>>,
     pub(crate) scoped_call_ids: Vec<usize>,
     pub(crate) output_gate_ids: Vec<GateId>,
     pub(crate) num_outputs: usize,
@@ -399,6 +402,7 @@ pub(crate) struct SummedSubCircuitCallInfo {
     pub(crate) sub_circuit_id: usize,
     pub(crate) call_inputs: Vec<Vec<BatchedWire>>,
     pub(crate) param_bindings: Vec<Arc<[SubCircuitParamValue]>>,
+    pub(crate) input_max_plaintext_norm_ranges: Option<Arc<[SubCircuitInputMaxPlaintextNormRange]>>,
     pub(crate) output_gate_ids: Vec<GateId>,
 }
 
@@ -435,7 +439,9 @@ pub struct PolyCircuit<P: Poly> {
     pub(crate) print_value: BTreeMap<GateId, String>,
     pub(crate) sub_circuit_calls: BTreeMap<usize, SubCircuitCall>,
     pub(crate) summed_sub_circuit_calls: BTreeMap<usize, SummedSubCircuitCall>,
-    pub(crate) sub_circuit_params: Vec<SubCircuitParamKind>,
+    pub(crate) sub_circuit_params: Vec<SubCircuitParamSpec>,
+    pub(crate) sub_circuit_input_max_plaintext_norm_ranges:
+        Option<Arc<[SubCircuitInputMaxPlaintextNormRange]>>,
     pub(crate) output_ids: Vec<GateId>,
     pub(crate) num_input: usize,
     pub(crate) gate_counts: HashMap<PolyGateKind, usize>,
@@ -455,6 +461,8 @@ impl<P: Poly> PartialEq for PolyCircuit<P> {
             self.sub_circuit_calls == other.sub_circuit_calls &&
             self.summed_sub_circuit_calls == other.summed_sub_circuit_calls &&
             self.sub_circuit_params == other.sub_circuit_params &&
+            self.sub_circuit_input_max_plaintext_norm_ranges ==
+                other.sub_circuit_input_max_plaintext_norm_ranges &&
             self.output_ids == other.output_ids &&
             self.gate_counts == other.gate_counts &&
             self.num_input == other.num_input &&
@@ -486,6 +494,10 @@ impl<P: Poly> std::fmt::Debug for PolyCircuit<P> {
             .field("num_inputs", &self.num_input)
             .field("num_outputs", &self.output_ids.len())
             .field("num_sub_circuit_params", &self.sub_circuit_params.len())
+            .field(
+                "sub_circuit_input_max_plaintext_norm_ranges",
+                &self.sub_circuit_input_max_plaintext_norm_ranges,
+            )
             .field("sub_circuit_calls", &self.sub_circuit_calls)
             .field("summed_sub_circuit_calls", &self.summed_sub_circuit_calls)
             .field("direct_sub_circuit_ids", &direct_sub_circuit_ids)
@@ -502,5 +514,46 @@ impl<P: Poly> std::fmt::Debug for PolyCircuit<P> {
 impl<P: Poly> Default for PolyCircuit<P> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ::serde::Serialize, ::serde::Deserialize)]
+pub struct SubCircuitInputMaxPlaintextNormRange {
+    pub start: usize,
+    pub end: usize,
+    pub norm: BigUint,
+}
+
+impl SubCircuitInputMaxPlaintextNormRange {
+    pub fn new(start: usize, end: usize, norm: BigUint) -> Self {
+        assert!(start <= end, "sub-circuit plaintext range start must not exceed end");
+        Self { start, end, norm }
+    }
+
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
+    pub fn compress(norms: &[BigUint]) -> Vec<Self> {
+        if norms.is_empty() {
+            return Vec::new();
+        }
+        let mut ranges = Vec::new();
+        let mut current_start = 0usize;
+        let mut current_norm = norms[0].clone();
+        for (idx, norm) in norms.iter().enumerate().skip(1) {
+            if *norm == current_norm {
+                continue;
+            }
+            ranges.push(Self::new(current_start, idx, current_norm));
+            current_start = idx;
+            current_norm = norm.clone();
+        }
+        ranges.push(Self::new(current_start, norms.len(), current_norm));
+        ranges
     }
 }

--- a/src/circuit/poly_circuit/subcircuits.rs
+++ b/src/circuit/poly_circuit/subcircuits.rs
@@ -263,6 +263,7 @@ impl<P: Poly> PolyCircuit<P> {
             sub_circuit_id: call.sub_circuit_id,
             inputs: self.collect_sub_circuit_call_inputs(call),
             param_bindings: self.binding_set(call.binding_set_id),
+            input_max_plaintext_norm_ranges: call.input_max_plaintext_norm_ranges.clone(),
             output_gate_ids: call.output_gate_ids.clone(),
         }
     }
@@ -293,6 +294,7 @@ impl<P: Poly> PolyCircuit<P> {
             sub_circuit_id: call.sub_circuit_id,
             call_inputs,
             param_bindings,
+            input_max_plaintext_norm_ranges: call.input_max_plaintext_norm_ranges.clone(),
             output_gate_ids: call.output_gate_ids.clone(),
         }
     }
@@ -314,9 +316,9 @@ impl<P: Poly> PolyCircuit<P> {
         )
     }
 
-    pub fn register_sub_circuit_param(&mut self, kind: SubCircuitParamKind) -> usize {
+    pub fn register_sub_circuit_param(&mut self, spec: SubCircuitParamSpec) -> usize {
         let param_id = self.sub_circuit_params.len();
-        self.sub_circuit_params.push(kind);
+        self.sub_circuit_params.push(spec);
         param_id
     }
 
@@ -328,13 +330,119 @@ impl<P: Poly> PolyCircuit<P> {
         let actual = self
             .sub_circuit_params
             .get(param_id)
-            .copied()
+            .map(SubCircuitParamSpec::kind)
             .unwrap_or_else(|| panic!("sub-circuit parameter {param_id} is out of range"));
         assert_eq!(
             actual, expected,
             "sub-circuit parameter kind mismatch for param {param_id}: expected {:?}, got {:?}",
             expected, actual
         );
+    }
+
+    pub(crate) fn simulator_param_bindings(&self) -> Arc<[SubCircuitParamValue]> {
+        Arc::from(
+            self.sub_circuit_params
+                .iter()
+                .map(SubCircuitParamSpec::simulator_binding)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    pub(crate) fn sub_circuit_input_max_plaintext_norm_ranges(
+        &self,
+    ) -> Option<&[SubCircuitInputMaxPlaintextNormRange]> {
+        self.sub_circuit_input_max_plaintext_norm_ranges.as_deref()
+    }
+
+    pub(crate) fn sub_circuit_call_input_max_plaintext_norm_ranges(
+        &self,
+        call_id: usize,
+    ) -> Option<&[SubCircuitInputMaxPlaintextNormRange]> {
+        self.sub_circuit_calls
+            .get(&call_id)
+            .expect("sub-circuit call missing")
+            .input_max_plaintext_norm_ranges
+            .as_deref()
+    }
+
+    pub(crate) fn summed_sub_circuit_call_input_max_plaintext_norm_ranges(
+        &self,
+        summed_call_id: usize,
+    ) -> Option<&[SubCircuitInputMaxPlaintextNormRange]> {
+        self.summed_sub_circuit_calls
+            .get(&summed_call_id)
+            .expect("summed sub-circuit call missing")
+            .input_max_plaintext_norm_ranges
+            .as_deref()
+    }
+
+    fn validate_sub_circuit_input_max_plaintext_norm_ranges(
+        &self,
+        ranges: &[SubCircuitInputMaxPlaintextNormRange],
+        context: &str,
+    ) {
+        let mut expected_start = 0usize;
+        for range in ranges {
+            assert!(
+                !range.is_empty(),
+                "{context}: sub-circuit plaintext range [{}, {}) must not be empty",
+                range.start,
+                range.end
+            );
+            assert_eq!(
+                range.start, expected_start,
+                "{context}: sub-circuit plaintext ranges must be contiguous and sorted"
+            );
+            assert!(
+                range.end <= self.num_input(),
+                "{context}: sub-circuit plaintext range [{}, {}) exceeds num_input={}",
+                range.start,
+                range.end,
+                self.num_input()
+            );
+            expected_start = range.end;
+        }
+        assert_eq!(
+            expected_start,
+            self.num_input(),
+            "{context}: sub-circuit plaintext ranges must cover every input wire"
+        );
+    }
+
+    fn normalized_sub_circuit_input_max_plaintext_norm_ranges<I>(
+        &self,
+        circuit_id: usize,
+        ranges: Option<I>,
+        context: &str,
+    ) -> Option<Arc<[SubCircuitInputMaxPlaintextNormRange]>>
+    where
+        I: IntoIterator<Item = SubCircuitInputMaxPlaintextNormRange>,
+    {
+        let ranges = ranges?;
+        let ranges = Arc::from(ranges.into_iter().collect::<Vec<_>>());
+        let stored = self.sub_circuit_registry.get(circuit_id);
+        stored.validate_sub_circuit_input_max_plaintext_norm_ranges(&ranges, context);
+        Some(ranges)
+    }
+
+    fn validate_sub_circuit_param_bindings(
+        &self,
+        circuit_id: usize,
+        param_bindings: &[SubCircuitParamValue],
+        context: &str,
+    ) {
+        let stored = self.sub_circuit_registry.get(circuit_id);
+        let expected_param_specs = &stored.sub_circuit_params;
+        assert_eq!(
+            param_bindings.len(),
+            expected_param_specs.len(),
+            "{context}: sub-circuit parameter count mismatch"
+        );
+        for (param_idx, (binding, expected_spec)) in
+            param_bindings.iter().zip(expected_param_specs.iter()).enumerate()
+        {
+            expected_spec.validate_binding(binding, param_idx);
+        }
     }
 
     pub(crate) fn direct_sub_circuit_ids(&self) -> BTreeSet<usize> {
@@ -406,12 +514,54 @@ impl<P: Poly> PolyCircuit<P> {
         self.sub_circuit_registry.register_arc(sub_circuit)
     }
 
+    pub fn register_sub_circuit_with_max_plaintext_norms<T, I>(
+        &mut self,
+        sub_circuit: T,
+        max_plaintext_norm_ranges: I,
+    ) -> usize
+    where
+        T: Into<Arc<Self>>,
+        I: IntoIterator<Item = SubCircuitInputMaxPlaintextNormRange>,
+    {
+        let mut sub_circuit = sub_circuit.into();
+        let ranges = Arc::from(max_plaintext_norm_ranges.into_iter().collect::<Vec<_>>());
+        {
+            let sub_circuit_mut = Arc::make_mut(&mut sub_circuit);
+            sub_circuit_mut.inherit_registries_from_parent(self);
+            sub_circuit_mut.validate_sub_circuit_input_max_plaintext_norm_ranges(
+                &ranges,
+                "sub-circuit registration",
+            );
+            sub_circuit_mut.sub_circuit_input_max_plaintext_norm_ranges = Some(ranges);
+        }
+        self.sub_circuit_registry.register_arc(sub_circuit)
+    }
+
     pub fn call_sub_circuit<I, W>(&mut self, circuit_id: usize, inputs: I) -> Vec<BatchedWire>
     where
         I: IntoIterator<Item = W>,
         W: Into<BatchedWire>,
     {
         self.call_sub_circuit_with_bindings(circuit_id, inputs, &[])
+    }
+
+    pub fn call_sub_circuit_with_max_plaintext_norms<I, W, R>(
+        &mut self,
+        circuit_id: usize,
+        inputs: I,
+        input_max_plaintext_norm_ranges: R,
+    ) -> Vec<BatchedWire>
+    where
+        I: IntoIterator<Item = W>,
+        W: Into<BatchedWire>,
+        R: IntoIterator<Item = SubCircuitInputMaxPlaintextNormRange>,
+    {
+        self.call_sub_circuit_with_bindings_and_max_plaintext_norms(
+            circuit_id,
+            inputs,
+            &[],
+            input_max_plaintext_norm_ranges,
+        )
     }
 
     pub fn call_sub_circuit_with_shared_input_prefix_and_bindings<I, W>(
@@ -425,11 +575,55 @@ impl<P: Poly> PolyCircuit<P> {
         I: IntoIterator<Item = W>,
         W: Into<BatchedWire>,
     {
-        self.call_sub_circuit_with_prefix_and_bindings(
+        self.call_sub_circuit_with_prefix_and_bindings_and_max_plaintext_norms(
             circuit_id,
             Some(shared_input_prefix_set_id),
             input_suffix,
             param_bindings,
+            Option::<Vec<SubCircuitInputMaxPlaintextNormRange>>::None,
+        )
+    }
+
+    pub fn call_sub_circuit_with_shared_input_prefix_and_bindings_and_max_plaintext_norms<I, W, R>(
+        &mut self,
+        circuit_id: usize,
+        shared_input_prefix_set_id: usize,
+        input_suffix: I,
+        param_bindings: &[SubCircuitParamValue],
+        input_max_plaintext_norm_ranges: R,
+    ) -> Vec<BatchedWire>
+    where
+        I: IntoIterator<Item = W>,
+        W: Into<BatchedWire>,
+        R: IntoIterator<Item = SubCircuitInputMaxPlaintextNormRange>,
+    {
+        self.call_sub_circuit_with_prefix_and_bindings_and_max_plaintext_norms(
+            circuit_id,
+            Some(shared_input_prefix_set_id),
+            input_suffix,
+            param_bindings,
+            Some(input_max_plaintext_norm_ranges),
+        )
+    }
+
+    pub fn call_sub_circuit_with_bindings_and_max_plaintext_norms<I, W, R>(
+        &mut self,
+        circuit_id: usize,
+        inputs: I,
+        param_bindings: &[SubCircuitParamValue],
+        input_max_plaintext_norm_ranges: R,
+    ) -> Vec<BatchedWire>
+    where
+        I: IntoIterator<Item = W>,
+        W: Into<BatchedWire>,
+        R: IntoIterator<Item = SubCircuitInputMaxPlaintextNormRange>,
+    {
+        self.call_sub_circuit_with_prefix_and_bindings_and_max_plaintext_norms(
+            circuit_id,
+            None,
+            inputs,
+            param_bindings,
+            Some(input_max_plaintext_norm_ranges),
         )
     }
 
@@ -443,42 +637,47 @@ impl<P: Poly> PolyCircuit<P> {
         I: IntoIterator<Item = W>,
         W: Into<BatchedWire>,
     {
-        self.call_sub_circuit_with_prefix_and_bindings(circuit_id, None, inputs, param_bindings)
+        self.call_sub_circuit_with_prefix_and_bindings_and_max_plaintext_norms(
+            circuit_id,
+            None,
+            inputs,
+            param_bindings,
+            Option::<Vec<SubCircuitInputMaxPlaintextNormRange>>::None,
+        )
     }
 
-    fn call_sub_circuit_with_prefix_and_bindings<I, W>(
+    fn call_sub_circuit_with_prefix_and_bindings_and_max_plaintext_norms<I, W, R>(
         &mut self,
         circuit_id: usize,
         shared_input_prefix_set_id: Option<usize>,
         input_suffix: I,
         param_bindings: &[SubCircuitParamValue],
+        input_max_plaintext_norm_ranges: Option<R>,
     ) -> Vec<BatchedWire>
     where
         I: IntoIterator<Item = W>,
         W: Into<BatchedWire>,
+        R: IntoIterator<Item = SubCircuitInputMaxPlaintextNormRange>,
     {
         let input_suffix = input_suffix.into_iter().map(Into::into).collect::<Vec<_>>();
         let total_num_inputs = shared_input_prefix_set_id
             .map(|input_set_id| batched_wire_slice_len(self.input_set(input_set_id).as_ref()))
             .unwrap_or(0) +
             batched_wire_slice_len(&input_suffix);
-        #[cfg(debug_assertions)]
-        {
-            let stored = self.sub_circuit_registry.get(circuit_id);
-            let num_inputs = stored.num_input();
-            assert_eq!(total_num_inputs, num_inputs);
-            let expected_param_kinds = &stored.sub_circuit_params;
-            assert_eq!(param_bindings.len(), expected_param_kinds.len());
-            for (param_idx, (binding, expected_kind)) in
-                param_bindings.iter().zip(expected_param_kinds.iter()).enumerate()
-            {
-                assert_eq!(
-                    binding.kind(),
-                    *expected_kind,
-                    "sub-circuit parameter kind mismatch at binding {param_idx}"
-                );
-            }
-        }
+        let stored = self.sub_circuit_registry.get(circuit_id);
+        let num_inputs = stored.num_input();
+        assert_eq!(total_num_inputs, num_inputs);
+        self.validate_sub_circuit_param_bindings(
+            circuit_id,
+            param_bindings,
+            "direct sub-circuit call",
+        );
+        let input_max_plaintext_norm_ranges = self
+            .normalized_sub_circuit_input_max_plaintext_norm_ranges(
+                circuit_id,
+                input_max_plaintext_norm_ranges,
+                "direct sub-circuit call",
+            );
         let num_outputs = self.sub_circuit_num_output(circuit_id);
         let call_id = self.sub_circuit_calls.len();
         let binding_set_id = self.binding_registry.register(param_bindings);
@@ -497,6 +696,7 @@ impl<P: Poly> PolyCircuit<P> {
             shared_input_prefix_set_id,
             input_suffix,
             binding_set_id,
+            input_max_plaintext_norm_ranges,
             scoped_call_id,
             output_gate_ids: output_gate_ids.clone(),
             num_outputs,
@@ -511,6 +711,24 @@ impl<P: Poly> PolyCircuit<P> {
         call_input_set_ids: Vec<usize>,
         call_binding_set_ids: Vec<usize>,
     ) -> Vec<BatchedWire> {
+        self.call_sub_circuit_sum_many_with_binding_set_ids_and_max_plaintext_norms(
+            circuit_id,
+            call_input_set_ids,
+            call_binding_set_ids,
+            Option::<Vec<SubCircuitInputMaxPlaintextNormRange>>::None,
+        )
+    }
+
+    pub fn call_sub_circuit_sum_many_with_binding_set_ids_and_max_plaintext_norms<R>(
+        &mut self,
+        circuit_id: usize,
+        call_input_set_ids: Vec<usize>,
+        call_binding_set_ids: Vec<usize>,
+        input_max_plaintext_norm_ranges: Option<R>,
+    ) -> Vec<BatchedWire>
+    where
+        R: IntoIterator<Item = SubCircuitInputMaxPlaintextNormRange>,
+    {
         assert!(
             !call_input_set_ids.is_empty(),
             "summed sub-circuit call requires at least one inner call"
@@ -520,11 +738,9 @@ impl<P: Poly> PolyCircuit<P> {
             call_binding_set_ids.len(),
             "summed sub-circuit call requires one binding set per inner call"
         );
-        #[cfg(debug_assertions)]
         {
             let stored = self.sub_circuit_registry.get(circuit_id);
-            let (num_inputs, expected_param_kinds) =
-                (stored.num_input(), &stored.sub_circuit_params);
+            let num_inputs = stored.num_input();
             for (call_idx, (input_set_id, binding_set_id)) in
                 call_input_set_ids.iter().zip(call_binding_set_ids.iter()).enumerate()
             {
@@ -535,22 +751,19 @@ impl<P: Poly> PolyCircuit<P> {
                     "summed sub-circuit input count mismatch at inner call {call_idx}"
                 );
                 let bindings = self.binding_set(*binding_set_id);
-                assert_eq!(
-                    bindings.len(),
-                    expected_param_kinds.len(),
-                    "summed sub-circuit parameter count mismatch at inner call {call_idx}"
+                self.validate_sub_circuit_param_bindings(
+                    circuit_id,
+                    bindings.as_ref(),
+                    "summed sub-circuit call",
                 );
-                for (param_idx, (binding, expected_kind)) in
-                    bindings.iter().zip(expected_param_kinds.iter()).enumerate()
-                {
-                    assert_eq!(
-                        binding.kind(),
-                        *expected_kind,
-                        "summed sub-circuit parameter kind mismatch at inner call {call_idx}, binding {param_idx}"
-                    );
-                }
             }
         }
+        let input_max_plaintext_norm_ranges = self
+            .normalized_sub_circuit_input_max_plaintext_norm_ranges(
+                circuit_id,
+                input_max_plaintext_norm_ranges,
+                "summed sub-circuit call",
+            );
         let num_outputs = self.sub_circuit_num_output(circuit_id);
         let summed_call_id = self.summed_sub_circuit_calls.len();
         let scoped_call_ids = (0..call_input_set_ids.len())
@@ -579,6 +792,7 @@ impl<P: Poly> PolyCircuit<P> {
                 sub_circuit_id: circuit_id,
                 call_input_set_ids,
                 call_binding_set_ids,
+                input_max_plaintext_norm_ranges,
                 scoped_call_ids,
                 output_gate_ids: output_gate_ids.clone(),
                 num_outputs,

--- a/src/circuit/poly_circuit/tests.rs
+++ b/src/circuit/poly_circuit/tests.rs
@@ -701,7 +701,8 @@ fn test_register_and_call_parameterized_sub_circuit() {
     let input_poly = create_random_poly(&params);
 
     let mut sub_circuit = PolyCircuit::new();
-    let scalar_param = sub_circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul);
+    let scalar_param = sub_circuit
+        .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar: 3 });
     let sub_inputs = sub_circuit.input(1).to_vec();
     let scaled = sub_circuit.small_scalar_mul_param(sub_inputs[0], scalar_param);
     sub_circuit.output(vec![scaled]);
@@ -736,7 +737,8 @@ fn test_register_and_call_parameterized_sub_circuit() {
 #[test]
 fn test_parameterized_sub_circuit_reuses_identical_binding_sets() {
     let mut sub_circuit = PolyCircuit::<DCRTPoly>::new();
-    let scalar_param = sub_circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul);
+    let scalar_param = sub_circuit
+        .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar: 9 });
     let sub_inputs = sub_circuit.input(1).to_vec();
     let scaled = sub_circuit.small_scalar_mul_param(sub_inputs[0], scalar_param);
     sub_circuit.output(vec![scaled]);
@@ -745,17 +747,17 @@ fn test_parameterized_sub_circuit_reuses_identical_binding_sets() {
     let main_inputs = main_circuit.input(1).to_vec();
     let sub_id = main_circuit.register_sub_circuit(sub_circuit);
 
-    let _ = main_circuit.call_sub_circuit_with_bindings(
+    main_circuit.call_sub_circuit_with_bindings(
         sub_id,
         &[main_inputs[0]],
         &[SubCircuitParamValue::SmallScalarMul(vec![7])],
     );
-    let _ = main_circuit.call_sub_circuit_with_bindings(
+    main_circuit.call_sub_circuit_with_bindings(
         sub_id,
         &[main_inputs[0]],
         &[SubCircuitParamValue::SmallScalarMul(vec![7])],
     );
-    let _ = main_circuit.call_sub_circuit_with_bindings(
+    main_circuit.call_sub_circuit_with_bindings(
         sub_id,
         &[main_inputs[0]],
         &[SubCircuitParamValue::SmallScalarMul(vec![9])],
@@ -770,9 +772,48 @@ fn test_parameterized_sub_circuit_reuses_identical_binding_sets() {
 }
 
 #[test]
+#[should_panic(expected = "exceeds declared max")]
+fn test_parameterized_sub_circuit_rejects_binding_above_declared_max() {
+    let mut sub_circuit = PolyCircuit::<DCRTPoly>::new();
+    let scalar_param = sub_circuit
+        .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar: 3 });
+    let sub_inputs = sub_circuit.input(1).to_vec();
+    let scaled = sub_circuit.small_scalar_mul_param(sub_inputs[0], scalar_param);
+    sub_circuit.output(vec![scaled]);
+
+    let mut main_circuit = PolyCircuit::<DCRTPoly>::new();
+    let main_inputs = main_circuit.input(1).to_vec();
+    let sub_id = main_circuit.register_sub_circuit(sub_circuit);
+    main_circuit.call_sub_circuit_with_bindings(
+        sub_id,
+        &[main_inputs[0]],
+        &[SubCircuitParamValue::SmallScalarMul(vec![4])],
+    );
+}
+
+#[test]
+fn test_register_sub_circuit_with_max_plaintext_norms_preserves_ranges() {
+    let mut sub_circuit = PolyCircuit::<DCRTPoly>::new();
+    let sub_inputs = sub_circuit.input(4).to_vec();
+    sub_circuit.output(sub_inputs.clone());
+
+    let mut main_circuit = PolyCircuit::<DCRTPoly>::new();
+    let ranges = vec![
+        SubCircuitInputMaxPlaintextNormRange::new(0, 2, BigUint::from(7u64)),
+        SubCircuitInputMaxPlaintextNormRange::new(2, 4, BigUint::from(31u64)),
+    ];
+    let sub_id =
+        main_circuit.register_sub_circuit_with_max_plaintext_norms(sub_circuit, ranges.clone());
+
+    let registered = main_circuit.registered_sub_circuit_ref(sub_id);
+    assert_eq!(registered.sub_circuit_input_max_plaintext_norm_ranges(), Some(ranges.as_slice()));
+}
+
+#[test]
 fn test_register_sub_circuit_reuses_child_binding_sets_without_duplication() {
     let mut leaf_circuit = PolyCircuit::<DCRTPoly>::new();
-    let scalar_param = leaf_circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul);
+    let scalar_param = leaf_circuit
+        .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar: 11 });
     let leaf_inputs = leaf_circuit.input(1).to_vec();
     let scaled = leaf_circuit.small_scalar_mul_param(leaf_inputs[0], scalar_param);
     leaf_circuit.output(vec![scaled]);
@@ -780,12 +821,12 @@ fn test_register_sub_circuit_reuses_child_binding_sets_without_duplication() {
     let mut middle_circuit = PolyCircuit::<DCRTPoly>::new();
     let middle_inputs = middle_circuit.input(1).to_vec();
     let leaf_id = middle_circuit.register_sub_circuit(leaf_circuit);
-    let _ = middle_circuit.call_sub_circuit_with_bindings(
+    middle_circuit.call_sub_circuit_with_bindings(
         leaf_id,
         &[middle_inputs[0]],
         &[SubCircuitParamValue::SmallScalarMul(vec![11])],
     );
-    let _ = middle_circuit.call_sub_circuit_with_bindings(
+    middle_circuit.call_sub_circuit_with_bindings(
         leaf_id,
         &[middle_inputs[0]],
         &[SubCircuitParamValue::SmallScalarMul(vec![11])],
@@ -795,7 +836,7 @@ fn test_register_sub_circuit_reuses_child_binding_sets_without_duplication() {
     let mut main_circuit = PolyCircuit::<DCRTPoly>::new();
     let main_inputs = main_circuit.input(1).to_vec();
     let middle_id = main_circuit.register_sub_circuit(middle_circuit);
-    let _ = main_circuit.call_sub_circuit(middle_id, &[main_inputs[0]]);
+    main_circuit.call_sub_circuit(middle_id, &[main_inputs[0]]);
 
     assert_eq!(main_circuit.binding_registry.binding_sets.len(), 2);
     let registered_middle = main_circuit.registered_sub_circuit_ref(middle_id);
@@ -808,7 +849,8 @@ fn test_register_and_call_summed_parameterized_sub_circuit() {
     let input_poly = create_random_poly(&params);
 
     let mut sub_circuit = PolyCircuit::new();
-    let scalar_param = sub_circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul);
+    let scalar_param = sub_circuit
+        .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar: 3 });
     let sub_inputs = sub_circuit.input(1).to_vec();
     let scaled = sub_circuit.small_scalar_mul_param(sub_inputs[0], scalar_param);
     sub_circuit.output(vec![scaled]);

--- a/src/circuit/serde.rs
+++ b/src/circuit/serde.rs
@@ -1,7 +1,7 @@
 use crate::{
     circuit::{
         BatchedWire, GateParamSource, PolyCircuit, PolyGate, PolyGateType, SubCircuitCall,
-        SubCircuitParamKind, SubCircuitParamValue,
+        SubCircuitParamSpec, SubCircuitParamValue,
         gate::{GateId, SlotTransferSpec},
     },
     poly::Poly,
@@ -22,7 +22,7 @@ pub enum SerializablePolyGateType {
     Add,
     Sub,
     Mul,
-    PubLut { lut_id: GateParamSource<usize> },
+    PubLut { lut_id: usize },
     SubCircuitOutput { call_id: usize, output_idx: usize, num_inputs: usize },
     SummedSubCircuitOutput { summed_call_id: usize, output_idx: usize, num_inputs: usize },
 }
@@ -68,6 +68,8 @@ pub struct SerializableSubCircuitCall {
     pub shared_input_prefix: Option<Vec<BatchedWire>>,
     pub input_suffix: Vec<BatchedWire>,
     pub param_bindings: Vec<SubCircuitParamValue>,
+    pub input_max_plaintext_norm_ranges:
+        Option<Vec<crate::circuit::SubCircuitInputMaxPlaintextNormRange>>,
     pub scoped_call_id: usize,
     pub output_gate_ids: Vec<GateId>,
     pub num_outputs: usize,
@@ -78,6 +80,8 @@ pub struct SerializableSummedSubCircuitCall {
     pub sub_circuit_id: usize,
     pub call_inputs: Vec<Vec<BatchedWire>>,
     pub param_bindings: Vec<Vec<SubCircuitParamValue>>,
+    pub input_max_plaintext_norm_ranges:
+        Option<Vec<crate::circuit::SubCircuitInputMaxPlaintextNormRange>>,
     pub scoped_call_ids: Vec<usize>,
     pub output_gate_ids: Vec<GateId>,
     pub num_outputs: usize,
@@ -89,7 +93,9 @@ pub struct SerializablePolyCircuit {
     sub_circuits: BTreeMap<usize, Box<SerializablePolyCircuit>>,
     sub_circuit_calls: BTreeMap<usize, SerializableSubCircuitCall>,
     summed_sub_circuit_calls: BTreeMap<usize, SerializableSummedSubCircuitCall>,
-    sub_circuit_params: Vec<SubCircuitParamKind>,
+    sub_circuit_params: Vec<SubCircuitParamSpec>,
+    sub_circuit_input_max_plaintext_norm_ranges:
+        Option<Vec<crate::circuit::SubCircuitInputMaxPlaintextNormRange>>,
     output_ids: Vec<GateId>,
     num_input: usize,
     next_scoped_call_id: usize,
@@ -120,7 +126,10 @@ impl SerializablePolyCircuit {
         sub_circuits: BTreeMap<usize, Box<SerializablePolyCircuit>>,
         sub_circuit_calls: BTreeMap<usize, SerializableSubCircuitCall>,
         summed_sub_circuit_calls: BTreeMap<usize, SerializableSummedSubCircuitCall>,
-        sub_circuit_params: Vec<SubCircuitParamKind>,
+        sub_circuit_params: Vec<SubCircuitParamSpec>,
+        sub_circuit_input_max_plaintext_norm_ranges: Option<
+            Vec<crate::circuit::SubCircuitInputMaxPlaintextNormRange>,
+        >,
         output_ids: Vec<GateId>,
         num_input: usize,
         next_scoped_call_id: usize,
@@ -131,6 +140,7 @@ impl SerializablePolyCircuit {
             sub_circuit_calls,
             summed_sub_circuit_calls,
             sub_circuit_params,
+            sub_circuit_input_max_plaintext_norm_ranges,
             output_ids,
             num_input,
             next_scoped_call_id,
@@ -156,6 +166,10 @@ impl SerializablePolyCircuit {
                         shared_input_prefix,
                         input_suffix: call.input_suffix.clone(),
                         param_bindings,
+                        input_max_plaintext_norm_ranges: call
+                            .input_max_plaintext_norm_ranges
+                            .as_ref()
+                            .map(|ranges| ranges.as_ref().to_vec()),
                         scoped_call_id: call.scoped_call_id,
                         output_gate_ids: call.output_gate_ids.clone(),
                         num_outputs: call.num_outputs,
@@ -189,6 +203,10 @@ impl SerializablePolyCircuit {
                         sub_circuit_id: call.sub_circuit_id,
                         call_inputs,
                         param_bindings,
+                        input_max_plaintext_norm_ranges: call
+                            .input_max_plaintext_norm_ranges
+                            .as_ref()
+                            .map(|ranges| ranges.as_ref().to_vec()),
                         scoped_call_ids: call.scoped_call_ids.clone(),
                         output_gate_ids: call.output_gate_ids.clone(),
                         num_outputs: call.num_outputs,
@@ -222,6 +240,9 @@ impl SerializablePolyCircuit {
                             PolyGateType::Sub => SerializablePolyGateType::Sub,
                             PolyGateType::Mul => SerializablePolyGateType::Mul,
                             PolyGateType::PubLut { lut_id } => {
+                                let GateParamSource::Const(lut_id) = lut_id else {
+                                    panic!("parameterized public lookup ids are not serializable");
+                                };
                                 SerializablePolyGateType::PubLut { lut_id }
                             }
                             PolyGateType::SubCircuitOutput { call_id, output_idx, num_inputs } => {
@@ -274,6 +295,10 @@ impl SerializablePolyCircuit {
             calls_vec.into_iter().collect(),
             summed_calls_vec.into_iter().collect(),
             circuit.sub_circuit_params,
+            circuit
+                .sub_circuit_input_max_plaintext_norm_ranges
+                .as_ref()
+                .map(|ranges| ranges.as_ref().to_vec()),
             circuit.output_ids,
             circuit.num_input,
             circuit.next_scoped_call_id,
@@ -358,7 +383,9 @@ impl SerializablePolyCircuit {
                                     SerializablePolyGateType::Sub => PolyGateType::Sub,
                                     SerializablePolyGateType::Mul => PolyGateType::Mul,
                                     SerializablePolyGateType::PubLut { lut_id } => {
-                                        PolyGateType::PubLut { lut_id }
+                                        PolyGateType::PubLut {
+                                            lut_id: GateParamSource::Const(lut_id),
+                                        }
                                     }
                                     SerializablePolyGateType::SubCircuitOutput {
                                         call_id,
@@ -425,6 +452,9 @@ impl SerializablePolyCircuit {
                         shared_input_prefix_set_id,
                         input_suffix: call.input_suffix,
                         binding_set_id,
+                        input_max_plaintext_norm_ranges: call
+                            .input_max_plaintext_norm_ranges
+                            .map(Arc::from),
                         scoped_call_id: call.scoped_call_id,
                         output_gate_ids: call.output_gate_ids,
                         num_outputs: call.num_outputs,
@@ -451,6 +481,9 @@ impl SerializablePolyCircuit {
                         sub_circuit_id: call.sub_circuit_id,
                         call_input_set_ids,
                         call_binding_set_ids,
+                        input_max_plaintext_norm_ranges: call
+                            .input_max_plaintext_norm_ranges
+                            .map(Arc::from),
                         scoped_call_ids: call.scoped_call_ids,
                         output_gate_ids: call.output_gate_ids,
                         num_outputs: call.num_outputs,
@@ -459,6 +492,8 @@ impl SerializablePolyCircuit {
             })
             .collect();
         circuit.sub_circuit_params = self.sub_circuit_params;
+        circuit.sub_circuit_input_max_plaintext_norm_ranges =
+            self.sub_circuit_input_max_plaintext_norm_ranges.map(Arc::from);
         circuit.num_input = self.num_input;
         circuit.output_ids = self.output_ids;
         circuit.next_scoped_call_id = self.next_scoped_call_id;
@@ -593,8 +628,8 @@ mod tests {
     #[test]
     fn test_serialization_roundtrip_with_parameterized_sub_circuit() {
         let mut sub_circuit: PolyCircuit<DCRTPoly> = PolyCircuit::new();
-        let scalar_param =
-            sub_circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul);
+        let scalar_param = sub_circuit
+            .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar: 5 });
         let sub_inputs = sub_circuit.input(1).to_vec();
         let scaled = sub_circuit.small_scalar_mul_param(sub_inputs[0], scalar_param);
         sub_circuit.output(vec![scaled]);
@@ -617,8 +652,8 @@ mod tests {
     #[test]
     fn test_serialization_roundtrip_with_summed_sub_circuit() {
         let mut sub_circuit: PolyCircuit<DCRTPoly> = PolyCircuit::new();
-        let scalar_param =
-            sub_circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul);
+        let scalar_param = sub_circuit
+            .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar: 3 });
         let sub_inputs = sub_circuit.input(1).to_vec();
         let scaled = sub_circuit.small_scalar_mul_param(sub_inputs[0], scalar_param);
         sub_circuit.output(vec![scaled]);

--- a/src/gadgets/arith/nested_rns/context.rs
+++ b/src/gadgets/arith/nested_rns/context.rs
@@ -706,16 +706,25 @@ impl NestedRnsPolyContext {
         let inputs = circuit.input(p_moduli_depth);
         let x = inputs;
         let scalar_y_param_ids = (0..p_moduli_depth)
-            .map(|_| {
+            .map(|p_idx| {
+                let max_scalar =
+                    u32::try_from(p_moduli[p_idx] - 1).expect("p modulus must fit in u32");
                 (0..p_moduli_depth)
                     .map(|_| {
-                        circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul)
+                        circuit.register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul {
+                            max_scalar,
+                        })
                     })
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
         let scalar_v_param_ids = (0..p_moduli_depth)
-            .map(|_| circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul))
+            .map(|p_idx| {
+                let max_scalar =
+                    u32::try_from(p_moduli[p_idx] - 1).expect("p modulus must fit in u32");
+                circuit
+                    .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar })
+            })
             .collect::<Vec<_>>();
 
         let ys = (0..p_moduli_depth)
@@ -755,7 +764,11 @@ impl NestedRnsPolyContext {
         let (left, right) = inputs.split_at(p_moduli_depth);
         let one = circuit.const_one_gate();
         let offset_param_ids = (0..p_moduli_depth)
-            .map(|_| circuit.register_sub_circuit_param(SubCircuitParamKind::LargeScalarMul))
+            .map(|_| {
+                circuit.register_sub_circuit_param(SubCircuitParamSpec::LargeScalarMul {
+                    max_scalar: BigUint::from(u128::MAX),
+                })
+            })
             .collect::<Vec<_>>();
         let outputs = (0..p_moduli_depth)
             .map(|p_idx| {

--- a/src/gadgets/arith/nested_rns/context.rs
+++ b/src/gadgets/arith/nested_rns/context.rs
@@ -223,17 +223,19 @@ impl NestedRnsPolyContext {
     fn register_local_support_subcircuits<P: Poly + 'static>(
         circuit: &mut PolyCircuit<P>,
         p_moduli: &[u64],
+        p_max: u64,
+        trace_capacity_bound: &BigUint,
         lut_mod_p_ids: &[usize],
         lut_x_to_y_ids: &[usize],
         lut_x_to_real_ids: &[usize],
         lut_real_to_v_id: usize,
     ) -> NestedRnsRegisteredSubcircuitIds {
-        let p_moduli_depth = p_moduli.len();
         NestedRnsRegisteredSubcircuitIds {
             add_without_reduce_id: circuit
                 .register_sub_circuit(Self::add_without_reduce_subcircuit::<P>(p_moduli)),
-            sub_with_trace_offsets_id: circuit
-                .register_sub_circuit(Self::sub_with_trace_offsets_subcircuit::<P>(p_moduli_depth)),
+            sub_with_trace_offsets_id: circuit.register_sub_circuit(
+                Self::sub_with_trace_offsets_subcircuit::<P>(p_moduli, p_max, trace_capacity_bound),
+            ),
             lazy_reduce_id: circuit
                 .register_sub_circuit(Self::lazy_reduce_subcircuit::<P>(p_moduli, lut_mod_p_ids)),
             decomposition_terms_id: circuit.register_sub_circuit(
@@ -325,6 +327,8 @@ impl NestedRnsPolyContext {
             let registered_ids = Self::register_local_support_subcircuits::<P>(
                 circuit,
                 &p_moduli,
+                max_p_modulus,
+                &lut_mod_p_max_map_size,
                 &lut_mod_p_ids,
                 &lut_x_to_y_ids,
                 &lut_x_to_real_ids,
@@ -507,6 +511,8 @@ impl NestedRnsPolyContext {
         let registered_ids = Self::register_local_support_subcircuits::<P>(
             circuit,
             &p_moduli,
+            max_p_modulus,
+            &lut_mod_p_max_map_size,
             &lut_mod_p_ids,
             &lut_x_to_y_ids,
             &lut_x_to_real_ids,
@@ -706,16 +712,25 @@ impl NestedRnsPolyContext {
         let inputs = circuit.input(p_moduli_depth);
         let x = inputs;
         let scalar_y_param_ids = (0..p_moduli_depth)
-            .map(|_| {
+            .map(|p_idx| {
+                let max_scalar =
+                    u32::try_from(p_moduli[p_idx] - 1).expect("p modulus must fit in u32");
                 (0..p_moduli_depth)
                     .map(|_| {
-                        circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul)
+                        circuit.register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul {
+                            max_scalar,
+                        })
                     })
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
         let scalar_v_param_ids = (0..p_moduli_depth)
-            .map(|_| circuit.register_sub_circuit_param(SubCircuitParamKind::SmallScalarMul))
+            .map(|p_idx| {
+                let max_scalar =
+                    u32::try_from(p_moduli[p_idx] - 1).expect("p modulus must fit in u32");
+                circuit
+                    .register_sub_circuit_param(SubCircuitParamSpec::SmallScalarMul { max_scalar })
+            })
             .collect::<Vec<_>>();
 
         let ys = (0..p_moduli_depth)
@@ -749,13 +764,24 @@ impl NestedRnsPolyContext {
         circuit
     }
 
-    fn sub_with_trace_offsets_subcircuit<P: Poly>(p_moduli_depth: usize) -> PolyCircuit<P> {
+    fn sub_with_trace_offsets_subcircuit<P: Poly>(
+        p_moduli: &[u64],
+        p_max: u64,
+        trace_capacity_bound: &BigUint,
+    ) -> PolyCircuit<P> {
         let mut circuit = PolyCircuit::<P>::new();
+        let p_moduli_depth = p_moduli.len();
         let inputs = circuit.input(2 * p_moduli_depth);
         let (left, right) = inputs.split_at(p_moduli_depth);
         let one = circuit.const_one_gate();
+        let max_trace = trace_capacity_bound - BigUint::from(1u64);
+        let max_offset_multiplier = (&max_trace + BigUint::from(p_max - 1)) / BigUint::from(p_max);
         let offset_param_ids = (0..p_moduli_depth)
-            .map(|_| circuit.register_sub_circuit_param(SubCircuitParamKind::LargeScalarMul))
+            .map(|p_idx| {
+                circuit.register_sub_circuit_param(SubCircuitParamSpec::LargeScalarMul {
+                    max_scalar: &max_offset_multiplier * BigUint::from(p_moduli[p_idx]),
+                })
+            })
             .collect::<Vec<_>>();
         let outputs = (0..p_moduli_depth)
             .map(|p_idx| {

--- a/src/gadgets/arith/nested_rns/mod.rs
+++ b/src/gadgets/arith/nested_rns/mod.rs
@@ -10,7 +10,7 @@ mod poly;
 mod tests;
 
 use crate::{
-    circuit::{BatchedWire, PolyCircuit, SubCircuitParamKind, SubCircuitParamValue, gate::GateId},
+    circuit::{BatchedWire, PolyCircuit, SubCircuitParamSpec, SubCircuitParamValue, gate::GateId},
     gadgets::conv_mul::{
         negacyclic_conv_mul_right_decomposed_term_many_subcircuit, negacyclic_conv_mul_right_sparse,
     },

--- a/src/gadgets/conv_mul/mod.rs
+++ b/src/gadgets/conv_mul/mod.rs
@@ -18,7 +18,7 @@ mod montgomery;
 mod nested_rns;
 
 use crate::{
-    circuit::{BatchedWire, PolyCircuit, SubCircuitParamKind, SubCircuitParamValue, gate::GateId},
+    circuit::{BatchedWire, PolyCircuit, SubCircuitParamSpec, SubCircuitParamValue, gate::GateId},
     gadgets::arith::{ModularArithmeticContext, ModularArithmeticGadget},
     poly::{Poly, PolyParams},
 };
@@ -131,10 +131,14 @@ fn q_level_diagonal_product_subcircuit<P: Poly + 'static, C: NegacyclicConvoluti
     let ctx = Arc::new(template_ctx.clone());
     let p_moduli_depth = ctx.q_level_row_width();
     let lhs_slot_transfer_param_ids = (0..p_moduli_depth)
-        .map(|_| circuit.register_sub_circuit_param(SubCircuitParamKind::SlotTransfer))
+        .map(|_| {
+            circuit.register_sub_circuit_param(SubCircuitParamSpec::SlotTransfer {
+                max_scalar: u32::MAX,
+            })
+        })
         .collect::<Vec<_>>();
-    let rhs_slot_transfer_param_id =
-        circuit.register_sub_circuit_param(SubCircuitParamKind::SlotTransfer);
+    let rhs_slot_transfer_param_id = circuit
+        .register_sub_circuit_param(SubCircuitParamSpec::SlotTransfer { max_scalar: u32::MAX });
     let lhs_row = circuit.input(p_moduli_depth).to_vec();
     let rhs_row = circuit.input(p_moduli_depth).to_vec();
     let lhs_transferred = lhs_row

--- a/src/gadgets/conv_mul/mod.rs
+++ b/src/gadgets/conv_mul/mod.rs
@@ -18,7 +18,7 @@ mod montgomery;
 mod nested_rns;
 
 use crate::{
-    circuit::{BatchedWire, PolyCircuit, SubCircuitParamKind, SubCircuitParamValue, gate::GateId},
+    circuit::{BatchedWire, PolyCircuit, SubCircuitParamSpec, SubCircuitParamValue, gate::GateId},
     gadgets::arith::{ModularArithmeticContext, ModularArithmeticGadget},
     poly::{Poly, PolyParams},
 };
@@ -28,6 +28,8 @@ use std::{sync::Arc, time::Instant};
 use tracing::debug;
 
 pub trait NegacyclicConvolutionContext<P: Poly>: ModularArithmeticContext<P> {
+    fn q_level_diagonal_product_param_specs(&self) -> Vec<SubCircuitParamSpec>;
+
     fn q_level_diagonal_product_param_bindings(
         &self,
         diagonal: usize,
@@ -130,11 +132,15 @@ fn q_level_diagonal_product_subcircuit<P: Poly + 'static, C: NegacyclicConvoluti
     let mut circuit = source_circuit.fresh_sub_circuit();
     let ctx = Arc::new(template_ctx.clone());
     let p_moduli_depth = ctx.q_level_row_width();
-    let lhs_slot_transfer_param_ids = (0..p_moduli_depth)
-        .map(|_| circuit.register_sub_circuit_param(SubCircuitParamKind::SlotTransfer))
+    let param_specs = ctx.q_level_diagonal_product_param_specs();
+    assert_eq!(param_specs.len(), p_moduli_depth + 1);
+    let lhs_slot_transfer_param_ids = param_specs[..p_moduli_depth]
+        .iter()
+        .cloned()
+        .map(|spec| circuit.register_sub_circuit_param(spec))
         .collect::<Vec<_>>();
     let rhs_slot_transfer_param_id =
-        circuit.register_sub_circuit_param(SubCircuitParamKind::SlotTransfer);
+        circuit.register_sub_circuit_param(param_specs[p_moduli_depth].clone());
     let lhs_row = circuit.input(p_moduli_depth).to_vec();
     let rhs_row = circuit.input(p_moduli_depth).to_vec();
     let lhs_transferred = lhs_row

--- a/src/gadgets/conv_mul/nested_rns.rs
+++ b/src/gadgets/conv_mul/nested_rns.rs
@@ -1,6 +1,9 @@
 use super::{NegacyclicConvolutionContext, RingGswConvolution};
 use crate::{
-    circuit::{BatchedWire, PolyCircuit, SlotTransferSpec, SubCircuitParamValue, gate::GateId},
+    circuit::{
+        BatchedWire, PolyCircuit, SlotTransferSpec, SubCircuitParamSpec, SubCircuitParamValue,
+        gate::GateId,
+    },
     gadgets::arith::{NestedRnsPoly, NestedRnsPolyContext},
     poly::Poly,
 };
@@ -8,6 +11,19 @@ use num_bigint::BigUint;
 use rayon::prelude::*;
 
 impl<P: Poly + 'static> NegacyclicConvolutionContext<P> for NestedRnsPolyContext {
+    fn q_level_diagonal_product_param_specs(&self) -> Vec<SubCircuitParamSpec> {
+        let mut specs = self
+            .p_moduli
+            .iter()
+            .map(|&p_i| SubCircuitParamSpec::SlotTransfer {
+                max_scalar: u32::try_from(p_i - 1)
+                    .expect("signed slot-transfer scalar must fit in u32"),
+            })
+            .collect::<Vec<_>>();
+        specs.push(SubCircuitParamSpec::SlotTransfer { max_scalar: 1 });
+        specs
+    }
+
     fn q_level_diagonal_product_param_bindings(
         &self,
         diagonal: usize,

--- a/src/simulator/eval_error/engine.rs
+++ b/src/simulator/eval_error/engine.rs
@@ -204,7 +204,7 @@ impl PolyCircuit<DCRTPoly> {
                         |(
                             call_id,
                             sub_circuit_id,
-                            param_bindings,
+                            _param_bindings,
                             shared_prefix_set_id,
                             suffix_plaintext_norms,
                         )| {
@@ -237,8 +237,10 @@ impl PolyCircuit<DCRTPoly> {
                                 call_id,
                                 ErrorNormPreparedSubCircuitSummaryRequest {
                                     sub_circuit_id,
-                                    param_bindings,
                                     input_plaintext_profile,
+                                    input_max_plaintext_norm_ranges: self
+                                        .sub_circuit_call_input_max_plaintext_norm_ranges(call_id)
+                                        .map(|ranges| Arc::from(ranges.to_vec())),
                                 },
                             )
                         },
@@ -447,7 +449,7 @@ impl PolyCircuit<DCRTPoly> {
                                         .iter()
                                         .copied()
                                         .zip(call_binding_set_ids[batch_start..batch_end].iter().copied())
-                                        .map(|(input_set_id, binding_set_id)| {
+                                        .map(|(input_set_id, _binding_set_id)| {
                                             let input_plaintext_norms = self
                                                 .collect_error_norm_plaintext_norms_for_value_input_set(
                                                     self.input_set(input_set_id).as_ref(),
@@ -457,11 +459,15 @@ impl PolyCircuit<DCRTPoly> {
                                                 );
                                             ErrorNormPreparedSubCircuitSummaryRequest {
                                                 sub_circuit_id,
-                                                param_bindings: self.binding_set(binding_set_id),
                                                 input_plaintext_profile:
                                                     ErrorNormInputPlaintextProfile::flat_from_vec(
                                                         input_plaintext_norms,
                                                     ),
+                                                input_max_plaintext_norm_ranges: self
+                                                    .summed_sub_circuit_call_input_max_plaintext_norm_ranges(
+                                                        *summed_call_id,
+                                                    )
+                                                    .map(|ranges| Arc::from(ranges.to_vec())),
                                             }
                                         })
                                         .collect::<Vec<_>>();

--- a/src/simulator/eval_error/engine.rs
+++ b/src/simulator/eval_error/engine.rs
@@ -174,7 +174,7 @@ impl PolyCircuit<DCRTPoly> {
                             self.sub_circuit_call_shared_prefix_set_id(*call_id);
                         self.with_sub_circuit_call_by_id(
                             *call_id,
-                            |sub_circuit_id, param_bindings, _shared_prefix, suffix, _| {
+                            |sub_circuit_id, _, _shared_prefix, suffix, _| {
                                 let suffix_plaintext_norms = suffix
                                     .par_iter()
                                     .flat_map_iter(|batch| batch.gate_ids())
@@ -190,7 +190,6 @@ impl PolyCircuit<DCRTPoly> {
                                 (
                                     *call_id,
                                     sub_circuit_id,
-                                    param_bindings,
                                     shared_prefix_set_id,
                                     suffix_plaintext_norms,
                                 )
@@ -204,7 +203,6 @@ impl PolyCircuit<DCRTPoly> {
                         |(
                             call_id,
                             sub_circuit_id,
-                            param_bindings,
                             shared_prefix_set_id,
                             suffix_plaintext_norms,
                         )| {
@@ -237,8 +235,10 @@ impl PolyCircuit<DCRTPoly> {
                                 call_id,
                                 ErrorNormPreparedSubCircuitSummaryRequest {
                                     sub_circuit_id,
-                                    param_bindings,
                                     input_plaintext_profile,
+                                    input_max_plaintext_norm_ranges: self
+                                        .sub_circuit_call_input_max_plaintext_norm_ranges(call_id)
+                                        .map(|ranges| Arc::from(ranges.to_vec())),
                                 },
                             )
                         },
@@ -284,12 +284,7 @@ impl PolyCircuit<DCRTPoly> {
                                         }
                                         self.with_sub_circuit_call_by_id(
                                             *call_id,
-                                            |actual_sub_circuit_id,
-                                             _param_bindings,
-                                             shared_prefix,
-                                             suffix,
-                                             output_gate_ids| {
-                                                let _ = actual_sub_circuit_id;
+                                            |_, _, shared_prefix, suffix, output_gate_ids| {
                                                 assert_eq!(
                                                     output_gate_ids.len(),
                                                     summary.output_len(),
@@ -427,7 +422,7 @@ impl PolyCircuit<DCRTPoly> {
                 for summed_call_id in summed_call_chunk {
                     self.with_summed_sub_circuit_call_by_id(
                         *summed_call_id,
-                        |sub_circuit_id, call_input_set_ids, call_binding_set_ids, output_gate_ids| {
+                        |sub_circuit_id, call_input_set_ids, _, output_gate_ids| {
                             prepared_summed_call_count += 1;
                             let output_range =
                                 BatchedWire::from_batches(output_gate_ids.iter().copied());
@@ -446,8 +441,7 @@ impl PolyCircuit<DCRTPoly> {
                                     let batch_requests = call_input_set_ids[batch_start..batch_end]
                                         .iter()
                                         .copied()
-                                        .zip(call_binding_set_ids[batch_start..batch_end].iter().copied())
-                                        .map(|(input_set_id, binding_set_id)| {
+                                        .map(|input_set_id| {
                                             let input_plaintext_norms = self
                                                 .collect_error_norm_plaintext_norms_for_value_input_set(
                                                     self.input_set(input_set_id).as_ref(),
@@ -457,11 +451,15 @@ impl PolyCircuit<DCRTPoly> {
                                                 );
                                             ErrorNormPreparedSubCircuitSummaryRequest {
                                                 sub_circuit_id,
-                                                param_bindings: self.binding_set(binding_set_id),
                                                 input_plaintext_profile:
                                                     ErrorNormInputPlaintextProfile::flat_from_vec(
                                                         input_plaintext_norms,
                                                     ),
+                                                input_max_plaintext_norm_ranges: self
+                                                    .summed_sub_circuit_call_input_max_plaintext_norm_ranges(
+                                                        *summed_call_id,
+                                                    )
+                                                    .map(|ranges| Arc::from(ranges.to_vec())),
                                             }
                                         })
                                         .collect::<Vec<_>>();

--- a/src/simulator/eval_error/mod.rs
+++ b/src/simulator/eval_error/mod.rs
@@ -4,8 +4,8 @@ use super::{
 use crate::{
     circuit::{
         BatchedWire, Evaluable, GroupedCallExecutionLayer, PolyCircuit, PolyGateType,
-        SubCircuitParamValue, batched_wire_slice_at, batched_wire_slice_len, gate::GateId,
-        iter_batched_wire_gates,
+        SubCircuitInputMaxPlaintextNormRange, SubCircuitParamValue, batched_wire_slice_at,
+        batched_wire_slice_len, gate::GateId, iter_batched_wire_gates,
     },
     element::PolyElem,
     lookup::{PltEvaluator, PublicLut, commit_eval::compute_padded_len},
@@ -73,6 +73,12 @@ struct ErrorNormSubCircuitSummaryCacheKey {
     input_plaintext_norms: Vec<ErrorNormPolyNormKey>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ErrorNormPreparedSummaryKeyMode {
+    IncludeNormalizedInputPlaintextNorms,
+    ExcludeInputPlaintextNorms,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Cycle-detection key for the recursive summary builder.
 ///
@@ -136,6 +142,108 @@ fn error_norm_sub_circuit_summary_cache_key(
         sub_circuit_id,
         input_plaintext_norms: input_plaintext_norms.iter().map(error_norm_poly_norm_key).collect(),
     }
+}
+
+fn error_norm_sub_circuit_summary_cache_key_with_mode(
+    circuit_key: usize,
+    sub_circuit_id: usize,
+    input_plaintext_norms: &[PolyNorm],
+    key_mode: ErrorNormPreparedSummaryKeyMode,
+) -> ErrorNormSubCircuitSummaryCacheKey {
+    match key_mode {
+        ErrorNormPreparedSummaryKeyMode::IncludeNormalizedInputPlaintextNorms => {
+            error_norm_sub_circuit_summary_cache_key(
+                circuit_key,
+                sub_circuit_id,
+                input_plaintext_norms,
+            )
+        }
+        ErrorNormPreparedSummaryKeyMode::ExcludeInputPlaintextNorms => {
+            ErrorNormSubCircuitSummaryCacheKey {
+                circuit_key,
+                sub_circuit_id,
+                input_plaintext_norms: Vec::new(),
+            }
+        }
+    }
+}
+
+fn validate_input_plaintext_norms_against_ranges(
+    ranges: &[SubCircuitInputMaxPlaintextNormRange],
+    actual_input_plaintext_norms: &[PolyNorm],
+    norm_ctx: &Arc<SimulatorContext>,
+    context: &str,
+) -> Arc<[PolyNorm]> {
+    if actual_input_plaintext_norms.is_empty() {
+        let mut normalized = Vec::with_capacity(ranges.last().map(|range| range.end).unwrap_or(0));
+        for range in ranges {
+            let max_norm_bd = BigDecimal::from(num_bigint::BigInt::from(range.norm.clone()));
+            normalized.extend(
+                std::iter::repeat_with(|| PolyNorm::new(Arc::clone(norm_ctx), max_norm_bd.clone()))
+                    .take(range.len()),
+            );
+        }
+        return Arc::from(normalized);
+    }
+
+    let expected_len = ranges.last().map(|range| range.end).unwrap_or(0);
+    assert_eq!(
+        actual_input_plaintext_norms.len(),
+        expected_len,
+        "{context}: sub-circuit plaintext envelope length mismatch"
+    );
+    let mut normalized = Vec::with_capacity(actual_input_plaintext_norms.len());
+    for range in ranges {
+        let max_norm_bd = BigDecimal::from(num_bigint::BigInt::from(range.norm.clone()));
+        for (offset, actual_norm) in
+            actual_input_plaintext_norms[range.start..range.end].iter().enumerate()
+        {
+            assert!(
+                actual_norm.norm <= max_norm_bd,
+                "{context}: input plaintext norm at index {} exceeds declared max (actual={}, max={})",
+                range.start + offset,
+                actual_norm.norm,
+                max_norm_bd
+            );
+            normalized.push(PolyNorm::new(Arc::clone(norm_ctx), max_norm_bd.clone()));
+        }
+    }
+    Arc::from(normalized)
+}
+
+fn normalize_sub_circuit_input_plaintext_norms(
+    sub_circuit: &PolyCircuit<DCRTPoly>,
+    actual_input_plaintext_norms: &[PolyNorm],
+    call_input_max_plaintext_norm_ranges: Option<&[SubCircuitInputMaxPlaintextNormRange]>,
+    norm_ctx: &Arc<SimulatorContext>,
+    context: &str,
+) -> (Arc<[PolyNorm]>, ErrorNormPreparedSummaryKeyMode) {
+    if let Some(ranges) = sub_circuit.sub_circuit_input_max_plaintext_norm_ranges() {
+        return (
+            validate_input_plaintext_norms_against_ranges(
+                ranges,
+                actual_input_plaintext_norms,
+                norm_ctx,
+                context,
+            ),
+            ErrorNormPreparedSummaryKeyMode::ExcludeInputPlaintextNorms,
+        );
+    }
+    if let Some(ranges) = call_input_max_plaintext_norm_ranges {
+        return (
+            validate_input_plaintext_norms_against_ranges(
+                ranges,
+                actual_input_plaintext_norms,
+                norm_ctx,
+                context,
+            ),
+            ErrorNormPreparedSummaryKeyMode::IncludeNormalizedInputPlaintextNorms,
+        );
+    }
+    (
+        Arc::from(actual_input_plaintext_norms.to_vec()),
+        ErrorNormPreparedSummaryKeyMode::IncludeNormalizedInputPlaintextNorms,
+    )
 }
 
 /// Return the largest plaintext-profile bit width in one summary request.
@@ -1444,8 +1552,8 @@ impl ErrorNormInputPlaintextProfile {
 /// compressed the relevant input plaintext norms.
 struct ErrorNormPreparedSubCircuitSummaryRequest {
     sub_circuit_id: usize,
-    param_bindings: Arc<[SubCircuitParamValue]>,
     input_plaintext_profile: ErrorNormInputPlaintextProfile,
+    input_max_plaintext_norm_ranges: Option<Arc<[SubCircuitInputMaxPlaintextNormRange]>>,
 }
 
 mod engine;

--- a/src/simulator/eval_error/summary.rs
+++ b/src/simulator/eval_error/summary.rs
@@ -760,7 +760,6 @@ impl PolyCircuit<DCRTPoly> {
         &self,
         sub_circuit_id: usize,
         input_plaintext_norms: Arc<[PolyNorm]>,
-        param_bindings: Arc<[SubCircuitParamValue]>,
         one_error: &ErrorNorm,
         plt_evaluator: Option<&P>,
         slot_transfer_evaluator: Option<&dyn AffineSlotTransferEvaluator>,
@@ -768,11 +767,34 @@ impl PolyCircuit<DCRTPoly> {
         visiting: &mut HashSet<ErrorNormSummaryBuildKey>,
     ) -> ErrorNormSubCircuitSummaryCacheKey {
         let sub_circuit = self.registered_sub_circuit_ref(sub_circuit_id);
+        let norm_ctx = input_plaintext_norms
+            .first()
+            .map(|norm| norm.ctx.clone())
+            .unwrap_or_else(|| one_error.plaintext_norm.ctx.clone());
+        let (input_plaintext_norms, key_mode) = normalize_sub_circuit_input_plaintext_norms(
+            sub_circuit.as_ref(),
+            input_plaintext_norms.as_ref(),
+            None,
+            &norm_ctx,
+            &format!("summary registration sub_circuit_id={sub_circuit_id}"),
+        );
+        let param_bindings = sub_circuit.simulator_param_bindings();
         let cache_key = error_norm_sub_circuit_summary_cache_key(
             Arc::as_ptr(&sub_circuit) as usize,
             sub_circuit_id,
-            &input_plaintext_norms,
+            input_plaintext_norms.as_ref(),
         );
+        let cache_key =
+            if matches!(key_mode, ErrorNormPreparedSummaryKeyMode::ExcludeInputPlaintextNorms) {
+                error_norm_sub_circuit_summary_cache_key_with_mode(
+                    Arc::as_ptr(&sub_circuit) as usize,
+                    sub_circuit_id,
+                    input_plaintext_norms.as_ref(),
+                    key_mode,
+                )
+            } else {
+                cache_key
+            };
         let binding_sig = Arc::as_ptr(&param_bindings).cast::<u8>() as usize;
         let build_key = ErrorNormSummaryBuildKey { cache_key: cache_key.clone(), binding_sig };
         if registry.nodes.contains_key(&cache_key) {
@@ -788,8 +810,8 @@ impl PolyCircuit<DCRTPoly> {
         visiting.insert(build_key.clone());
         let (output_plaintext_norms, direct_call_keys) =
             sub_circuit.as_ref().compute_error_norm_plaintext_norms_for_summary(
-                &input_plaintext_norms,
-                &param_bindings,
+                input_plaintext_norms.as_ref(),
+                param_bindings.as_ref(),
                 one_error,
                 plt_evaluator,
                 slot_transfer_evaluator,
@@ -970,7 +992,7 @@ impl PolyCircuit<DCRTPoly> {
                 let shared_prefix_set_id = self.sub_circuit_call_shared_prefix_set_id(call_id);
                 self.with_sub_circuit_call_by_id(
                     call_id,
-                    |sub_id, bindings, _shared_prefix, suffix, output_gate_ids| {
+                    |sub_id, _, _shared_prefix, suffix, output_gate_ids| {
                         let input_plaintext_profile = if let Some(input_set_id) = shared_prefix_set_id {
                             let prefix_norms = shared_prefix_plaintext_norms
                                 .entry(input_set_id)
@@ -1024,7 +1046,6 @@ impl PolyCircuit<DCRTPoly> {
                         let child_key = self.register_error_norm_summary_node(
                             sub_id,
                             Arc::from(input_plaintext_profile.materialize()),
-                            bindings.clone(),
                             one_error,
                             _plt_evaluator,
                             _slot_transfer_evaluator,
@@ -1047,22 +1068,15 @@ impl PolyCircuit<DCRTPoly> {
             }
 
             for summed_call_id in summed_sub_circuit_call_ids {
-                let (sub_id, call_input_set_ids, call_binding_set_ids, output_gate_ids) = self
+                let (sub_id, call_input_set_ids, output_gate_ids) = self
                     .with_summed_sub_circuit_call_by_id(
                         summed_call_id,
-                        |sub_id, call_input_set_ids, call_binding_set_ids, output_gate_ids| {
-                            (
-                                sub_id,
-                                call_input_set_ids.to_vec(),
-                                call_binding_set_ids.to_vec(),
-                                output_gate_ids.to_vec(),
-                            )
+                        |sub_id, call_input_set_ids, _, output_gate_ids| {
+                            (sub_id, call_input_set_ids.to_vec(), output_gate_ids.to_vec())
                         },
                     );
                 let mut output_accum: Vec<Option<PolyNorm>> = vec![None; output_gate_ids.len()];
-                for (input_set_id, binding_set_id) in
-                    call_input_set_ids.into_iter().zip(call_binding_set_ids.into_iter())
-                {
+                for input_set_id in call_input_set_ids {
                     let input_ids = self.input_set(input_set_id);
                     let child_inputs = input_ids
                         .iter()
@@ -1079,7 +1093,6 @@ impl PolyCircuit<DCRTPoly> {
                     let child_key = self.register_error_norm_summary_node(
                         sub_id,
                         Arc::from(child_inputs),
-                        self.binding_set(binding_set_id),
                         one_error,
                         _plt_evaluator,
                         _slot_transfer_evaluator,
@@ -1624,12 +1637,7 @@ impl PolyCircuit<DCRTPoly> {
                         summed_call_id,
                         self.with_summed_sub_circuit_call_by_id(
                             *summed_call_id,
-                            |_sub_circuit_id,
-                             call_input_set_ids,
-                             _call_binding_set_ids,
-                             _output_gate_ids| {
-                                call_input_set_ids.len()
-                            },
+                            |_, call_input_set_ids, _, _| call_input_set_ids.len(),
                         ),
                         prepared_summed_call_count,
                         prepare_summed_sub_calls_start.elapsed().as_millis(),
@@ -1893,14 +1901,27 @@ impl PolyCircuit<DCRTPoly> {
         let mut unique_request_index_by_key =
             HashMap::<ErrorNormSubCircuitSummaryCacheKey, usize>::new();
         let mut request_unique_indices = Vec::with_capacity(requests.len());
-        let mut unique_requests = Vec::<(usize, Arc<[SubCircuitParamValue]>, Vec<PolyNorm>)>::new();
+        let mut unique_requests = Vec::<(usize, Vec<PolyNorm>)>::new();
         for request in requests {
             let materialized_input_plaintext_norms = request.input_plaintext_profile.materialize();
             let sub_circuit = self.registered_sub_circuit_ref(request.sub_circuit_id);
-            let cache_key = error_norm_sub_circuit_summary_cache_key(
+            let norm_ctx = materialized_input_plaintext_norms
+                .first()
+                .map(|norm| norm.ctx.clone())
+                .unwrap_or_else(|| one_error.plaintext_norm.ctx.clone());
+            let (normalized_input_plaintext_norms, key_mode) =
+                normalize_sub_circuit_input_plaintext_norms(
+                    sub_circuit.as_ref(),
+                    &materialized_input_plaintext_norms,
+                    request.input_max_plaintext_norm_ranges.as_deref(),
+                    &norm_ctx,
+                    &format!("prepared summary request sub_circuit_id={}", request.sub_circuit_id),
+                );
+            let cache_key = error_norm_sub_circuit_summary_cache_key_with_mode(
                 Arc::as_ptr(&sub_circuit) as usize,
                 request.sub_circuit_id,
-                &materialized_input_plaintext_norms,
+                normalized_input_plaintext_norms.as_ref(),
+                key_mode,
             );
             let unique_idx =
                 if let Some(&existing_idx) = unique_request_index_by_key.get(&cache_key) {
@@ -1910,8 +1931,7 @@ impl PolyCircuit<DCRTPoly> {
                     unique_request_index_by_key.insert(cache_key, next_idx);
                     unique_requests.push((
                         request.sub_circuit_id,
-                        request.param_bindings,
-                        materialized_input_plaintext_norms,
+                        normalized_input_plaintext_norms.as_ref().to_vec(),
                     ));
                     next_idx
                 };
@@ -1937,7 +1957,7 @@ impl PolyCircuit<DCRTPoly> {
         let mut registry = ErrorNormSummaryRegistry::default();
         let mut visiting = HashSet::<ErrorNormSummaryBuildKey>::new();
 
-        for (_unique_idx, (sub_circuit_id, param_bindings, materialized_input_plaintext_norms)) in
+        for (_unique_idx, (sub_circuit_id, materialized_input_plaintext_norms)) in
             unique_requests.iter().enumerate()
         {
             let _profile_inputs = materialized_input_plaintext_norms.len();
@@ -1972,7 +1992,6 @@ impl PolyCircuit<DCRTPoly> {
             self.register_error_norm_summary_node(
                 *sub_circuit_id,
                 Arc::from(materialized_input_plaintext_norms.clone()),
-                Arc::clone(param_bindings),
                 one_error,
                 plt_evaluator,
                 slot_transfer_evaluator,
@@ -1995,7 +2014,7 @@ impl PolyCircuit<DCRTPoly> {
         request_unique_indices
             .into_iter()
             .map(|unique_idx| {
-                let (sub_circuit_id, _param_bindings, materialized_input_plaintext_norms) =
+                let (sub_circuit_id, materialized_input_plaintext_norms) =
                     &unique_requests[unique_idx];
                 let sub_circuit = self.registered_sub_circuit_ref(*sub_circuit_id);
                 let cache_key = error_norm_sub_circuit_summary_cache_key(
@@ -2049,9 +2068,7 @@ impl PolyCircuit<DCRTPoly> {
         let mut grouped_idx_by_key = HashMap::<ErrorNormSubCircuitSummaryCacheKey, usize>::new();
         let mut grouped_requests = Vec::<ErrorNormPreparedSubCircuitSummaryRequest>::new();
         let mut grouped_input_set_counts = Vec::<HashMap<usize, usize>>::new();
-        for (&input_set_id, &binding_set_id) in
-            call_input_set_ids.iter().zip(call_binding_set_ids.iter())
-        {
+        for &input_set_id in call_input_set_ids {
             // Streaming the profiles keeps duplicate summed-call inputs from materializing
             // tens of thousands of identical plaintext-profile vectors at once.
             let input_ids = self.input_set(input_set_id);
@@ -2079,10 +2096,10 @@ impl PolyCircuit<DCRTPoly> {
                 grouped_idx_by_key.insert(cache_key, next_idx);
                 grouped_requests.push(ErrorNormPreparedSubCircuitSummaryRequest {
                     sub_circuit_id,
-                    param_bindings: self.binding_set(binding_set_id),
                     input_plaintext_profile: ErrorNormInputPlaintextProfile::flat_from_vec(
                         input_plaintext_profile,
                     ),
+                    input_max_plaintext_norm_ranges: None,
                 });
                 grouped_input_set_counts.push(HashMap::new());
                 next_idx
@@ -2170,7 +2187,7 @@ impl PolyCircuit<DCRTPoly> {
             PolyGateType::SubCircuitOutput { call_id, output_idx, .. } => self
                 .with_sub_circuit_call_by_id(
                     call_id,
-                    |sub_circuit_id, param_bindings, shared_prefix, suffix, _output_gate_ids| {
+                    |sub_circuit_id, param_bindings, shared_prefix, suffix, _| {
                         let child_key = resolve_ctx
                             .direct_call_keys
                             .get(&call_id)
@@ -2253,7 +2270,7 @@ impl PolyCircuit<DCRTPoly> {
             PolyGateType::SummedSubCircuitOutput { summed_call_id, output_idx, .. } => self
                 .with_summed_sub_circuit_call_by_id(
                     summed_call_id,
-                    |sub_circuit_id, call_input_set_ids, call_binding_set_ids, _output_gate_ids| {
+                    |sub_circuit_id, call_input_set_ids, call_binding_set_ids, _| {
                         let grouped_summary_requests = self
                             .build_grouped_summed_sub_circuit_summary_requests_direct(
                                 sub_circuit_id,

--- a/src/simulator/eval_error/summary.rs
+++ b/src/simulator/eval_error/summary.rs
@@ -760,7 +760,7 @@ impl PolyCircuit<DCRTPoly> {
         &self,
         sub_circuit_id: usize,
         input_plaintext_norms: Arc<[PolyNorm]>,
-        param_bindings: Arc<[SubCircuitParamValue]>,
+        _param_bindings: Arc<[SubCircuitParamValue]>,
         one_error: &ErrorNorm,
         plt_evaluator: Option<&P>,
         slot_transfer_evaluator: Option<&dyn AffineSlotTransferEvaluator>,
@@ -768,11 +768,34 @@ impl PolyCircuit<DCRTPoly> {
         visiting: &mut HashSet<ErrorNormSummaryBuildKey>,
     ) -> ErrorNormSubCircuitSummaryCacheKey {
         let sub_circuit = self.registered_sub_circuit_ref(sub_circuit_id);
+        let norm_ctx = input_plaintext_norms
+            .first()
+            .map(|norm| norm.ctx.clone())
+            .unwrap_or_else(|| one_error.plaintext_norm.ctx.clone());
+        let (input_plaintext_norms, key_mode) = normalize_sub_circuit_input_plaintext_norms(
+            sub_circuit.as_ref(),
+            input_plaintext_norms.as_ref(),
+            None,
+            &norm_ctx,
+            &format!("summary registration sub_circuit_id={sub_circuit_id}"),
+        );
+        let param_bindings = sub_circuit.simulator_param_bindings();
         let cache_key = error_norm_sub_circuit_summary_cache_key(
             Arc::as_ptr(&sub_circuit) as usize,
             sub_circuit_id,
-            &input_plaintext_norms,
+            input_plaintext_norms.as_ref(),
         );
+        let cache_key =
+            if matches!(key_mode, ErrorNormPreparedSummaryKeyMode::ExcludeInputPlaintextNorms) {
+                error_norm_sub_circuit_summary_cache_key_with_mode(
+                    Arc::as_ptr(&sub_circuit) as usize,
+                    sub_circuit_id,
+                    input_plaintext_norms.as_ref(),
+                    key_mode,
+                )
+            } else {
+                cache_key
+            };
         let binding_sig = Arc::as_ptr(&param_bindings).cast::<u8>() as usize;
         let build_key = ErrorNormSummaryBuildKey { cache_key: cache_key.clone(), binding_sig };
         if registry.nodes.contains_key(&cache_key) {
@@ -788,8 +811,8 @@ impl PolyCircuit<DCRTPoly> {
         visiting.insert(build_key.clone());
         let (output_plaintext_norms, direct_call_keys) =
             sub_circuit.as_ref().compute_error_norm_plaintext_norms_for_summary(
-                &input_plaintext_norms,
-                &param_bindings,
+                input_plaintext_norms.as_ref(),
+                param_bindings.as_ref(),
                 one_error,
                 plt_evaluator,
                 slot_transfer_evaluator,
@@ -1897,10 +1920,23 @@ impl PolyCircuit<DCRTPoly> {
         for request in requests {
             let materialized_input_plaintext_norms = request.input_plaintext_profile.materialize();
             let sub_circuit = self.registered_sub_circuit_ref(request.sub_circuit_id);
-            let cache_key = error_norm_sub_circuit_summary_cache_key(
+            let norm_ctx = materialized_input_plaintext_norms
+                .first()
+                .map(|norm| norm.ctx.clone())
+                .unwrap_or_else(|| one_error.plaintext_norm.ctx.clone());
+            let (normalized_input_plaintext_norms, key_mode) =
+                normalize_sub_circuit_input_plaintext_norms(
+                    sub_circuit.as_ref(),
+                    &materialized_input_plaintext_norms,
+                    request.input_max_plaintext_norm_ranges.as_deref(),
+                    &norm_ctx,
+                    &format!("prepared summary request sub_circuit_id={}", request.sub_circuit_id),
+                );
+            let cache_key = error_norm_sub_circuit_summary_cache_key_with_mode(
                 Arc::as_ptr(&sub_circuit) as usize,
                 request.sub_circuit_id,
-                &materialized_input_plaintext_norms,
+                normalized_input_plaintext_norms.as_ref(),
+                key_mode,
             );
             let unique_idx =
                 if let Some(&existing_idx) = unique_request_index_by_key.get(&cache_key) {
@@ -1910,8 +1946,8 @@ impl PolyCircuit<DCRTPoly> {
                     unique_request_index_by_key.insert(cache_key, next_idx);
                     unique_requests.push((
                         request.sub_circuit_id,
-                        request.param_bindings,
-                        materialized_input_plaintext_norms,
+                        sub_circuit.simulator_param_bindings(),
+                        normalized_input_plaintext_norms.as_ref().to_vec(),
                     ));
                     next_idx
                 };
@@ -2049,7 +2085,7 @@ impl PolyCircuit<DCRTPoly> {
         let mut grouped_idx_by_key = HashMap::<ErrorNormSubCircuitSummaryCacheKey, usize>::new();
         let mut grouped_requests = Vec::<ErrorNormPreparedSubCircuitSummaryRequest>::new();
         let mut grouped_input_set_counts = Vec::<HashMap<usize, usize>>::new();
-        for (&input_set_id, &binding_set_id) in
+        for (&input_set_id, &_binding_set_id) in
             call_input_set_ids.iter().zip(call_binding_set_ids.iter())
         {
             // Streaming the profiles keeps duplicate summed-call inputs from materializing
@@ -2079,10 +2115,10 @@ impl PolyCircuit<DCRTPoly> {
                 grouped_idx_by_key.insert(cache_key, next_idx);
                 grouped_requests.push(ErrorNormPreparedSubCircuitSummaryRequest {
                     sub_circuit_id,
-                    param_bindings: self.binding_set(binding_set_id),
                     input_plaintext_profile: ErrorNormInputPlaintextProfile::flat_from_vec(
                         input_plaintext_profile,
                     ),
+                    input_max_plaintext_norm_ranges: None,
                 });
                 grouped_input_set_counts.push(HashMap::new());
                 next_idx

--- a/tests/test_gpu_lwe_nested_rns_goldreich_ring_gsw_bench.rs
+++ b/tests/test_gpu_lwe_nested_rns_goldreich_ring_gsw_bench.rs
@@ -69,6 +69,7 @@ const DEFAULT_P_MODULI_BITS: usize = 7;
 const DEFAULT_MAX_UNREDUCED_MULS: usize = 4;
 const DEFAULT_SCALE: u64 = 1 << 8;
 const DEFAULT_BASE_BITS: u32 = 14;
+const DEFAULT_MIN_CRT_DEPTH: usize = 1;
 const DEFAULT_MAX_CRT_DEPTH: usize = 64;
 const DEFAULT_ERROR_SIGMA: f64 = 4.0;
 const DEFAULT_D_SECRET: usize = 1;
@@ -100,6 +101,7 @@ struct GoldreichRingGswBenchConfig {
     max_unreduced_muls: usize,
     scale: u64,
     base_bits: u32,
+    min_crt_depth: usize,
     max_crt_depth: usize,
     error_sigma: f64,
     d_secret: usize,
@@ -156,6 +158,8 @@ impl GoldreichRingGswBenchConfig {
         let scale = env_or_parse_u64("LWE_GOLDREICH_RING_GSW_BENCH_SCALE", DEFAULT_SCALE);
         let base_bits =
             env_or_parse_u32("LWE_GOLDREICH_RING_GSW_BENCH_BASE_BITS", DEFAULT_BASE_BITS);
+        let min_crt_depth =
+            env_or_parse_usize("LWE_GOLDREICH_RING_GSW_BENCH_MIN_CRT_DEPTH", DEFAULT_MIN_CRT_DEPTH);
         let max_crt_depth =
             env_or_parse_usize("LWE_GOLDREICH_RING_GSW_BENCH_MAX_CRT_DEPTH", DEFAULT_MAX_CRT_DEPTH);
         let error_sigma =
@@ -191,7 +195,12 @@ impl GoldreichRingGswBenchConfig {
         );
         assert!(scale > 0, "LWE_GOLDREICH_RING_GSW_BENCH_SCALE must be > 0");
         assert!(base_bits > 0, "LWE_GOLDREICH_RING_GSW_BENCH_BASE_BITS must be > 0");
+        assert!(min_crt_depth > 0, "LWE_GOLDREICH_RING_GSW_BENCH_MIN_CRT_DEPTH must be > 0");
         assert!(max_crt_depth > 0, "LWE_GOLDREICH_RING_GSW_BENCH_MAX_CRT_DEPTH must be > 0");
+        assert!(
+            min_crt_depth <= max_crt_depth,
+            "LWE_GOLDREICH_RING_GSW_BENCH_MIN_CRT_DEPTH must be <= LWE_GOLDREICH_RING_GSW_BENCH_MAX_CRT_DEPTH"
+        );
         assert!(error_sigma >= 0.0, "LWE_GOLDREICH_RING_GSW_BENCH_ERROR_SIGMA must be >= 0");
         assert!(d_secret > 0, "LWE_GOLDREICH_RING_GSW_BENCH_D_SECRET must be > 0");
         assert!(bench_iterations > 0, "LWE_GOLDREICH_RING_GSW_BENCH_BENCH_ITERATIONS must be > 0");
@@ -208,6 +217,7 @@ impl GoldreichRingGswBenchConfig {
             max_unreduced_muls,
             scale,
             base_bits,
+            min_crt_depth,
             max_crt_depth,
             error_sigma,
             d_secret,
@@ -467,8 +477,7 @@ fn find_crt_depth_for_goldreich_ring_gsw_bench(
         return (requested_crt_depth, params);
     }
 
-    let min_crt_depth = 1usize;
-    let mut low = min_crt_depth;
+    let mut low = cfg.min_crt_depth;
     let mut high = cfg.max_crt_depth;
     while low < high {
         let mid = low + (high - low) / 2;
@@ -501,8 +510,8 @@ fn find_crt_depth_for_goldreich_ring_gsw_bench(
     }
 
     panic!(
-        "crt_depth satisfying the LWE error threshold was not found up to LWE_GOLDREICH_RING_GSW_BENCH_MAX_CRT_DEPTH ({})",
-        cfg.max_crt_depth
+        "crt_depth satisfying the LWE error threshold was not found in LWE_GOLDREICH_RING_GSW_BENCH_MIN_CRT_DEPTH..=LWE_GOLDREICH_RING_GSW_BENCH_MAX_CRT_DEPTH ({}..={})",
+        cfg.min_crt_depth, cfg.max_crt_depth
     );
 }
 


### PR DESCRIPTION
## Summary
- Add binding envelopes for parameterized subcircuits and validate them at call sites.
- Reuse shared NestedRNS helper subcircuits instead of rebuilding per call.
- Reduce error-simulation memory pressure by keeping metadata-only summaries where possible.

## Testing
- `cargo +nightly fmt --all`
- Focused `simulator::eval_error` and `nested_rns` unit tests passed.
- `CRT_DEPTH=4` and `LWE_GOLDREICH_RING_GSW_BENCH_ACTIVE_LEVELS=4` GPU bench build completed and progressed past circuit construction.