### PR TITLE
Switch GPU staging serialization to CPU-friendly matrix bytes

### DIFF
--- a/src/lookup/ggh15/pubkey_gpu.rs
+++ b/src/lookup/ggh15/pubkey_gpu.rs
@@ -156,7 +156,7 @@ where
         let needs_cross_device_copy =
             device_ids.iter().any(|&device_id| device_id != source_device_id);
         let b1_trapdoor_bytes = needs_cross_device_copy.then(|| TS::trapdoor_to_bytes(b1_trapdoor));
-        let b1_matrix_bytes = needs_cross_device_copy.then(|| b1_matrix.to_compact_bytes());
+        let b1_matrix_bytes = needs_cross_device_copy.then(|| b1_matrix.to_cpu_staging_bytes());
 
         device_ids
             .into_iter()
@@ -181,7 +181,10 @@ where
                                 "failed to deserialize trapdoor for preloaded LUT device resources",
                             ),
                         ),
-                        DeviceReplica::Owned(M::from_compact_bytes(&local_params, matrix_bytes)),
+                        DeviceReplica::Owned(M::from_cpu_staging_bytes(
+                            &local_params,
+                            matrix_bytes,
+                        )),
                     )
                 };
                 GpuLutBaseDeviceShared {
@@ -241,8 +244,8 @@ where
         let needs_cross_device_copy =
             device_ids.iter().any(|&device_id| device_id != source_device_id);
         let b0_trapdoor_bytes = needs_cross_device_copy.then(|| TS::trapdoor_to_bytes(b0_trapdoor));
-        let b0_matrix_bytes = needs_cross_device_copy.then(|| b0_matrix.to_compact_bytes());
-        let b1_matrix_bytes = needs_cross_device_copy.then(|| b1_matrix.to_compact_bytes());
+        let b0_matrix_bytes = needs_cross_device_copy.then(|| b0_matrix.to_cpu_staging_bytes());
+        let b1_matrix_bytes = needs_cross_device_copy.then(|| b1_matrix.to_cpu_staging_bytes());
 
         device_ids
             .into_iter()
@@ -272,8 +275,14 @@ where
                                     "failed to deserialize b0 trapdoor for preloaded gate device resources",
                                 ),
                             ),
