### PR TITLE
Replace GPU RNG seeding with 256-bit host-provided keys

### DIFF
--- a/cuda/include/ChaCha.cuh
+++ b/cuda/include/ChaCha.cuh
@@ -6,6 +6,11 @@
 
 namespace gpu_chacha
 {
+    struct GpuRngSeed
+    {
+        uint64_t words[4];
+    };
+
     struct DeviceChaChaRng
     {
         uint32_t state[16];
@@ -14,8 +19,6 @@ namespace gpu_chacha
     };
 
     __device__ __forceinline__ uint32_t rotl32(uint32_t x, uint32_t n);
-
-    __device__ __forceinline__ uint64_t splitmix64_next(uint64_t &state);
 
     __device__ __forceinline__ void quarter_round(
         uint32_t &a,
@@ -27,9 +30,14 @@ namespace gpu_chacha
         const uint32_t in_state[16],
         uint32_t out_block[16]);
 
+    __device__ __forceinline__ void hchacha20(
+        const uint32_t key[8],
+        const uint32_t nonce[4],
+        uint32_t out_key[8]);
+
     __device__ __forceinline__ void rng_init(
         DeviceChaChaRng &rng,
-        uint64_t seed,
+        const GpuRngSeed &seed,
         uint64_t stream0,
         uint64_t stream1,
         uint64_t stream2,

--- a/cuda/include/matrix/MatrixSampling.cuh
+++ b/cuda/include/matrix/MatrixSampling.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ChaCha.cuh"
 #include "matrix/Matrix.cuh"
 
 int launch_sample_distribution_multi_limb_kernel(
@@ -13,7 +14,7 @@ int launch_sample_distribution_multi_limb_kernel(
     const std::vector<uint32_t> &limb_indices,
     int dist_type,
     double sigma,
-    uint64_t seed,
+    gpu_chacha::GpuRngSeed seed,
     cudaStream_t stream);
 
 #ifdef __cplusplus
@@ -25,13 +26,13 @@ extern "C"
         GpuMatrix *out,
         int dist_type,
         double sigma,
-        uint64_t seed);
+        gpu_chacha::GpuRngSeed seed);
 
     int gpu_matrix_sample_distribution_columns(
         GpuMatrix *out,
         int dist_type,
         double sigma,
-        uint64_t seed,
+        gpu_chacha::GpuRngSeed seed,
         size_t full_ncol,
         size_t col_offset);
 

--- a/cuda/include/matrix/MatrixTrapdoor.cuh
+++ b/cuda/include/matrix/MatrixTrapdoor.cuh
@@ -2,6 +2,8 @@
 
 #include "matrix/Matrix.cuh"
 
+typedef struct GpuP1CovarianceCache GpuP1CovarianceCache;
+
 int launch_gauss_samp_gq_arb_base_multi_kernel(
     const std::vector<const uint64_t *> &src_ptrs,
     const std::vector<uint64_t *> &dst_ptrs,
@@ -76,6 +78,23 @@ extern "C"
         double sigma,
         double s,
         double dgg_stddev,
+        uint64_t seed,
+        GpuMatrix *out);
+
+    int gpu_matrix_create_p1_covariance_cache(
+        const GpuMatrix *a_mat,
+        const GpuMatrix *b_mat,
+        const GpuMatrix *d_mat,
+        double sigma,
+        double s,
+        double dgg_stddev,
+        GpuP1CovarianceCache **out_cache);
+
+    void gpu_matrix_destroy_p1_covariance_cache(GpuP1CovarianceCache *cache);
+
+    int gpu_matrix_sample_p1_full_cached(
+        const GpuP1CovarianceCache *cache,
+        const GpuMatrix *tp2,
         uint64_t seed,
         GpuMatrix *out);
 

--- a/cuda/include/matrix/MatrixTrapdoor.cuh
+++ b/cuda/include/matrix/MatrixTrapdoor.cuh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ChaCha.cuh"
 #include "matrix/Matrix.cuh"
 
 typedef struct GpuP1CovarianceCache GpuP1CovarianceCache;
@@ -15,7 +16,7 @@ int launch_gauss_samp_gq_arb_base_multi_kernel(
     const std::vector<uint32_t> &digit_indices,
     double c,
     const std::vector<uint32_t> &tower_indices,
-    uint64_t seed,
+    gpu_chacha::GpuRngSeed seed,
     const std::vector<uint64_t> &out_moduli,
     int device,
     cudaStream_t stream);
@@ -40,7 +41,7 @@ int launch_sample_p1_integer_kernel(
     double sigma,
     double s,
     double dgg_stddev,
-    uint64_t seed,
+    gpu_chacha::GpuRngSeed seed,
     cudaStream_t stream,
     int device_id,
     int64_t **sampled_out_device,
@@ -67,7 +68,7 @@ extern "C"
         uint32_t base_bits,
         double c,
         double dgg_stddev,
-        uint64_t seed,
+        gpu_chacha::GpuRngSeed seed,
         GpuMatrix *out);
 
     int gpu_matrix_sample_p1_full(
@@ -78,7 +79,7 @@ extern "C"
         double sigma,
         double s,
         double dgg_stddev,
-        uint64_t seed,
+        gpu_chacha::GpuRngSeed seed,
         GpuMatrix *out);
 
     int gpu_matrix_create_p1_covariance_cache(
@@ -95,7 +96,7 @@ extern "C"
     int gpu_matrix_sample_p1_full_cached(
         const GpuP1CovarianceCache *cache,
         const GpuMatrix *tp2,
-        uint64_t seed,
+        gpu_chacha::GpuRngSeed seed,
         GpuMatrix *out);
 
 #ifdef __cplusplus

--- a/cuda/src/ChaCha.cu
+++ b/cuda/src/ChaCha.cu
@@ -7,14 +7,6 @@ namespace gpu_chacha
         return (x << n) | (x >> (32U - n));
     }
 
-    __device__ __forceinline__ uint64_t splitmix64_next(uint64_t &state)
-    {
-        uint64_t z = (state += 0x9e3779b97f4a7c15ULL);
-        z = (z ^ (z >> 30U)) * 0xbf58476d1ce4e5b9ULL;
-        z = (z ^ (z >> 27U)) * 0x94d049bb133111ebULL;
-        return z ^ (z >> 31U);
-    }
-
     __device__ __forceinline__ void quarter_round(
         uint32_t &a,
         uint32_t &b,
@@ -67,9 +59,51 @@ namespace gpu_chacha
         }
     }
 
+    __device__ __forceinline__ void hchacha20(
+        const uint32_t key[8],
+        const uint32_t nonce[4],
+        uint32_t out_key[8])
+    {
+        uint32_t x[16];
+        x[0] = 0x61707865U;
+        x[1] = 0x3320646eU;
+        x[2] = 0x79622d32U;
+        x[3] = 0x6b206574U;
+        for (uint32_t i = 0; i < 8; ++i)
+        {
+            x[4 + i] = key[i];
+        }
+        for (uint32_t i = 0; i < 4; ++i)
+        {
+            x[12 + i] = nonce[i];
+        }
+
+        for (uint32_t round = 0; round < 10; ++round)
+        {
+            quarter_round(x[0], x[4], x[8], x[12]);
+            quarter_round(x[1], x[5], x[9], x[13]);
+            quarter_round(x[2], x[6], x[10], x[14]);
+            quarter_round(x[3], x[7], x[11], x[15]);
+
+            quarter_round(x[0], x[5], x[10], x[15]);
+            quarter_round(x[1], x[6], x[11], x[12]);
+            quarter_round(x[2], x[7], x[8], x[13]);
+            quarter_round(x[3], x[4], x[9], x[14]);
+        }
+
+        out_key[0] = x[0];
+        out_key[1] = x[1];
+        out_key[2] = x[2];
+        out_key[3] = x[3];
+        out_key[4] = x[12];
+        out_key[5] = x[13];
+        out_key[6] = x[14];
+        out_key[7] = x[15];
+    }
+
     __device__ __forceinline__ void rng_init(
         DeviceChaChaRng &rng,
-        uint64_t seed,
+        const GpuRngSeed &seed,
         uint64_t stream0,
         uint64_t stream1,
         uint64_t stream2,
@@ -80,25 +114,31 @@ namespace gpu_chacha
         rng.state[2] = 0x79622d32U;
         rng.state[3] = 0x6b206574U;
 
-        uint64_t mix = seed ^ 0x243f6a8885a308d3ULL;
-        mix ^= (stream0 + 0x9e3779b97f4a7c15ULL);
-        mix ^= (stream1 + 0xbf58476d1ce4e5b9ULL);
-        mix ^= (stream2 + 0x94d049bb133111ebULL);
-        mix ^= (domain_tag + 0xd6e8feb86659fd93ULL);
-
+        uint32_t base_key[8];
         for (uint32_t i = 0; i < 4; ++i)
         {
-            const uint64_t v = splitmix64_next(mix);
-            rng.state[4 + 2 * i] = static_cast<uint32_t>(v);
-            rng.state[5 + 2 * i] = static_cast<uint32_t>(v >> 32U);
+            const uint64_t word = seed.words[i];
+            base_key[2 * i] = static_cast<uint32_t>(word);
+            base_key[2 * i + 1] = static_cast<uint32_t>(word >> 32U);
         }
 
-        const uint64_t n0 = splitmix64_next(mix);
-        const uint64_t n1 = splitmix64_next(mix);
-        rng.state[12] = 0U;
-        rng.state[13] = static_cast<uint32_t>(n0);
-        rng.state[14] = static_cast<uint32_t>(n0 >> 32U);
-        rng.state[15] = static_cast<uint32_t>(n1);
+        uint32_t hnonce[4] = {
+            static_cast<uint32_t>(domain_tag),
+            static_cast<uint32_t>(domain_tag >> 32U),
+            static_cast<uint32_t>(stream2),
+            static_cast<uint32_t>(stream2 >> 32U),
+        };
+        uint32_t subkey[8];
+        hchacha20(base_key, hnonce, subkey);
+        for (uint32_t i = 0; i < 8; ++i)
+        {
+            rng.state[4 + i] = subkey[i];
+        }
+
+        rng.state[12] = static_cast<uint32_t>(stream0);
+        rng.state[13] = static_cast<uint32_t>(stream0 >> 32U);
+        rng.state[14] = static_cast<uint32_t>(stream1);
+        rng.state[15] = static_cast<uint32_t>(stream1 >> 32U);
 
         rng.block_idx = 8U;
     }
@@ -107,6 +147,10 @@ namespace gpu_chacha
     {
         chacha20_block(rng.state, rng.block);
         rng.state[12] += 1U;
+        if (rng.state[12] == 0U)
+        {
+            rng.state[13] += 1U;
+        }
         rng.block_idx = 0U;
     }
 