-                            DeviceReplica::Owned(M::from_compact_bytes(&local_params, b0_bytes)),
-                            DeviceReplica::Owned(M::from_compact_bytes(&local_params, b1_bytes)),
+                            DeviceReplica::Owned(M::from_cpu_staging_bytes(
+                                &local_params,
+                                b0_bytes,
+                            )),
+                            DeviceReplica::Owned(M::from_cpu_staging_bytes(
+                                &local_params,
+                                b1_bytes,
+                            )),
                         )
                     };
                 GpuGateBaseDeviceShared {
@@ -301,14 +310,14 @@ where
             .expect("gpu params must include at least one device id");
         let needs_cross_device_copy =
             base_shared.iter().any(|device_shared| device_shared.device_id != source_device_id);
-        let bytes = needs_cross_device_copy.then(|| matrix.to_compact_bytes());
+        let bytes = needs_cross_device_copy.then(|| matrix.to_cpu_staging_bytes());
         base_shared
             .iter()
             .map(|device_shared| {
                 if device_shared.device_id == source_device_id {
                     DeviceReplica::Borrowed(matrix)
                 } else {
-                    DeviceReplica::Owned(M::from_compact_bytes(
+                    DeviceReplica::Owned(M::from_cpu_staging_bytes(
                         &device_shared.params,
                         bytes.as_ref().expect(
                             "cross-device gate replica requested without serialized source bytes",

--- a/src/lookup/lwe/pubkey_gpu.rs
+++ b/src/lookup/lwe/pubkey_gpu.rs
@@ -122,7 +122,7 @@ where
     let trapdoor_bytes =
         needs_cross_device_copy.then(|| ST::trapdoor_to_bytes(evaluator.trapdoor.as_ref()));
     let pub_matrix_bytes =
-        needs_cross_device_copy.then(|| evaluator.pub_matrix.as_ref().to_compact_bytes());
+        needs_cross_device_copy.then(|| evaluator.pub_matrix.as_ref().to_cpu_staging_bytes());
 
     device_ids
         .into_iter()
@@ -145,7 +145,7 @@ where
                         .expect("cross-device trapdoor bytes must exist for LWE GPU sampling"),
                 )
                 .expect("failed to deserialize LWE trapdoor replica");
-                let pub_matrix = M::from_compact_bytes(
+                let pub_matrix = M::from_cpu_staging_bytes(
                     &local_params,
                     pub_matrix_bytes
                         .as_ref()

--- a/src/matrix/gpu_dcrt_poly.rs
+++ b/src/matrix/gpu_dcrt_poly.rs
@@ -51,6 +51,55 @@ pub struct GpuDCRTPolyMatrix {
     raw: *mut GpuMatrixOpaque,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpuDCRTMatrixRnsSnapshot {
+    nrow: usize,
+    ncol: usize,
+    level: usize,
+    is_ntt: bool,
+    bytes_per_poly: usize,
+    bytes: Vec<u8>,
+}
+
+impl GpuDCRTMatrixRnsSnapshot {
+    pub fn nrow(&self) -> usize {
+        self.nrow
+    }
+
+    pub fn ncol(&self) -> usize {
+        self.ncol
+    }
+
+    pub fn level(&self) -> usize {
+        self.level
+    }
+
+    pub fn is_ntt(&self) -> bool {
+        self.is_ntt
+    }
+
+    pub fn bytes_per_poly(&self) -> usize {
+        self.bytes_per_poly
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    fn validate_for_params(&self, params: &GpuDCRTPolyParams) {
+        assert!(self.level < params.crt_depth(), "invalid RNS snapshot level");
+        let expected_bytes_per_poly = rns_bytes_len_for_level(params, self.level);
+        assert_eq!(
+            self.bytes_per_poly, expected_bytes_per_poly,
+            "RNS snapshot bytes_per_poly mismatch"
+        );
+        let poly_count = self.nrow.checked_mul(self.ncol).expect("RNS snapshot shape overflow");
+        let expected_len =
+            poly_count.checked_mul(self.bytes_per_poly).expect("RNS snapshot byte length overflow");
+        assert_eq!(self.bytes.len(), expected_len, "RNS snapshot byte length mismatch");
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum GpuMatrixSampleDist {
     Uniform,
@@ -559,6 +608,54 @@ impl GpuDCRTPolyMatrix {
         self.is_ntt = format == GPU_POLY_FORMAT_EVAL;
     }
 
+    pub fn to_rns_snapshot(&self) -> GpuDCRTMatrixRnsSnapshot {
+        let bytes_per_poly = rns_bytes_len_for_level(&self.params, self.level);
+        let poly_count = self.nrow.checked_mul(self.ncol).expect("matrix shape overflow");
+        let mut bytes = vec![0u8; poly_count.saturating_mul(bytes_per_poly)];
+        let format = if self.is_ntt { GPU_POLY_FORMAT_EVAL } else { GPU_POLY_FORMAT_COEFF };
+        self.store_rns_bytes(&mut bytes, bytes_per_poly, format);
+        GpuDCRTMatrixRnsSnapshot {
+            nrow: self.nrow,
+            ncol: self.ncol,
+            level: self.level,
+            is_ntt: self.is_ntt,
+            bytes_per_poly,
+            bytes,
+        }
+    }
+
+    pub fn from_rns_snapshot(
+        params: &GpuDCRTPolyParams,
+        snapshot: &GpuDCRTMatrixRnsSnapshot,
+    ) -> Self {
+        snapshot.validate_for_params(params);
+        let mut out = Self::new_empty_with_state(
+            params,
+            snapshot.nrow,
+            snapshot.ncol,
+            snapshot.level,
+            snapshot.is_ntt,
+        );
+        if !snapshot.bytes.is_empty() {
+            let format = if snapshot.is_ntt { GPU_POLY_FORMAT_EVAL } else { GPU_POLY_FORMAT_COEFF };
+            out.load_rns_bytes(&snapshot.bytes, snapshot.bytes_per_poly, format);
+        }
+        out
+    }
+
+    pub fn load_rns_snapshot(&mut self, snapshot: &GpuDCRTMatrixRnsSnapshot) {
+        snapshot.validate_for_params(&self.params);
+        assert_eq!(self.nrow, snapshot.nrow, "RNS snapshot row count mismatch");
+        assert_eq!(self.ncol, snapshot.ncol, "RNS snapshot column count mismatch");
+        assert_eq!(self.level, snapshot.level, "RNS snapshot level mismatch");
+        assert_eq!(self.is_ntt, snapshot.is_ntt, "RNS snapshot format mismatch");
+        if snapshot.bytes.is_empty() {
+            return;
+        }
+        let format = if snapshot.is_ntt { GPU_POLY_FORMAT_EVAL } else { GPU_POLY_FORMAT_COEFF };
+        self.load_rns_bytes(&snapshot.bytes, snapshot.bytes_per_poly, format);
+    }
+
     fn cpu_params(&self) -> DCRTPolyParams {
         DCRTPolyParams::new(
             self.params.ring_dimension(),
@@ -890,6 +987,41 @@ impl PolyMatrix for GpuDCRTPolyMatrix {
             out.is_ntt = true;
         }
         out
+    }
+
+    fn into_cpu_staging_bytes(self) -> Vec<u8> {
+        let snapshot = self.to_rns_snapshot();
+        bincode::encode_to_vec(
+            (
+                1u8,
+                snapshot.nrow,
+                snapshot.ncol,
+                snapshot.level,
+                snapshot.is_ntt,
+                snapshot.bytes_per_poly,
+                snapshot.bytes,
+            ),
+            bincode::config::standard(),
+        )
+        .expect("Failed to serialize GPU matrix RNS staging bytes")
+    }
+
+    fn from_cpu_staging_bytes(params: &<Self::P as Poly>::Params, bytes: &[u8]) -> Self {
+        let (version, nrow, ncol, level, is_ntt, bytes_per_poly, payload): (
+            u8,
+            usize,
+            usize,
+            usize,
+            bool,
+            usize,
+            Vec<u8>,
+        ) = bincode::decode_from_slice(bytes, bincode::config::standard())
+            .expect("Failed to deserialize GPU matrix RNS staging bytes")
+            .0;
+        assert_eq!(version, 1, "Unsupported GPU matrix RNS staging version: {version}");
+        let snapshot =
+            GpuDCRTMatrixRnsSnapshot { nrow, ncol, level, is_ntt, bytes_per_poly, bytes: payload };
+        Self::from_rns_snapshot(params, &snapshot)
     }
 
     fn zero_compact_bytes(
@@ -1707,8 +1839,13 @@ fn block_offsets(range: Range<usize>, block: usize) -> Vec<usize> {
 }
 
 fn rns_bytes_len(params: &GpuDCRTPolyParams) -> usize {
-    let n = params.ring_dimension() as usize;
     let level = params.crt_depth().saturating_sub(1);
+    rns_bytes_len_for_level(params, level)
+}
+
+fn rns_bytes_len_for_level(params: &GpuDCRTPolyParams, level: usize) -> usize {
+    assert!(level < params.crt_depth(), "invalid RNS byte length level");
+    let n = params.ring_dimension() as usize;
     (level + 1).saturating_mul(n).saturating_mul(std::mem::size_of::<u64>())
 }
 

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -89,6 +89,15 @@ pub trait PolyMatrix:
         self.clone().into_compact_bytes()
     }
     fn from_compact_bytes(params: &<Self::P as Poly>::Params, bytes: &[u8]) -> Self;
+    fn into_cpu_staging_bytes(self) -> Vec<u8> {
+        self.into_compact_bytes()
+    }
+    fn to_cpu_staging_bytes(&self) -> Vec<u8> {
+        self.clone().into_cpu_staging_bytes()
+    }
+    fn from_cpu_staging_bytes(params: &<Self::P as Poly>::Params, bytes: &[u8]) -> Self {
+        Self::from_compact_bytes(params, bytes)
+    }
     fn zero_compact_bytes(
         params: &<Self::P as Poly>::Params,
         nrow: usize,


### PR DESCRIPTION
## Summary
- Route GPU lookup preloading through new CPU staging byte paths for GGH15 and LWE public key replicas.
- Add GPU DCRT matrix RNS snapshot support so matrices can be serialized and restored with explicit shape, level, and NTT state.
- Introduce default CPU staging byte helpers on `PolyMatrix` to keep existing matrix types compatible.

## Testing
- Not run (not requested)