--- a/cuda/src/matrix/MatrixArith.cu
+++ b/cuda/src/matrix/MatrixArith.cu
@@ -2612,7 +2612,7 @@ int launch_sample_p1_integer_kernel(
     double sigma,
     double s,
     double dgg_stddev,
-    uint64_t seed,
+    gpu_chacha::GpuRngSeed seed,
     cudaStream_t stream,
     int device_id,
     int64_t **sampled_out_device,

--- a/cuda/src/matrix/MatrixSampling.cu
+++ b/cuda/src/matrix/MatrixSampling.cu
@@ -1,4 +1,5 @@
 using gpu_chacha::DeviceChaChaRng;
+using gpu_chacha::GpuRngSeed;
 using gpu_chacha::rng_init;
 using gpu_chacha::rng_next_u64;
 
@@ -220,7 +221,7 @@ __global__ void matrix_sample_distribution_multi_limb_kernel(
     uint32_t limb_idx,
     int dist_type,
     double sigma,
-    uint64_t seed)
+    GpuRngSeed seed)
 {
     size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     size_t total = poly_count * n;
@@ -309,7 +310,7 @@ int launch_sample_distribution_multi_limb_kernel(
     uint32_t limb_idx,
     int dist_type,
     double sigma,
-    uint64_t seed,
+    GpuRngSeed seed,
     cudaStream_t stream,
     const GpuMatrix *,
     const dim3 *)
@@ -352,7 +353,7 @@ static int gpu_matrix_sample_distribution_impl(
     GpuMatrix *out,
     int dist_type,
     double sigma,
-    uint64_t seed,
+    GpuRngSeed seed,
     size_t full_ncol,
     size_t col_offset)
 {
@@ -474,7 +475,7 @@ extern "C" int gpu_matrix_sample_distribution(
     GpuMatrix *out,
     int dist_type,
     double sigma,
-    uint64_t seed)
+    GpuRngSeed seed)
 {
     return gpu_matrix_sample_distribution_impl(out, dist_type, sigma, seed, out ? out->cols : 0, 0);
 }
@@ -483,7 +484,7 @@ extern "C" int gpu_matrix_sample_distribution_columns(
     GpuMatrix *out,
     int dist_type,
     double sigma,
-    uint64_t seed,
+    GpuRngSeed seed,
     size_t full_ncol,
     size_t col_offset)
 {

--- a/cuda/src/matrix/MatrixTrapdoor.cu
+++ b/cuda/src/matrix/MatrixTrapdoor.cu
@@ -73,6 +73,290 @@ namespace
     }
 }
 
+struct GpuP1CovarianceCache
+{
+    GpuContext *ctx = nullptr;
+    int level = -1;
+    size_t d_rows = 0;
+    size_t n = 0;
+    size_t m = 0;
+    uint64_t modulus = 0;
+    double sigma = 0.0;
+    double s = 0.0;
+    int device = -1;
+    cudaStream_t stream = nullptr;
+    cudaEvent_t ready_event = nullptr;
+    double *sqrt_var = nullptr;      // [coeff][row]
+    double *update_coeff = nullptr;  // [coeff][sampled_row][updated_row]
+};
+
+__global__ void matrix_precompute_p1_covariance_kernel(
+    const uint8_t *a_base,
+    const uint8_t *b_base,
+    const uint8_t *d_base,
+    size_t a_stride_bytes,
+    size_t b_stride_bytes,
+    size_t d_stride_bytes,
+    uint8_t a_coeff_bytes,
+    uint8_t b_coeff_bytes,
+    uint8_t d_coeff_bytes,
+    size_t d,
+    size_t n,
+    uint64_t modulus,
+    double sigma,
+    double s,
+    double dgg_stddev,
+    double *cov_workspace,
+    double *sqrt_var_out,
+    double *update_coeff_out)
+{
+    const size_t coeff_idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (coeff_idx >= n)
+    {
+        return;
+    }
+
+    const size_t m = d * 2;
+    if (m == 0)
+    {
+        return;
+    }
+
+    double *cov = cov_workspace + coeff_idx * m * m;
+    double *sqrt_var = sqrt_var_out + coeff_idx * m;
+    double *update_coeff = update_coeff_out + coeff_idx * m * m;
+
+    const double sigma2 = sigma * sigma;
+    const double s2 = s * s;
+    const double fallback_var = dgg_stddev * dgg_stddev;
+    const double eps = 1e-9;
+
+    for (size_t i = 0; i < d; ++i)
+    {
+        for (size_t j = 0; j < d; ++j)
+        {
+            const size_t ij = matrix_index(i, j, d);
+            const size_t ji = matrix_index(j, i, d);
+            const double a_ij = static_cast<double>(centered_residue_i64(
+                matrix_load_limb_u64(a_base, ij, coeff_idx, a_stride_bytes, a_coeff_bytes),
+                modulus));
+            const double d_ij = static_cast<double>(centered_residue_i64(
+                matrix_load_limb_u64(d_base, ij, coeff_idx, d_stride_bytes, d_coeff_bytes),
+                modulus));
+            const double b_ij = static_cast<double>(centered_residue_i64(
+                matrix_load_limb_u64(b_base, ij, coeff_idx, b_stride_bytes, b_coeff_bytes),
+                modulus));
+            const double b_ji = static_cast<double>(centered_residue_i64(
+                matrix_load_limb_u64(b_base, ji, coeff_idx, b_stride_bytes, b_coeff_bytes),
+                modulus));
+
+            cov[matrix_index(i, j, m)] = -sigma2 * a_ij + (i == j ? s2 : 0.0);
+            cov[matrix_index(i + d, j + d, m)] = -sigma2 * d_ij + (i == j ? s2 : 0.0);
+            cov[matrix_index(i, j + d, m)] = -sigma2 * b_ij;
+            cov[matrix_index(i + d, j, m)] = -sigma2 * b_ji;
+        }
+    }
+
+    for (int t = static_cast<int>(m) - 1; t >= 0; --t)
+    {
+        const size_t tt = static_cast<size_t>(t);
+        double var = cov[matrix_index(tt, tt, m)];
+        if (!(var > eps))
+        {
+            var = fallback_var;
+        }
+        sqrt_var[tt] = sqrt(var);
+
+        for (int i = 0; i < t; ++i)
+        {
+            update_coeff[tt * m + static_cast<size_t>(i)] =
+                cov[matrix_index(static_cast<size_t>(i), tt, m)] / var;
+        }
+
+        if (t == 0)
+        {
+            break;
+        }
+
+        for (int i = 0; i < t; ++i)
+        {
+            const double coeff_i = update_coeff[tt * m + static_cast<size_t>(i)];
+            for (int j = 0; j <= i; ++j)
+            {
+                const double col_j =
+                    update_coeff[tt * m + static_cast<size_t>(j)] * var;
+                double updated =
+                    cov[matrix_index(static_cast<size_t>(i), static_cast<size_t>(j), m)] -
+                    coeff_i * col_j;
+                cov[matrix_index(static_cast<size_t>(i), static_cast<size_t>(j), m)] = updated;
+                cov[matrix_index(static_cast<size_t>(j), static_cast<size_t>(i), m)] = updated;
+            }
+        }
+    }
+}
+
+__global__ void matrix_sample_p1_integer_cached_kernel_small(
+    const uint8_t *tp2_base,
+    size_t tp2_stride_bytes,
+    uint8_t tp2_coeff_bytes,
+    const double *sqrt_var_base,
+    const double *update_coeff_base,
+    size_t d,
+    size_t cols,
+    size_t n,
+    int64_t *sampled_out,
+    uint64_t modulus,
+    double c_scale,
+    uint64_t seed)
+{
+    const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const size_t total_samples = cols * n;
+    if (idx >= total_samples)
+    {
+        return;
+    }
+
+    const size_t m = d * 2;
+    if (m == 0 || m > kSampleP1LocalMaxM)
+    {
+        return;
+    }
+
+    const size_t col_idx = idx / n;
+    const size_t coeff_idx = idx - col_idx * n;
+    double mean[kSampleP1LocalMaxM];
+    int64_t sampled[kSampleP1LocalMaxM];
+    const double *sqrt_var = sqrt_var_base + coeff_idx * m;
+    const double *update_coeff = update_coeff_base + coeff_idx * m * m;
+
+    DeviceChaChaRng rng;
+    rng_init(
+        rng,
+        seed,
+        static_cast<uint64_t>(col_idx + 1),
+        static_cast<uint64_t>(coeff_idx + 1),
+        0,
+        0x7065727475726231ULL);
+
+    for (size_t row = 0; row < m; ++row)
+    {
+        const size_t tp_idx = matrix_index(row, col_idx, cols);
+        const double c_centered = static_cast<double>(centered_residue_i64(
+            matrix_load_limb_u64(tp2_base, tp_idx, coeff_idx, tp2_stride_bytes, tp2_coeff_bytes),
+            modulus));
+        mean[row] = c_scale * c_centered;
+    }
+
+    for (int t = static_cast<int>(m) - 1; t >= 0; --t)
+    {
+        const size_t tt = static_cast<size_t>(t);
+        const double mu = mean[tt];
+        const int64_t z = sample_integer_karney(rng, mu, sqrt_var[tt]);
+        sampled[tt] = z;
+
+        if (t == 0)
+        {
+            break;
+        }
+
+        const double delta = static_cast<double>(z) - mu;
+        for (int i = 0; i < t; ++i)
+        {
+            mean[static_cast<size_t>(i)] +=
+                update_coeff[tt * m + static_cast<size_t>(i)] * delta;
+        }
+    }
+
+    for (size_t row = 0; row < m; ++row)
+    {
+        const size_t out_idx = matrix_index(row, col_idx, cols) * n + coeff_idx;
+        sampled_out[out_idx] = sampled[row];
+    }
+}
+
+__global__ void matrix_sample_p1_integer_cached_kernel_large(
+    const uint8_t *tp2_base,
+    size_t tp2_stride_bytes,
+    uint8_t tp2_coeff_bytes,
+    const double *sqrt_var_base,
+    const double *update_coeff_base,
+    size_t d,
+    size_t cols,
+    size_t n,
+    size_t sample_start,
+    size_t sample_count,
+    double *mean_workspace,
+    int64_t *sampled_workspace,
+    int64_t *sampled_out,
+    uint64_t modulus,
+    double c_scale,
+    uint64_t seed)
+{
+    const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= sample_count)
+    {
+        return;
+    }
+
+    const size_t m = d * 2;
+    if (m == 0)
+    {
+        return;
+    }
+
+    const size_t sample_idx = sample_start + idx;
+    const size_t col_idx = sample_idx / n;
+    const size_t coeff_idx = sample_idx - col_idx * n;
+    double *mean = mean_workspace + idx * m;
+    int64_t *sampled = sampled_workspace + idx * m;
+    const double *sqrt_var = sqrt_var_base + coeff_idx * m;
+    const double *update_coeff = update_coeff_base + coeff_idx * m * m;
+
+    DeviceChaChaRng rng;
+    rng_init(
+        rng,
+        seed,
+        static_cast<uint64_t>(col_idx + 1),
+        static_cast<uint64_t>(coeff_idx + 1),
+        0,
+        0x7065727475726231ULL);
+
+    for (size_t row = 0; row < m; ++row)
+    {
+        const size_t tp_idx = matrix_index(row, col_idx, cols);
+        const double c_centered = static_cast<double>(centered_residue_i64(
+            matrix_load_limb_u64(tp2_base, tp_idx, coeff_idx, tp2_stride_bytes, tp2_coeff_bytes),
+            modulus));
+        mean[row] = c_scale * c_centered;
+    }
+
+    for (int t = static_cast<int>(m) - 1; t >= 0; --t)
+    {
+        const size_t tt = static_cast<size_t>(t);
+        const double mu = mean[tt];
+        const int64_t z = sample_integer_karney(rng, mu, sqrt_var[tt]);
+        sampled[tt] = z;
+
+        if (t == 0)
+        {
+            break;
+        }
+
+        const double delta = static_cast<double>(z) - mu;
+        for (int i = 0; i < t; ++i)
+        {
+            mean[static_cast<size_t>(i)] +=
+                update_coeff[tt * m + static_cast<size_t>(i)] * delta;
+        }
+    }
+
+    for (size_t row = 0; row < m; ++row)
+    {
+        const size_t out_idx = matrix_index(row, col_idx, cols) * n + coeff_idx;
+        sampled_out[out_idx] = sampled[row];
+    }
+}
+
 __global__ void matrix_sample_p1_integer_kernel_small(
     const uint8_t *a_base,
     const uint8_t *b_base,
@@ -1035,6 +1319,296 @@ int launch_sample_p1_integer_kernel(
     return 0;
 }
 
+int launch_precompute_p1_covariance_kernel(
+    const uint8_t *a_base,
+    const uint8_t *b_base,
+    const uint8_t *d_base,
+    size_t a_stride_bytes,
+    size_t b_stride_bytes,
+    size_t d_stride_bytes,
+    uint8_t a_coeff_bytes,
+    uint8_t b_coeff_bytes,
+    uint8_t d_coeff_bytes,
+    size_t d,
+    size_t n,
+    uint64_t modulus,
+    double sigma,
+    double s,
+    double dgg_stddev,
+    int device_id,
+    cudaStream_t stream,
+    double *cov_workspace,
+    double *sqrt_var_out,
+    double *update_coeff_out)
+{
+    if (!a_base || !b_base || !d_base || !cov_workspace || !sqrt_var_out || !update_coeff_out)
+    {
+        return set_error("null pointer in matrix_precompute_p1_covariance_kernel");
+    }
+    if (a_coeff_bytes == 0 || b_coeff_bytes == 0 || d_coeff_bytes == 0 ||
+        a_stride_bytes < n * static_cast<size_t>(a_coeff_bytes) ||
+        b_stride_bytes < n * static_cast<size_t>(b_coeff_bytes) ||
+        d_stride_bytes < n * static_cast<size_t>(d_coeff_bytes))
+    {
+        return set_error("invalid stride in matrix_precompute_p1_covariance_kernel");
+    }
+    if (d == 0 || n == 0)
+    {
+        return 0;
+    }
+    if (!(sigma > 0.0) || !(s > sigma) || !(dgg_stddev > 0.0))
+    {
+        return set_error("invalid Gaussian parameters in matrix_precompute_p1_covariance_kernel");
+    }
+    if (device_id < 0 || !stream)
+    {
+        return set_error("invalid device/stream in matrix_precompute_p1_covariance_kernel");
+    }
+
+    cudaError_t err = cudaSetDevice(device_id);
+    if (err != cudaSuccess)
+    {
+        return set_error(err);
+    }
+
+    const int threads = 256;
+    const int blocks = static_cast<int>((n + threads - 1) / threads);
+    matrix_precompute_p1_covariance_kernel<<<blocks, threads, 0, stream>>>(
+        a_base,
+        b_base,
+        d_base,
+        a_stride_bytes,
+        b_stride_bytes,
+        d_stride_bytes,
+        a_coeff_bytes,
+        b_coeff_bytes,
+        d_coeff_bytes,
+        d,
+        n,
+        modulus,
+        sigma,
+        s,
+        dgg_stddev,
+        cov_workspace,
+        sqrt_var_out,
+        update_coeff_out);
+    err = cudaGetLastError();
+    if (err != cudaSuccess)
+    {
+        return set_error(err);
+    }
+    return 0;
+}
+
+int launch_sample_p1_integer_cached_kernel(
+    const uint8_t *tp2_base,
+    size_t tp2_stride_bytes,
+    uint8_t tp2_coeff_bytes,
+    const GpuP1CovarianceCache *cache,
+    size_t cols,
+    int64_t **sampled_out_device,
+    uint64_t seed,
+    cudaStream_t stream,
+    int device_id,
+    cudaEvent_t sampled_ready_event)
+{
+    if (!sampled_out_device)
+    {
+        return set_error("null output pointer in matrix_sample_p1_integer_cached_kernel");
+    }
+    *sampled_out_device = nullptr;
+    if (!tp2_base || !cache || !cache->sqrt_var || !cache->update_coeff)
+    {
+        return set_error("null pointer in matrix_sample_p1_integer_cached_kernel");
+    }
+    if (tp2_coeff_bytes == 0 ||
+        tp2_stride_bytes < cache->n * static_cast<size_t>(tp2_coeff_bytes))
+    {
+        return set_error("invalid stride in matrix_sample_p1_integer_cached_kernel");
+    }
+    if (cache->d_rows == 0 || cols == 0 || cache->n == 0)
+    {
+        return 0;
+    }
+    if (device_id < 0 || !stream)
+    {
+        return set_error("invalid device/stream in matrix_sample_p1_integer_cached_kernel");
+    }
+
+    cudaError_t err = cudaSetDevice(device_id);
+    if (err != cudaSuccess)
+    {
+        return set_error(err);
+    }
+
+    const size_t m = cache->m;
+    const size_t entry_count = m * cols;
+    if (entry_count > std::numeric_limits<size_t>::max() / cache->n ||
+        entry_count * cache->n > std::numeric_limits<size_t>::max() / sizeof(int64_t))
+    {
+        return set_error("sample byte overflow in matrix_sample_p1_integer_cached_kernel");
+    }
+    const size_t total_values = entry_count * cache->n;
+    const size_t total_samples = cols * cache->n;
+    const double denom = cache->s * cache->s - cache->sigma * cache->sigma;
+    if (!(denom > 0.0))
+    {
+        return set_error("invalid cached Gaussian denominator");
+    }
+    const double c_scale = -(cache->sigma * cache->sigma) / denom;
+
+    int64_t *d_sampled_out = nullptr;
+    auto free_all = [&]()
+    {
+        if (d_sampled_out)
+        {
+            cudaFreeAsync(d_sampled_out, stream);
+            d_sampled_out = nullptr;
+        }
+    };
+
+    err = cudaMallocAsync(reinterpret_cast<void **>(&d_sampled_out), total_values * sizeof(int64_t), stream);
+    if (err != cudaSuccess)
+    {
+        free_all();
+        return set_error(err);
+    }
+
+    const int threads = 256;
+    if (m <= kSampleP1LocalMaxM)
+    {
+        const int blocks = static_cast<int>((total_samples + threads - 1) / threads);
+        matrix_sample_p1_integer_cached_kernel_small<<<blocks, threads, 0, stream>>>(
+            tp2_base,
+            tp2_stride_bytes,
+            tp2_coeff_bytes,
+            cache->sqrt_var,
+            cache->update_coeff,
+            cache->d_rows,
+            cols,
+            cache->n,
+            d_sampled_out,
+            cache->modulus,
+            c_scale,
+            seed);
+        err = cudaGetLastError();
+        if (err != cudaSuccess)
+        {
+            free_all();
+            return set_error(err);
+        }
+    }
+    else
+    {
+        if (m > std::numeric_limits<size_t>::max() / sizeof(double) ||
+            m > std::numeric_limits<size_t>::max() / sizeof(int64_t))
+        {
+            free_all();
+            return set_error("workspace overflow in matrix_sample_p1_integer_cached_kernel");
+        }
+        const size_t mean_bytes_per_sample = m * sizeof(double);
+        const size_t sampled_bytes_per_sample = m * sizeof(int64_t);
+        if (mean_bytes_per_sample >
+            std::numeric_limits<size_t>::max() - sampled_bytes_per_sample)
+        {
+            free_all();
+            return set_error("workspace overflow in matrix_sample_p1_integer_cached_kernel");
+        }
+        const size_t bytes_per_sample_total = mean_bytes_per_sample + sampled_bytes_per_sample;
+        void *workspace = nullptr;
+        double *mean_workspace = nullptr;
+        int64_t *sampled_workspace = nullptr;
+        auto free_workspace = [&]()
+        {
+            if (workspace)
+            {
+                cudaFreeAsync(workspace, stream);
+                workspace = nullptr;
+            }
+            mean_workspace = nullptr;
+            sampled_workspace = nullptr;
+        };
+
+        size_t chunk_samples = total_samples;
+        auto alloc_workspace = [&](size_t samples) -> bool
+        {
+            if (samples == 0 || samples > std::numeric_limits<size_t>::max() / bytes_per_sample_total)
+            {
+                return false;
+            }
+            const size_t workspace_bytes = samples * bytes_per_sample_total;
+            cudaError_t local_err = cudaMallocAsync(&workspace, workspace_bytes, stream);
+            if (local_err != cudaSuccess)
+            {
+                free_workspace();
+                return false;
+            }
+            auto *workspace_base = reinterpret_cast<uint8_t *>(workspace);
+            const size_t mean_bytes = samples * mean_bytes_per_sample;
+            mean_workspace = reinterpret_cast<double *>(workspace_base);
+            sampled_workspace = reinterpret_cast<int64_t *>(workspace_base + mean_bytes);
+            return true;
+        };
+
+        while (!alloc_workspace(chunk_samples))
+        {
+            if (chunk_samples <= 1)
+            {
+                free_workspace();
+                free_all();
+                return set_error("failed to allocate workspace in matrix_sample_p1_integer_cached_kernel");
+            }
+            chunk_samples = (chunk_samples + 1) / 2;
+        }
+
+        for (size_t sample_start = 0; sample_start < total_samples; sample_start += chunk_samples)
+        {
+            size_t sample_count = std::min(chunk_samples, total_samples - sample_start);
+            const int blocks = static_cast<int>((sample_count + threads - 1) / threads);
+            matrix_sample_p1_integer_cached_kernel_large<<<blocks, threads, 0, stream>>>(
+                tp2_base,
+                tp2_stride_bytes,
+                tp2_coeff_bytes,
+                cache->sqrt_var,
+                cache->update_coeff,
+                cache->d_rows,
+                cols,
+                cache->n,
+                sample_start,
+                sample_count,
+                mean_workspace,
+                sampled_workspace,
+                d_sampled_out,
+                cache->modulus,
+                c_scale,
+                seed);
+            err = cudaGetLastError();
+            if (err != cudaSuccess)
+            {
+                free_workspace();
+                free_all();
+                return set_error(err);
+            }
+        }
+        free_workspace();
+    }
+
+    if (sampled_ready_event)
+    {
+        err = cudaEventRecord(sampled_ready_event, stream);
+        if (err != cudaSuccess)
+        {
+            free_all();
+            return set_error(err);
+        }
+    }
+
+    *sampled_out_device = d_sampled_out;
+    d_sampled_out = nullptr;
+    free_all();
+    return 0;
+}
+
 int launch_scatter_p1_integer_to_limb_kernel_device(
     const int64_t *sampled_in_device,
     uint8_t *out_base,
@@ -1576,6 +2150,767 @@ extern "C" int gpu_matrix_gauss_samp_gq_arb_base(
         out->format = GPU_POLY_FORMAT_EVAL;
     }
 
+    cleanup();
+    return 0;
+}
+
+extern "C" int gpu_matrix_create_p1_covariance_cache(
+    const GpuMatrix *a_mat,
+    const GpuMatrix *b_mat,
+    const GpuMatrix *d_mat,
+    double sigma,
+    double s,
+    double dgg_stddev,
+    GpuP1CovarianceCache **out_cache)
+{
+    if (!out_cache)
+    {
+        return set_error("null output in gpu_matrix_create_p1_covariance_cache");
+    }
+    *out_cache = nullptr;
+    if (!a_mat || !b_mat || !d_mat)
+    {
+        return set_error("invalid gpu_matrix_create_p1_covariance_cache arguments");
+    }
+    if (!(sigma > 0.0) || !(s > sigma) || !(dgg_stddev > 0.0))
+    {
+        return set_error("invalid Gaussian parameters in gpu_matrix_create_p1_covariance_cache");
+    }
+    if (a_mat->ctx != b_mat->ctx || a_mat->ctx != d_mat->ctx)
+    {
+        return set_error("context mismatch in gpu_matrix_create_p1_covariance_cache");
+    }
+    if (a_mat->level != b_mat->level || a_mat->level != d_mat->level)
+    {
+        return set_error("level mismatch in gpu_matrix_create_p1_covariance_cache");
+    }
+    if (a_mat->format != GPU_POLY_FORMAT_COEFF ||
+        b_mat->format != GPU_POLY_FORMAT_COEFF ||
+        d_mat->format != GPU_POLY_FORMAT_COEFF)
+    {
+        return set_error("p1 covariance cache inputs must be coefficient matrices");
+    }
+    const size_t d_rows = a_mat->rows;
+    if (a_mat->cols != d_rows || b_mat->rows != d_rows || b_mat->cols != d_rows ||
+        d_mat->rows != d_rows || d_mat->cols != d_rows)
+    {
+        return set_error("A/B/D must be dxd in gpu_matrix_create_p1_covariance_cache");
+    }
+    if (d_rows == 0)
+    {
+        auto *empty_cache = new GpuP1CovarianceCache();
+        empty_cache->ctx = a_mat->ctx;
+        empty_cache->level = a_mat->level;
+        *out_cache = empty_cache;
+        return 0;
+    }
+    const int level = a_mat->level;
+    if (level < 0)
+    {
+        return set_error("invalid level in gpu_matrix_create_p1_covariance_cache");
+    }
+    if (a_mat->ctx->moduli.empty() || a_mat->ctx->limb_gpu_ids.empty())
+    {
+        return set_error("empty context in gpu_matrix_create_p1_covariance_cache");
+    }
+
+    const size_t n = static_cast<size_t>(a_mat->ctx->N);
+    const size_t m = 2 * d_rows;
+    if (m == 0 || m > std::numeric_limits<size_t>::max() / m)
+    {
+        return set_error("invalid dimension in gpu_matrix_create_p1_covariance_cache");
+    }
+    const size_t factor_elems = n * m;
+    if (n != 0 && factor_elems / n != m)
+    {
+        return set_error("factor size overflow in gpu_matrix_create_p1_covariance_cache");
+    }
+    if (factor_elems > std::numeric_limits<size_t>::max() / m)
+    {
+        return set_error("factor size overflow in gpu_matrix_create_p1_covariance_cache");
+    }
+    const size_t update_elems = factor_elems * m;
+    if (factor_elems > std::numeric_limits<size_t>::max() / sizeof(double) ||
+        update_elems > std::numeric_limits<size_t>::max() / sizeof(double))
+    {
+        return set_error("factor byte overflow in gpu_matrix_create_p1_covariance_cache");
+    }
+    const size_t sqrt_bytes = factor_elems * sizeof(double);
+    const size_t update_bytes = update_elems * sizeof(double);
+    const size_t cov_bytes = update_bytes;
+
+    const dim3 ref_limb_id = a_mat->ctx->limb_gpu_ids[0];
+    int ref_device = -1;
+    int status = matrix_limb_device(a_mat, ref_limb_id, &ref_device);
+    if (status != 0)
+    {
+        return status;
+    }
+    int b_device = -1;
+    status = matrix_limb_device(b_mat, ref_limb_id, &b_device);
+    if (status != 0)
+    {
+        return status;
+    }
+    int d_device = -1;
+    status = matrix_limb_device(d_mat, ref_limb_id, &d_device);
+    if (status != 0)
+    {
+        return status;
+    }
+    if (ref_device < 0 || b_device != ref_device || d_device != ref_device)
+    {
+        return set_error("reference limb device mismatch in gpu_matrix_create_p1_covariance_cache");
+    }
+    const uint8_t *a_base = matrix_limb_ptr_by_id(a_mat, 0, ref_limb_id);
+    const uint8_t *b_base = matrix_limb_ptr_by_id(b_mat, 0, ref_limb_id);
+    const uint8_t *d_base = matrix_limb_ptr_by_id(d_mat, 0, ref_limb_id);
+    if (!a_base || !b_base || !d_base)
+    {
+        return set_error("null reference limb base pointer in gpu_matrix_create_p1_covariance_cache");
+    }
+    size_t a_stride = 0;
+    size_t b_stride = 0;
+    size_t d_stride = 0;
+    uint8_t a_coeff_bytes = 0;
+    uint8_t b_coeff_bytes = 0;
+    uint8_t d_coeff_bytes = 0;
+    if (!matrix_limb_metadata_by_id(a_mat, ref_limb_id, &a_stride, &a_coeff_bytes) ||
+        !matrix_limb_metadata_by_id(b_mat, ref_limb_id, &b_stride, &b_coeff_bytes) ||
+        !matrix_limb_metadata_by_id(d_mat, ref_limb_id, &d_stride, &d_coeff_bytes))
+    {
+        return set_error("invalid reference limb metadata in gpu_matrix_create_p1_covariance_cache");
+    }
+
+    cudaError_t err = cudaSetDevice(ref_device);
+    if (err != cudaSuccess)
+    {
+        return set_error(err);
+    }
+
+    auto *cache = new GpuP1CovarianceCache();
+    cache->ctx = a_mat->ctx;
+    cache->level = a_mat->level;
+    cache->d_rows = d_rows;
+    cache->n = n;
+    cache->m = m;
+    cache->modulus = a_mat->ctx->moduli[0];
+    cache->sigma = sigma;
+    cache->s = s;
+    cache->device = ref_device;
+    err = cudaStreamCreateWithFlags(&cache->stream, cudaStreamNonBlocking);
+    if (err != cudaSuccess)
+    {
+        delete cache;
+        return set_error(err);
+    }
+
+    status = matrix_wait_limb_stream(a_mat, ref_limb_id, ref_device, cache->stream);
+    if (status != 0)
+    {
+        gpu_matrix_destroy_p1_covariance_cache(cache);
+        return status;
+    }
+    status = matrix_wait_limb_stream(b_mat, ref_limb_id, ref_device, cache->stream);
+    if (status != 0)
+    {
+        gpu_matrix_destroy_p1_covariance_cache(cache);
+        return status;
+    }
+    status = matrix_wait_limb_stream(d_mat, ref_limb_id, ref_device, cache->stream);
+    if (status != 0)
+    {
+        gpu_matrix_destroy_p1_covariance_cache(cache);
+        return status;
+    }
+
+    double *cov_workspace = nullptr;
+    auto cleanup = [&]()
+    {
+        cudaSetDevice(ref_device);
+        if (cov_workspace)
+        {
+            cudaFreeAsync(cov_workspace, cache->stream);
+            cov_workspace = nullptr;
+        }
+        if (cache)
+        {
+            gpu_matrix_destroy_p1_covariance_cache(cache);
+            cache = nullptr;
+        }
+    };
+
+    err = cudaMallocAsync(reinterpret_cast<void **>(&cache->sqrt_var), sqrt_bytes, cache->stream);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+    err = cudaMallocAsync(reinterpret_cast<void **>(&cache->update_coeff), update_bytes, cache->stream);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+    err = cudaMallocAsync(reinterpret_cast<void **>(&cov_workspace), cov_bytes, cache->stream);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+    err = cudaEventCreateWithFlags(&cache->ready_event, cudaEventDisableTiming);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+
+    status = launch_precompute_p1_covariance_kernel(
+        a_base,
+        b_base,
+        d_base,
+        a_stride,
+        b_stride,
+        d_stride,
+        a_coeff_bytes,
+        b_coeff_bytes,
+        d_coeff_bytes,
+        d_rows,
+        n,
+        cache->modulus,
+        sigma,
+        s,
+        dgg_stddev,
+        ref_device,
+        cache->stream,
+        cov_workspace,
+        cache->sqrt_var,
+        cache->update_coeff);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+    err = cudaEventRecord(cache->ready_event, cache->stream);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+    cudaFreeAsync(cov_workspace, cache->stream);
+    cov_workspace = nullptr;
+
+    status = matrix_track_limb_consumer(a_mat, ref_limb_id, ref_device, cache->stream);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+    status = matrix_track_limb_consumer(b_mat, ref_limb_id, ref_device, cache->stream);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+    status = matrix_track_limb_consumer(d_mat, ref_limb_id, ref_device, cache->stream);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+
+    *out_cache = cache;
+    cache = nullptr;
+    return 0;
+}
+
+extern "C" void gpu_matrix_destroy_p1_covariance_cache(GpuP1CovarianceCache *cache)
+{
+    if (!cache)
+    {
+        return;
+    }
+    if (cache->device >= 0)
+    {
+        cudaSetDevice(cache->device);
+        if (cache->sqrt_var)
+        {
+            if (cache->stream)
+            {
+                cudaFreeAsync(cache->sqrt_var, cache->stream);
+            }
+            else
+            {
+                cudaFree(cache->sqrt_var);
+            }
+            cache->sqrt_var = nullptr;
+        }
+        if (cache->update_coeff)
+        {
+            if (cache->stream)
+            {
+                cudaFreeAsync(cache->update_coeff, cache->stream);
+            }
+            else
+            {
+                cudaFree(cache->update_coeff);
+            }
+            cache->update_coeff = nullptr;
+        }
+        if (cache->ready_event)
+        {
+            cudaEventDestroy(cache->ready_event);
+            cache->ready_event = nullptr;
+        }
+        if (cache->stream)
+        {
+            cudaStreamDestroy(cache->stream);
+            cache->stream = nullptr;
+        }
+    }
+    delete cache;
+}
+
+extern "C" int gpu_matrix_sample_p1_full_cached(
+    const GpuP1CovarianceCache *cache,
+    const GpuMatrix *tp2,
+    uint64_t seed,
+    GpuMatrix *out)
+{
+    if (!cache || !tp2 || !out)
+    {
+        return set_error("invalid gpu_matrix_sample_p1_full_cached arguments");
+    }
+    if (cache->ctx != tp2->ctx || cache->ctx != out->ctx)
+    {
+        return set_error("context mismatch in gpu_matrix_sample_p1_full_cached");
+    }
+    if (cache->level != tp2->level || cache->level != out->level)
+    {
+        return set_error("level mismatch in gpu_matrix_sample_p1_full_cached");
+    }
+    if (tp2->format != GPU_POLY_FORMAT_COEFF)
+    {
+        return set_error("tp2 must be coefficient format in gpu_matrix_sample_p1_full_cached");
+    }
+    if (tp2->rows != 2 * cache->d_rows || out->rows != 2 * cache->d_rows || out->cols != tp2->cols)
+    {
+        return set_error("tp2/out shape mismatch in gpu_matrix_sample_p1_full_cached");
+    }
+    const size_t cols = tp2->cols;
+    if (cols == 0 || cache->d_rows == 0)
+    {
+        out->format = GPU_POLY_FORMAT_EVAL;
+        return 0;
+    }
+    const int level = cache->level;
+    if (level < 0)
+    {
+        return set_error("invalid level in gpu_matrix_sample_p1_full_cached");
+    }
+    const size_t crt_depth = static_cast<size_t>(level + 1);
+    if (tp2->ctx->moduli.size() < crt_depth || tp2->ctx->limb_gpu_ids.size() < crt_depth)
+    {
+        return set_error("unexpected context size in gpu_matrix_sample_p1_full_cached");
+    }
+
+    out->format = GPU_POLY_FORMAT_COEFF;
+    const dim3 ref_limb_id = tp2->ctx->limb_gpu_ids[0];
+    int ref_device = -1;
+    int status = matrix_limb_device(out, ref_limb_id, &ref_device);
+    if (status != 0)
+    {
+        return status;
+    }
+    cudaStream_t ref_stream = nullptr;
+    status = matrix_limb_stream(out, ref_limb_id, &ref_stream);
+    if (status != 0)
+    {
+        return status;
+    }
+    int tp2_ref_device = -1;
+    status = matrix_limb_device(tp2, ref_limb_id, &tp2_ref_device);
+    if (status != 0)
+    {
+        return status;
+    }
+    if (ref_device != cache->device || tp2_ref_device != ref_device)
+    {
+        return set_error("reference device mismatch in gpu_matrix_sample_p1_full_cached");
+    }
+    if (!ref_stream || ref_device < 0)
+    {
+        return set_error("invalid reference stream/device in gpu_matrix_sample_p1_full_cached");
+    }
+
+    const uint8_t *ref_tp2_base = matrix_limb_ptr_by_id(tp2, 0, ref_limb_id);
+    if (!ref_tp2_base)
+    {
+        return set_error("null tp2 reference limb base pointer in gpu_matrix_sample_p1_full_cached");
+    }
+    size_t ref_tp2_stride = 0;
+    uint8_t ref_tp2_coeff_bytes = 0;
+    if (!matrix_limb_metadata_by_id(tp2, ref_limb_id, &ref_tp2_stride, &ref_tp2_coeff_bytes))
+    {
+        return set_error("invalid tp2 reference limb metadata in gpu_matrix_sample_p1_full_cached");
+    }
+    if (ref_tp2_stride < cache->n * static_cast<size_t>(ref_tp2_coeff_bytes))
+    {
+        return set_error("invalid tp2 reference limb stride in gpu_matrix_sample_p1_full_cached");
+    }
+    status = matrix_wait_limb_stream(tp2, ref_limb_id, ref_device, ref_stream);
+    if (status != 0)
+    {
+        return status;
+    }
+
+    cudaError_t err = cudaSetDevice(ref_device);
+    if (err != cudaSuccess)
+    {
+        return set_error(err);
+    }
+    if (cache->ready_event)
+    {
+        err = cudaStreamWaitEvent(ref_stream, cache->ready_event, 0);
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+    }
+
+    struct DeviceSampleBuffer
+    {
+        int device;
+        int64_t *ptr;
+        cudaStream_t owner_stream;
+        cudaEvent_t ready_event;
+        std::vector<cudaEvent_t> consumer_done_events;
+    };
+    std::vector<DeviceSampleBuffer> sampled_device_buffers;
+    cudaEvent_t sampled_ready_event = nullptr;
+    int sampled_ready_device = -1;
+    int64_t *sampled_ref_device = nullptr;
+
+    auto cleanup = [&]()
+    {
+        if (sampled_ready_event)
+        {
+            if (sampled_ready_device >= 0)
+            {
+                cudaSetDevice(sampled_ready_device);
+            }
+            cudaEventDestroy(sampled_ready_event);
+            sampled_ready_event = nullptr;
+        }
+        for (auto &entry : sampled_device_buffers)
+        {
+            if (entry.device < 0)
+            {
+                entry.ptr = nullptr;
+                if (entry.ready_event)
+                {
+                    cudaEventDestroy(entry.ready_event);
+                    entry.ready_event = nullptr;
+                }
+                for (cudaEvent_t event : entry.consumer_done_events)
+                {
+                    cudaEventDestroy(event);
+                }
+                entry.consumer_done_events.clear();
+                continue;
+            }
+            cudaSetDevice(entry.device);
+            if (entry.ptr)
+            {
+                cudaFreeAsync(entry.ptr, entry.owner_stream);
+                entry.ptr = nullptr;
+            }
+            if (entry.ready_event)
+            {
+                cudaEventDestroy(entry.ready_event);
+                entry.ready_event = nullptr;
+            }
+            for (cudaEvent_t event : entry.consumer_done_events)
+            {
+                cudaEventDestroy(event);
+            }
+            entry.consumer_done_events.clear();
+        }
+        sampled_device_buffers.clear();
+    };
+
+    err = cudaEventCreateWithFlags(&sampled_ready_event, cudaEventDisableTiming);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+    sampled_ready_device = ref_device;
+
+    status = launch_sample_p1_integer_cached_kernel(
+        ref_tp2_base,
+        ref_tp2_stride,
+        ref_tp2_coeff_bytes,
+        cache,
+        cols,
+        &sampled_ref_device,
+        seed,
+        ref_stream,
+        ref_device,
+        sampled_ready_event);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+    status = matrix_track_limb_consumer(tp2, ref_limb_id, ref_device, ref_stream);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+    cudaEvent_t cache_consumer_done = nullptr;
+    status = matrix_get_thread_local_owner_link_event(cache->device, &cache_consumer_done);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+    err = cudaEventRecord(cache_consumer_done, ref_stream);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+    err = cudaStreamWaitEvent(cache->stream, cache_consumer_done, 0);
+    if (err != cudaSuccess)
+    {
+        cleanup();
+        return set_error(err);
+    }
+    if (sampled_ref_device)
+    {
+        sampled_device_buffers.push_back(
+            DeviceSampleBuffer{
+                ref_device,
+                sampled_ref_device,
+                ref_stream,
+                sampled_ready_event,
+                {}});
+        sampled_ready_event = nullptr;
+        sampled_ready_device = -1;
+    }
+
+    const size_t sampled_entry_count = 2 * cache->d_rows * cols;
+    if (sampled_entry_count > std::numeric_limits<size_t>::max() / cache->n ||
+        sampled_entry_count * cache->n > std::numeric_limits<size_t>::max() / sizeof(int64_t))
+    {
+        cleanup();
+        return set_error("sample byte overflow in gpu_matrix_sample_p1_full_cached");
+    }
+    const size_t sampled_bytes = sampled_entry_count * cache->n * sizeof(int64_t);
+
+    auto link_sample_buffer_consumer_done =
+        [&](int64_t *ptr, int device, cudaStream_t consumer_stream) -> int
+    {
+        if (!ptr)
+        {
+            return set_error("null sampled buffer in cached consumer link");
+        }
+        if (device < 0 || !consumer_stream)
+        {
+            return set_error("invalid device/stream in cached consumer link");
+        }
+        for (auto &entry : sampled_device_buffers)
+        {
+            if (entry.device != device || entry.ptr != ptr)
+            {
+                continue;
+            }
+            if (!entry.owner_stream || entry.owner_stream == consumer_stream)
+            {
+                return 0;
+            }
+            cudaError_t err = cudaSetDevice(device);
+            if (err != cudaSuccess)
+            {
+                return set_error(err);
+            }
+            cudaEvent_t consumer_done = nullptr;
+            err = cudaEventCreateWithFlags(&consumer_done, cudaEventDisableTiming);
+            if (err != cudaSuccess)
+            {
+                return set_error(err);
+            }
+            err = cudaEventRecord(consumer_done, consumer_stream);
+            if (err != cudaSuccess)
+            {
+                cudaEventDestroy(consumer_done);
+                return set_error(err);
+            }
+            err = cudaStreamWaitEvent(entry.owner_stream, consumer_done, 0);
+            if (err != cudaSuccess)
+            {
+                cudaEventDestroy(consumer_done);
+                return set_error(err);
+            }
+            entry.consumer_done_events.push_back(consumer_done);
+            return 0;
+        }
+        return set_error("missing sampled buffer owner for cached consumer link");
+    };
+
+    auto ensure_sample_buffer_on_device = [&](int device, cudaStream_t stream, int64_t **out_ptr) -> int
+    {
+        if (!out_ptr)
+        {
+            return set_error("invalid output in cached ensure_sample_buffer_on_device");
+        }
+        if (device < 0 || !stream)
+        {
+            return set_error("invalid device/stream in cached ensure_sample_buffer_on_device");
+        }
+        *out_ptr = nullptr;
+        for (auto &entry : sampled_device_buffers)
+        {
+            if (entry.device == device && entry.ptr)
+            {
+                cudaError_t wait_err = cudaSetDevice(device);
+                if (wait_err != cudaSuccess)
+                {
+                    return set_error(wait_err);
+                }
+                if (entry.ready_event)
+                {
+                    wait_err = cudaStreamWaitEvent(stream, entry.ready_event, 0);
+                    if (wait_err != cudaSuccess)
+                    {
+                        return set_error(wait_err);
+                    }
+                }
+                *out_ptr = entry.ptr;
+                return 0;
+            }
+        }
+        if (!sampled_ref_device)
+        {
+            return set_error("missing reference sample buffer in gpu_matrix_sample_p1_full_cached");
+        }
+        if (sampled_bytes == 0)
+        {
+            return 0;
+        }
+        cudaError_t err = cudaSetDevice(device);
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        int64_t *device_copy = nullptr;
+        err = cudaMallocAsync(reinterpret_cast<void **>(&device_copy), sampled_bytes, stream);
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        err = cudaMemcpyPeerAsync(device_copy, device, sampled_ref_device, ref_device, sampled_bytes, stream);
+        if (err != cudaSuccess)
+        {
+            cudaFreeAsync(device_copy, stream);
+            return set_error(err);
+        }
+        cudaEvent_t copy_ready = nullptr;
+        err = cudaEventCreateWithFlags(&copy_ready, cudaEventDisableTiming);
+        if (err != cudaSuccess)
+        {
+            cudaFreeAsync(device_copy, stream);
+            return set_error(err);
+        }
+        err = cudaEventRecord(copy_ready, stream);
+        if (err != cudaSuccess)
+        {
+            cudaEventDestroy(copy_ready);
+            cudaFreeAsync(device_copy, stream);
+            return set_error(err);
+        }
+        sampled_device_buffers.push_back(DeviceSampleBuffer{device, device_copy, stream, copy_ready, {}});
+        *out_ptr = device_copy;
+        return 0;
+    };
+
+    for (int limb = 0; limb <= level; ++limb)
+    {
+        const dim3 limb_id = tp2->ctx->limb_gpu_ids[static_cast<size_t>(limb)];
+        int out_device = -1;
+        status = matrix_limb_device(out, limb_id, &out_device);
+        if (status != 0)
+        {
+            cleanup();
+            return status;
+        }
+        cudaStream_t out_stream = nullptr;
+        status = matrix_limb_stream(out, limb_id, &out_stream);
+        if (status != 0)
+        {
+            cleanup();
+            return status;
+        }
+        uint8_t *out_base = matrix_limb_ptr_by_id(out, 0, limb_id);
+        if (!out_base)
+        {
+            cleanup();
+            return set_error("null output limb base pointer in gpu_matrix_sample_p1_full_cached");
+        }
+        size_t out_stride = 0;
+        uint8_t out_coeff_bytes = 0;
+        if (!matrix_limb_metadata_by_id(out, limb_id, &out_stride, &out_coeff_bytes))
+        {
+            cleanup();
+            return set_error("invalid output limb metadata in gpu_matrix_sample_p1_full_cached");
+        }
+
+        int64_t *sampled_for_device = nullptr;
+        status = ensure_sample_buffer_on_device(out_device, out_stream, &sampled_for_device);
+        if (status != 0)
+        {
+            cleanup();
+            return status;
+        }
+
+        status = launch_scatter_p1_integer_to_limb_kernel_device(
+            sampled_for_device,
+            out_base,
+            out_stride,
+            out_coeff_bytes,
+            sampled_entry_count,
+            cache->n,
+            tp2->ctx->moduli[static_cast<size_t>(limb)],
+            out_stream,
+            out_device);
+        if (status != 0)
+        {
+            cleanup();
+            return status;
+        }
+        status = matrix_record_limb_write(out, limb_id, out_stream);
+        if (status != 0)
+        {
+            cleanup();
+            return status;
+        }
+        status = link_sample_buffer_consumer_done(sampled_for_device, out_device, out_stream);
+        if (status != 0)
+        {
+            cleanup();
+            return status;
+        }
+    }
+
+    status = gpu_matrix_ntt_all(out);
+    if (status != 0)
+    {
+        cleanup();
+        return status;
+    }
+    out->format = GPU_POLY_FORMAT_EVAL;
     cleanup();
     return 0;
 }

--- a/cuda/src/matrix/MatrixTrapdoor.cu
+++ b/cuda/src/matrix/MatrixTrapdoor.cu
@@ -1,5 +1,7 @@
 constexpr size_t kSampleP1LocalMaxM = 8;
 
+using gpu_chacha::GpuRngSeed;
+
 namespace
 {
     struct ThreadLocalOwnerLinkEventState
@@ -207,7 +209,7 @@ __global__ void matrix_sample_p1_integer_cached_kernel_small(
     int64_t *sampled_out,
     uint64_t modulus,
     double c_scale,
-    uint64_t seed)
+    GpuRngSeed seed)
 {
     const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     const size_t total_samples = cols * n;
@@ -290,7 +292,7 @@ __global__ void matrix_sample_p1_integer_cached_kernel_large(
     int64_t *sampled_out,
     uint64_t modulus,
     double c_scale,
-    uint64_t seed)
+    GpuRngSeed seed)
 {
     const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (idx >= sample_count)
@@ -378,7 +380,7 @@ __global__ void matrix_sample_p1_integer_kernel_small(
     double sigma,
     double s,
     double dgg_stddev,
-    uint64_t seed)
+    GpuRngSeed seed)
 {
     const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     const size_t total_samples = cols * n;
@@ -536,7 +538,7 @@ __global__ void matrix_sample_p1_integer_kernel_large(
     double sigma,
     double s,
     double dgg_stddev,
-    uint64_t seed)
+    GpuRngSeed seed)
 {
     const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (idx >= sample_count)
@@ -708,7 +710,7 @@ __global__ void matrix_gauss_samp_gq_arb_base_sample_kernel(
     uint32_t digits_per_tower,
     double c,
     uint32_t tower_idx,
-    uint64_t seed)
+    GpuRngSeed seed)
 {
     size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     size_t total = poly_count * n;
@@ -907,7 +909,7 @@ int launch_gauss_samp_gq_arb_base_sample_kernel(
     uint32_t digits_per_tower,
     double c,
     uint32_t tower_idx,
-    uint64_t seed,
+    GpuRngSeed seed,
     int device,
     cudaStream_t stream)
 {
@@ -1049,7 +1051,7 @@ int launch_sample_p1_integer_kernel(
     double sigma,
     double s,
     double dgg_stddev,
-    uint64_t seed,
+    GpuRngSeed seed,
     cudaStream_t stream,
     int device_id,
     int64_t **sampled_out_device,
@@ -1407,7 +1409,7 @@ int launch_sample_p1_integer_cached_kernel(
     const GpuP1CovarianceCache *cache,
     size_t cols,
     int64_t **sampled_out_device,
-    uint64_t seed,
+    GpuRngSeed seed,
     cudaStream_t stream,
     int device_id,
     cudaEvent_t sampled_ready_event)
@@ -1672,7 +1674,7 @@ extern "C" int gpu_matrix_gauss_samp_gq_arb_base(
     uint32_t base_bits,
     double c,
     double dgg_stddev,
-    uint64_t seed,
+    GpuRngSeed seed,
     GpuMatrix *out)
 {
     (void)dgg_stddev;
@@ -2474,7 +2476,7 @@ extern "C" void gpu_matrix_destroy_p1_covariance_cache(GpuP1CovarianceCache *cac
 extern "C" int gpu_matrix_sample_p1_full_cached(
     const GpuP1CovarianceCache *cache,
     const GpuMatrix *tp2,
-    uint64_t seed,
+    GpuRngSeed seed,
     GpuMatrix *out)
 {
     if (!cache || !tp2 || !out)
@@ -2923,7 +2925,7 @@ extern "C" int gpu_matrix_sample_p1_full(
     double sigma,
     double s,
     double dgg_stddev,
-    uint64_t seed,
+    GpuRngSeed seed,
     GpuMatrix *out)
 {
     if (!a_mat || !b_mat || !d_mat || !tp2 || !out)

--- a/src/matrix/gpu_dcrt_poly.rs
+++ b/src/matrix/gpu_dcrt_poly.rs
@@ -9,10 +9,10 @@ use crate::{
                 GPU_MATRIX_DIST_BIT, GPU_MATRIX_DIST_GAUSS, GPU_MATRIX_DIST_TERNARY,
                 GPU_MATRIX_DIST_UNIFORM, GPU_POLY_FORMAT_COEFF, GPU_POLY_FORMAT_EVAL, GpuDCRTPoly,
                 GpuDCRTPolyParams, GpuEventSetOpaque, GpuMatrixOpaque, GpuP1CovarianceCacheOpaque,
-                check_status, gpu_event_set_destroy, gpu_event_set_wait, gpu_matrix_add,
-                gpu_matrix_add_block, gpu_matrix_copy, gpu_matrix_copy_block, gpu_matrix_create,
-                gpu_matrix_create_p1_covariance_cache, gpu_matrix_decompose_base,
-                gpu_matrix_decompose_base_small, gpu_matrix_destroy,
+                GpuRngSeed, check_status, gpu_event_set_destroy, gpu_event_set_wait,
+                gpu_matrix_add, gpu_matrix_add_block, gpu_matrix_copy, gpu_matrix_copy_block,
+                gpu_matrix_create, gpu_matrix_create_p1_covariance_cache,
+                gpu_matrix_decompose_base, gpu_matrix_decompose_base_small, gpu_matrix_destroy,
                 gpu_matrix_destroy_p1_covariance_cache, gpu_matrix_equal, gpu_matrix_fill_gadget,
                 gpu_matrix_fill_small_decomposed_identity_chunk, gpu_matrix_fill_small_gadget,
                 gpu_matrix_gauss_samp_gq_arb_base, gpu_matrix_intt_all,
@@ -396,7 +396,7 @@ impl GpuDCRTPolyMatrix {
         ncol: usize,
         dist: GpuMatrixSampleDist,
         sigma: f64,
-        seed: u64,
+        seed: GpuRngSeed,
     ) -> Self {
         let out = Self::new_empty(params, nrow, ncol);
         if nrow == 0 || ncol == 0 {
@@ -415,7 +415,7 @@ impl GpuDCRTPolyMatrix {
         col_len: usize,
         dist: GpuMatrixSampleDist,
         sigma: f64,
-        seed: u64,
+        seed: GpuRngSeed,
     ) -> Self {
         let col_end = col_start
             .checked_add(col_len)
@@ -445,7 +445,7 @@ impl GpuDCRTPolyMatrix {
         out
     }
 
-    pub fn gauss_samp_gq_arb_base(mut self, c: f64, dgg_stddev: f64, seed: u64) -> Self {
+    pub fn gauss_samp_gq_arb_base(mut self, c: f64, dgg_stddev: f64, seed: GpuRngSeed) -> Self {
         let log_base_q = self.params.modulus_digits();
         let out_nrow = self.nrow.saturating_mul(log_base_q);
         let out = Self::new_empty(&self.params, out_nrow, self.ncol);
@@ -500,7 +500,7 @@ impl GpuDCRTPolyMatrix {
     pub(crate) fn sample_p1_full_cached(
         cache: &GpuP1CovarianceCache,
         mut tp2: Self,
-        seed: u64,
+        seed: GpuRngSeed,
     ) -> Self {
         let out = Self::new_empty(&tp2.params, tp2.nrow, tp2.ncol);
         if tp2.nrow == 0 || tp2.ncol == 0 {
@@ -1775,6 +1775,12 @@ mod tests {
         GpuDCRTPolyParams::new(params.ring_dimension(), moduli, params.base_bits())
     }
 
+    fn gpu_test_seed(base: u64, offset: u64) -> GpuRngSeed {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&base.wrapping_add(offset).to_le_bytes());
+        GpuRngSeed::from_bytes(bytes)
+    }
+
     #[test]
     #[sequential]
     fn test_gpu_matrix_compact_cross_device_roundtrip_invariant() {
@@ -2214,8 +2220,11 @@ mod tests {
         let c = (base as f64 + 1.0) * 4.578;
         let gadget = GpuDCRTPolyMatrix::gadget_matrix(&gpu_params, matrix.row_size());
         for offset in 0..16u64 {
-            let sampled =
-                matrix.clone().gauss_samp_gq_arb_base(c, 4.578, 0x1234_5678_9abc_def0u64 + offset);
+            let sampled = matrix.clone().gauss_samp_gq_arb_base(
+                c,
+                4.578,
+                gpu_test_seed(0x1234_5678_9abc_def0u64, offset),
+            );
             let reconstructed = &gadget * &sampled;
             assert_eq!(reconstructed, matrix);
         }
@@ -2231,8 +2240,11 @@ mod tests {
         let varied_matrix = GpuDCRTPolyMatrix::from_poly_vec(&gpu_params, vec![vec![varied_poly]]);
         let varied_gadget = GpuDCRTPolyMatrix::gadget_matrix(&gpu_params, 1);
         for offset in 0..16u64 {
-            let sampled =
-                varied_matrix.clone().gauss_samp_gq_arb_base(c, 4.578, 0x00de_adbe_efu64 + offset);
+            let sampled = varied_matrix.clone().gauss_samp_gq_arb_base(
+                c,
+                4.578,
+                gpu_test_seed(0x00de_adbe_efu64, offset),
+            );
             let reconstructed = &varied_gadget * &sampled;
             assert_eq!(reconstructed, varied_matrix);
         }
@@ -2259,7 +2271,7 @@ mod tests {
             let sampled = wide_matrix.clone().gauss_samp_gq_arb_base(
                 c,
                 4.578,
-                0x55aa_aa55_1357_2468u64 + offset,
+                gpu_test_seed(0x55aa_aa55_1357_2468u64, offset),
             );
             let reconstructed = &wide_gadget * &sampled;
             assert_eq!(reconstructed, wide_matrix);
@@ -2284,7 +2296,7 @@ mod tests {
             let sampled = random_matrix.clone().gauss_samp_gq_arb_base(
                 c,
                 4.578,
-                0x0f0f_f0f0_2468_1357u64 + offset,
+                gpu_test_seed(0x0f0f_f0f0_2468_1357u64, offset),
             );
             let reconstructed = &random_gadget * &sampled;
             if reconstructed != random_matrix {

--- a/src/matrix/gpu_dcrt_poly.rs
+++ b/src/matrix/gpu_dcrt_poly.rs
@@ -8,16 +8,17 @@ use crate::{
             gpu::{
                 GPU_MATRIX_DIST_BIT, GPU_MATRIX_DIST_GAUSS, GPU_MATRIX_DIST_TERNARY,
                 GPU_MATRIX_DIST_UNIFORM, GPU_POLY_FORMAT_COEFF, GPU_POLY_FORMAT_EVAL, GpuDCRTPoly,
-                GpuDCRTPolyParams, GpuEventSetOpaque, GpuMatrixOpaque, check_status,
-                gpu_event_set_destroy, gpu_event_set_wait, gpu_matrix_add, gpu_matrix_add_block,
-                gpu_matrix_copy, gpu_matrix_copy_block, gpu_matrix_create,
-                gpu_matrix_decompose_base, gpu_matrix_decompose_base_small, gpu_matrix_destroy,
-                gpu_matrix_equal, gpu_matrix_fill_gadget,
+                GpuDCRTPolyParams, GpuEventSetOpaque, GpuMatrixOpaque, GpuP1CovarianceCacheOpaque,
+                check_status, gpu_event_set_destroy, gpu_event_set_wait, gpu_matrix_add,
+                gpu_matrix_add_block, gpu_matrix_copy, gpu_matrix_copy_block, gpu_matrix_create,
+                gpu_matrix_create_p1_covariance_cache, gpu_matrix_decompose_base,
+                gpu_matrix_decompose_base_small, gpu_matrix_destroy,
+                gpu_matrix_destroy_p1_covariance_cache, gpu_matrix_equal, gpu_matrix_fill_gadget,
                 gpu_matrix_fill_small_decomposed_identity_chunk, gpu_matrix_fill_small_gadget,
                 gpu_matrix_gauss_samp_gq_arb_base, gpu_matrix_intt_all,
                 gpu_matrix_load_compact_bytes, gpu_matrix_load_rns_batch, gpu_matrix_mul,
                 gpu_matrix_mul_scalar, gpu_matrix_ntt_all, gpu_matrix_sample_distribution,
-                gpu_matrix_sample_distribution_columns, gpu_matrix_sample_p1_full,
+                gpu_matrix_sample_distribution_columns, gpu_matrix_sample_p1_full_cached,
                 gpu_matrix_store_compact_bytes, gpu_matrix_store_const_coeff_batch,
                 gpu_matrix_store_rns_batch, gpu_matrix_sub,
             },
@@ -49,6 +50,23 @@ pub struct GpuDCRTPolyMatrix {
     level: usize,
     is_ntt: bool,
     raw: *mut GpuMatrixOpaque,
+}
+
+#[derive(Debug)]
+pub(crate) struct GpuP1CovarianceCache {
+    raw: *mut GpuP1CovarianceCacheOpaque,
+}
+
+unsafe impl Send for GpuP1CovarianceCache {}
+unsafe impl Sync for GpuP1CovarianceCache {}
+
+impl Drop for GpuP1CovarianceCache {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            unsafe { gpu_matrix_destroy_p1_covariance_cache(self.raw) };
+            self.raw = ptr::null_mut();
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -448,38 +466,49 @@ impl GpuDCRTPolyMatrix {
         out
     }
 
-    pub(crate) fn sample_p1_full(
+    pub(crate) fn create_p1_covariance_cache(
         a_mat: &Self,
         b_mat: &Self,
         d_mat: &Self,
-        mut tp2: Self,
         sigma: f64,
         s: f64,
         dgg_stddev: f64,
-        seed: u64,
-    ) -> Self {
+    ) -> GpuP1CovarianceCache {
         debug_assert_eq!(a_mat.params, b_mat.params, "A/B params mismatch");
         debug_assert_eq!(a_mat.params, d_mat.params, "A/D params mismatch");
-        debug_assert_eq!(a_mat.params, tp2.params, "A/tp2 params mismatch");
         debug_assert_eq!(a_mat.nrow, a_mat.ncol, "A must be square");
         debug_assert_eq!(b_mat.nrow, a_mat.nrow, "B row size mismatch");
         debug_assert_eq!(b_mat.ncol, a_mat.ncol, "B col size mismatch");
         debug_assert_eq!(d_mat.nrow, a_mat.nrow, "D row size mismatch");
         debug_assert_eq!(d_mat.ncol, a_mat.ncol, "D col size mismatch");
-        debug_assert_eq!(tp2.nrow, 2 * a_mat.nrow, "tp2 must have 2d rows");
+        let mut raw: *mut GpuP1CovarianceCacheOpaque = ptr::null_mut();
+        let status = unsafe {
+            gpu_matrix_create_p1_covariance_cache(
+                a_mat.raw,
+                b_mat.raw,
+                d_mat.raw,
+                sigma,
+                s,
+                dgg_stddev,
+                &mut raw as *mut *mut GpuP1CovarianceCacheOpaque,
+            )
+        };
+        check_status(status, "gpu_matrix_create_p1_covariance_cache");
+        GpuP1CovarianceCache { raw }
+    }
+
+    pub(crate) fn sample_p1_full_cached(
+        cache: &GpuP1CovarianceCache,
+        mut tp2: Self,
+        seed: u64,
+    ) -> Self {
         let out = Self::new_empty(&tp2.params, tp2.nrow, tp2.ncol);
         if tp2.nrow == 0 || tp2.ncol == 0 {
             return out;
         }
-        // tp2 is consumed by this API, so convert in-place and avoid C++-side
-        // tmp_tp2 create/copy/INTT path.
         tp2.intt_all_in_place();
-        let status = unsafe {
-            gpu_matrix_sample_p1_full(
-                a_mat.raw, b_mat.raw, d_mat.raw, tp2.raw, sigma, s, dgg_stddev, seed, out.raw,
-            )
-        };
-        check_status(status, "gpu_matrix_sample_p1_full");
+        let status = unsafe { gpu_matrix_sample_p1_full_cached(cache.raw, tp2.raw, seed, out.raw) };
+        check_status(status, "gpu_matrix_sample_p1_full_cached");
         out
     }
 

--- a/src/poly/dcrt/gpu.rs
+++ b/src/poly/dcrt/gpu.rs
@@ -38,6 +38,12 @@ pub(crate) struct GpuMatrixOpaque {
 
 #[allow(non_camel_case_types)]
 #[repr(C)]
+pub(crate) struct GpuP1CovarianceCacheOpaque {
+    _private: [u8; 0],
+}
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
 pub(crate) struct GpuEventSetOpaque {
     _private: [u8; 0],
 }
@@ -173,14 +179,19 @@ unsafe extern "C" {
         seed: u64,
         out: *mut GpuMatrixOpaque,
     ) -> c_int;
-    pub(crate) fn gpu_matrix_sample_p1_full(
+    pub(crate) fn gpu_matrix_create_p1_covariance_cache(
         a_mat: *const GpuMatrixOpaque,
         b_mat: *const GpuMatrixOpaque,
         d_mat: *const GpuMatrixOpaque,
-        tp2: *const GpuMatrixOpaque,
         sigma: f64,
         s: f64,
         dgg_stddev: f64,
+        out_cache: *mut *mut GpuP1CovarianceCacheOpaque,
+    ) -> c_int;
+    pub(crate) fn gpu_matrix_destroy_p1_covariance_cache(cache: *mut GpuP1CovarianceCacheOpaque);
+    pub(crate) fn gpu_matrix_sample_p1_full_cached(
+        cache: *const GpuP1CovarianceCacheOpaque,
+        tp2: *const GpuMatrixOpaque,
         seed: u64,
         out: *mut GpuMatrixOpaque,
     ) -> c_int;

--- a/src/poly/dcrt/gpu.rs
+++ b/src/poly/dcrt/gpu.rs
@@ -42,6 +42,24 @@ pub(crate) struct GpuP1CovarianceCacheOpaque {
     _private: [u8; 0],
 }
 
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct GpuRngSeed {
+    words: [u64; 4],
+}
+
+impl GpuRngSeed {
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        let mut words = [0u64; 4];
+        for (word, chunk) in words.iter_mut().zip(bytes.chunks_exact(8)) {
+            let mut word_bytes = [0u8; 8];
+            word_bytes.copy_from_slice(chunk);
+            *word = u64::from_le_bytes(word_bytes);
+        }
+        Self { words }
+    }
+}
+
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct GpuEventSetOpaque {
@@ -176,7 +194,7 @@ unsafe extern "C" {
         base_bits: u32,
         c: f64,
         dgg_stddev: f64,
-        seed: u64,
+        seed: GpuRngSeed,
         out: *mut GpuMatrixOpaque,
     ) -> c_int;
     pub(crate) fn gpu_matrix_create_p1_covariance_cache(
@@ -192,20 +210,20 @@ unsafe extern "C" {
     pub(crate) fn gpu_matrix_sample_p1_full_cached(
         cache: *const GpuP1CovarianceCacheOpaque,
         tp2: *const GpuMatrixOpaque,
-        seed: u64,
+        seed: GpuRngSeed,
         out: *mut GpuMatrixOpaque,
     ) -> c_int;
     pub(crate) fn gpu_matrix_sample_distribution(
         out: *mut GpuMatrixOpaque,
         dist_type: c_int,
         sigma: f64,
-        seed: u64,
+        seed: GpuRngSeed,
     ) -> c_int;
     pub(crate) fn gpu_matrix_sample_distribution_columns(
         out: *mut GpuMatrixOpaque,
         dist_type: c_int,
         sigma: f64,
-        seed: u64,
+        seed: GpuRngSeed,
         full_ncol: usize,
         col_offset: usize,
     ) -> c_int;

--- a/src/sampler/gpu.rs
+++ b/src/sampler/gpu.rs
@@ -3,7 +3,10 @@ use crate::{
         PolyMatrix,
         gpu_dcrt_poly::{GpuDCRTPolyMatrix, GpuMatrixSampleDist},
     },
-    poly::{Poly, dcrt::gpu::GpuDCRTPolyParams},
+    poly::{
+        Poly,
+        dcrt::gpu::{GpuDCRTPolyParams, GpuRngSeed},
+    },
     sampler::{DistType, PolyHashSampler, PolyUniformSampler},
 };
 use digest::OutputSizeUser;
@@ -112,22 +115,30 @@ where
     }
 }
 
-fn hash_seed_for_matrix<H: digest::Digest>(key: [u8; 32], tag: &[u8]) -> u64 {
-    let mut hasher = H::new();
-    hasher.update(b"GpuDCRTPolyHashSampler/v1");
-    hasher.update(key);
-    hasher.update(tag);
-    let digest = hasher.finalize();
-    let mut seed_bytes = [0u8; 8];
-    let take = digest.len().min(seed_bytes.len());
-    seed_bytes[..take].copy_from_slice(&digest[..take]);
-    if take == 0 {
-        return 0;
+fn hash_seed_for_matrix<H: digest::Digest>(key: [u8; 32], tag: &[u8]) -> GpuRngSeed {
+    let mut seed_bytes = [0u8; 32];
+    let mut written = 0usize;
+    let mut counter = 0u32;
+    while written < seed_bytes.len() {
+        let mut hasher = H::new();
+        hasher.update(b"GpuDCRTPolyHashSampler/v2");
+        hasher.update(key);
+        hasher.update(tag);
+        hasher.update(counter.to_le_bytes());
+        let digest = hasher.finalize();
+        assert!(!digest.is_empty(), "digest output must not be empty");
+        let take = (seed_bytes.len() - written).min(digest.len());
+        seed_bytes[written..written + take].copy_from_slice(&digest[..take]);
+        written += take;
+        counter = counter.wrapping_add(1);
     }
-    for i in take..seed_bytes.len() {
-        seed_bytes[i] = digest[i % take];
-    }
-    u64::from_le_bytes(seed_bytes)
+    GpuRngSeed::from_bytes(seed_bytes)
+}
+
+pub(crate) fn random_gpu_rng_seed() -> GpuRngSeed {
+    let mut seed_bytes = [0u8; 32];
+    rng().fill(&mut seed_bytes);
+    GpuRngSeed::from_bytes(seed_bytes)
 }
 
 fn sample_gpu_matrix_native(
@@ -136,9 +147,7 @@ fn sample_gpu_matrix_native(
     ncol: usize,
     dist: DistType,
 ) -> GpuDCRTPolyMatrix {
-    let mut prng = rng();
-    let seed: u64 = prng.random();
-    sample_gpu_matrix_with_seed(params, nrow, ncol, dist, seed)
+    sample_gpu_matrix_with_seed(params, nrow, ncol, dist, random_gpu_rng_seed())
 }
 
 fn sample_gpu_matrix_with_seed(
@@ -146,7 +155,7 @@ fn sample_gpu_matrix_with_seed(
     nrow: usize,
     ncol: usize,
     dist: DistType,
-    seed: u64,
+    seed: GpuRngSeed,
 ) -> GpuDCRTPolyMatrix {
     if nrow == 0 || ncol == 0 {
         return GpuDCRTPolyMatrix::zero(params, nrow, ncol);
@@ -194,7 +203,7 @@ fn sample_gpu_matrix_with_seed_columns(
     col_start: usize,
     col_len: usize,
     dist: DistType,
-    seed: u64,
+    seed: GpuRngSeed,
 ) -> GpuDCRTPolyMatrix {
     if nrow == 0 || col_len == 0 {
         return GpuDCRTPolyMatrix::zero(params, nrow, col_len);
@@ -363,7 +372,7 @@ mod tests {
             4,
             5,
             DistType::GaussDist { sigma },
-            0x1234_5678_9abc_def0,
+            GpuRngSeed::from_bytes([0x5au8; 32]),
         );
 
         let bound = sigma * 6.0;

--- a/src/sampler/trapdoor/gpu.rs
+++ b/src/sampler/trapdoor/gpu.rs
@@ -1,9 +1,11 @@
 use crate::{
     matrix::{PolyMatrix, gpu_dcrt_poly::GpuDCRTPolyMatrix},
     poly::{Poly, PolyParams, dcrt::gpu::GpuDCRTPolyParams},
-    sampler::{DistType, PolyTrapdoorSampler, PolyUniformSampler, gpu::GpuDCRTPolyUniformSampler},
+    sampler::{
+        DistType, PolyTrapdoorSampler, PolyUniformSampler,
+        gpu::{GpuDCRTPolyUniformSampler, random_gpu_rng_seed},
+    },
 };
-use rand::{Rng, rng};
 use rayon::prelude::*;
 use std::{
     sync::{Arc, Mutex},
@@ -291,10 +293,9 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
             "gpu preimage: computed perturbed_syndrome"
         );
 
-        let mut rng = rng();
-        let z_seed: u64 = rng.random();
         let gauss_start = Instant::now();
-        let z_hat_mat = perturbed_syndrome.gauss_samp_gq_arb_base(self.c, self.sigma, z_seed);
+        let z_hat_mat =
+            perturbed_syndrome.gauss_samp_gq_arb_base(self.c, self.sigma, random_gpu_rng_seed());
         tracing::debug!(
             elapsed_ms = gauss_start.elapsed().as_secs_f64() * 1_000.0,
             "gpu preimage: sampled z_hat_mat with gauss_samp_gq_arb_base"
@@ -457,15 +458,17 @@ fn sample_pert_square_mat_gpu_native_parts(
 
     // Keep perturbation generation on device: this sampler uses the full
     // 2d x 2d covariance induced by (A, B, D) and Tp2.
-    let mut prng = rng();
-    let p1_seed: u64 = prng.random();
     debug_assert_eq!(
         (c, s, dgg_stddev),
         p1_covariance_parameters(params, d, dgg_stddev),
         "cached p1 covariance parameters must match the current preimage parameters",
     );
     let p1_covariance_cache = get_or_create_p1_covariance_cache(trapdoor, c, s, dgg_stddev);
-    let p1 = GpuDCRTPolyMatrix::sample_p1_full_cached(p1_covariance_cache.as_ref(), tp2, p1_seed);
+    let p1 = GpuDCRTPolyMatrix::sample_p1_full_cached(
+        p1_covariance_cache.as_ref(),
+        tp2,
+        random_gpu_rng_seed(),
+    );
     tracing::debug!("gpu preimage sample_pert: sampled p1");
 
     GpuPerturbationSamples { p1, p2 }

--- a/src/sampler/trapdoor/gpu.rs
+++ b/src/sampler/trapdoor/gpu.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 use rand::{Rng, rng};
 use rayon::prelude::*;
-use std::time::Instant;
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
 
 const SIGMA: f64 = 4.578;
 const SPECTRAL_CONSTANT: f64 = 1.8;
@@ -19,14 +22,35 @@ struct GpuPerturbationSamples {
     p2: GpuDCRTPolyMatrix,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
+struct GpuP1CovarianceCacheEntry {
+    c: f64,
+    s: f64,
+    dgg_stddev: f64,
+    cache: Arc<crate::matrix::gpu_dcrt_poly::GpuP1CovarianceCache>,
+}
+
+#[derive(Debug, Clone)]
 pub struct GpuDCRTTrapdoor {
     pub r: GpuDCRTPolyMatrix,
     pub e: GpuDCRTPolyMatrix,
     a_mat_coeff: GpuDCRTPolyMatrix,
     b_mat_coeff: GpuDCRTPolyMatrix,
     d_mat_coeff: GpuDCRTPolyMatrix,
+    p1_covariance_cache: Arc<Mutex<Option<GpuP1CovarianceCacheEntry>>>,
 }
+
+impl PartialEq for GpuDCRTTrapdoor {
+    fn eq(&self, other: &Self) -> bool {
+        self.r == other.r &&
+            self.e == other.e &&
+            self.a_mat_coeff == other.a_mat_coeff &&
+            self.b_mat_coeff == other.b_mat_coeff &&
+            self.d_mat_coeff == other.d_mat_coeff
+    }
+}
+
+impl Eq for GpuDCRTTrapdoor {}
 
 impl GpuDCRTTrapdoor {
     pub fn new(params: &GpuDCRTPolyParams, size: usize, sigma: f64) -> Self {
@@ -38,7 +62,8 @@ impl GpuDCRTTrapdoor {
         let a_mat_coeff = coeff_cached_matrix(&(&r * &r.transpose()));
         let b_mat_coeff = coeff_cached_matrix(&(&r * &e.transpose()));
         let d_mat_coeff = coeff_cached_matrix(&(&e * &e.transpose()));
-        Self { r, e, a_mat_coeff, b_mat_coeff, d_mat_coeff }
+        let p1_covariance_cache = Arc::new(Mutex::new(None));
+        Self { r, e, a_mat_coeff, b_mat_coeff, d_mat_coeff, p1_covariance_cache }
     }
 
     pub fn to_compact_bytes(&self) -> Vec<u8> {
@@ -86,8 +111,53 @@ impl GpuDCRTTrapdoor {
         let a_mat_coeff = coeff_cached_matrix(&(&r * &r.transpose()));
         let b_mat_coeff = coeff_cached_matrix(&(&r * &e.transpose()));
         let d_mat_coeff = coeff_cached_matrix(&(&e * &e.transpose()));
-        Some(Self { r, e, a_mat_coeff, b_mat_coeff, d_mat_coeff })
+        let p1_covariance_cache = Arc::new(Mutex::new(None));
+        Some(Self { r, e, a_mat_coeff, b_mat_coeff, d_mat_coeff, p1_covariance_cache })
     }
+}
+
+fn p1_covariance_parameters(
+    params: &GpuDCRTPolyParams,
+    d: usize,
+    dgg_stddev: f64,
+) -> (f64, f64, f64) {
+    let base = 1 << params.base_bits();
+    let n = params.ring_dimension() as usize;
+    let k = params.modulus_digits();
+    let c = (base as f64 + 1.0) * SIGMA;
+    let s = SPECTRAL_CONSTANT *
+        (base as f64 + 1.0) *
+        SIGMA *
+        SIGMA *
+        (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
+    (c, s, dgg_stddev)
+}
+
+fn get_or_create_p1_covariance_cache(
+    trapdoor: &GpuDCRTTrapdoor,
+    c: f64,
+    s: f64,
+    dgg_stddev: f64,
+) -> Arc<crate::matrix::gpu_dcrt_poly::GpuP1CovarianceCache> {
+    let mut guard = trapdoor.p1_covariance_cache.lock().expect("p1 cache mutex poisoned");
+    if let Some(entry) = guard.as_ref() &&
+        entry.c == c &&
+        entry.s == s &&
+        entry.dgg_stddev == dgg_stddev
+    {
+        return entry.cache.clone();
+    }
+
+    let cache = Arc::new(GpuDCRTPolyMatrix::create_p1_covariance_cache(
+        &trapdoor.a_mat_coeff,
+        &trapdoor.b_mat_coeff,
+        &trapdoor.d_mat_coeff,
+        c,
+        s,
+        dgg_stddev,
+    ));
+    *guard = Some(GpuP1CovarianceCacheEntry { c, s, dgg_stddev, cache: cache.clone() });
+    cache
 }
 
 #[derive(Debug, Clone)]
@@ -389,16 +459,13 @@ fn sample_pert_square_mat_gpu_native_parts(
     // 2d x 2d covariance induced by (A, B, D) and Tp2.
     let mut prng = rng();
     let p1_seed: u64 = prng.random();
-    let p1 = GpuDCRTPolyMatrix::sample_p1_full(
-        &trapdoor.a_mat_coeff,
-        &trapdoor.b_mat_coeff,
-        &trapdoor.d_mat_coeff,
-        tp2,
-        c,
-        s,
-        dgg_stddev,
-        p1_seed,
+    debug_assert_eq!(
+        (c, s, dgg_stddev),
+        p1_covariance_parameters(params, d, dgg_stddev),
+        "cached p1 covariance parameters must match the current preimage parameters",
     );
+    let p1_covariance_cache = get_or_create_p1_covariance_cache(trapdoor, c, s, dgg_stddev);
+    let p1 = GpuDCRTPolyMatrix::sample_p1_full_cached(p1_covariance_cache.as_ref(), tp2, p1_seed);
     tracing::debug!("gpu preimage sample_pert: sampled p1");
 
     GpuPerturbationSamples { p1, p2 }
@@ -538,6 +605,32 @@ mod tests {
         let preimage = trapdoor_sampler.preimage(&params, &trapdoor, &public_matrix, &target);
         let product = &public_matrix * &preimage;
         assert_eq!(product, target);
+    }
+
+    #[test]
+    #[sequential]
+    fn test_gpu_preimage_reuses_trapdoor_cache_for_distinct_targets() {
+        gpu_device_sync();
+        let size = 3usize;
+        let cpu_params = gpu_test_params();
+        let params = gpu_params_from_cpu(&cpu_params);
+        let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let (trapdoor, public_matrix) = trapdoor_sampler.trapdoor(&params, size);
+        let uniform_sampler = GpuDCRTPolyUniformSampler::new();
+
+        let first_target =
+            uniform_sampler.sample_uniform(&params, size, size, DistType::FinRingDist);
+        let second_target =
+            uniform_sampler.sample_uniform(&params, size, size, DistType::FinRingDist);
+        assert_ne!(first_target, second_target, "targets should differ");
+
+        let first_preimage =
+            trapdoor_sampler.preimage(&params, &trapdoor, &public_matrix, &first_target);
+        let second_preimage =
+            trapdoor_sampler.preimage(&params, &trapdoor, &public_matrix, &second_target);
+
+        assert_eq!(&public_matrix * &first_preimage, first_target);
+        assert_eq!(&public_matrix * &second_preimage, second_target);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace CUDA sampler seeding with a 256-bit `GpuRngSeed` passed from the host instead of expanding a `u64` with SplitMix64.
- Initialize ChaCha directly from the full key and use domain/stream separation for sampler usage.
- Update Rust GPU sampler and trapdoor call sites so random and hash-derived seeds flow through the new 256-bit path.

## Testing
- Formatting passed with `cargo +nightly fmt --all`.
- GPU build passed with `cargo build --features gpu`.
- Focused GPU tests passed for the matrix sampler, hash sampler, and repeated trapdoor preimage path.
- Repeated runs of the focused GPU tests completed successfully to check for nondeterministic failures.