### PR TITLE
Make preimage sigma configurable across simulation and samplers

### DIFF
--- a/src/input_injector/mod.rs
+++ b/src/input_injector/mod.rs
@@ -1152,6 +1152,7 @@ mod tests {
             ctx.m_g as u64,
             &ctx.base,
             Some(injector.state_row_size() / DIAMOND_SECRET_SIZE),
+            None,
         );
         let expected_transition = PolyMatrixNorm::new(
             ctx.clone(),

--- a/src/input_injector/simulation.rs
+++ b/src/input_injector/simulation.rs
@@ -63,6 +63,7 @@ where
             ctx.m_g as u64,
             &ctx.base,
             Some(self.state_row_size() / DIAMOND_SECRET_SIZE),
+            None,
         );
         let transition_preimage =
             PolyMatrixNorm::new(ctx.clone(), state_cols, state_cols, preimage_norm.clone(), None);

--- a/src/sampler/trapdoor/gpu.rs
+++ b/src/sampler/trapdoor/gpu.rs
@@ -687,14 +687,15 @@ mod tests {
         assert!(larger_s > default_s);
     }
 
-    #[test]
-    #[sequential]
-    fn test_gpu_preimage_coefficients_below_compute_preimage_norm() {
+    fn assert_gpu_preimage_reconstructs_target_and_respects_norm_bound(
+        sigma: f64,
+        bound_sigma: Option<f64>,
+    ) {
         gpu_device_sync();
         let size = 2usize;
         let cpu_params = DCRTPolyParams::new(1 << 10, 5, 51, 17);
         let params = gpu_params_from_cpu(&cpu_params);
-        let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(&params, sigma);
         let (trapdoor, public_matrix) = trapdoor_sampler.trapdoor(&params, size);
         let uniform_sampler = GpuDCRTPolyUniformSampler::new();
 
@@ -704,7 +705,8 @@ mod tests {
             .expect("ring dimension sqrt should exist");
         let base = BigDecimal::from_biguint(BigUint::from(1u32) << params.base_bits(), 0);
         let m_g = (size * params.modulus_digits()) as u64;
-        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, None);
+        let preimage_norm_bound =
+            compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, bound_sigma);
         let modulus = params.modulus();
 
         for sample_idx in 0..4usize {
@@ -734,6 +736,19 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    #[sequential]
+    fn test_gpu_preimage_coefficients_below_compute_preimage_norm() {
+        assert_gpu_preimage_reconstructs_target_and_respects_norm_bound(SIGMA, None);
+    }
+
+    #[test]
+    #[sequential]
+    fn test_gpu_preimage_coefficients_below_compute_preimage_norm_non_default_sigma() {
+        let sigma = SIGMA * 1.25;
+        assert_gpu_preimage_reconstructs_target_and_respects_norm_bound(sigma, Some(sigma));
     }
 
     #[test]

--- a/src/sampler/trapdoor/gpu.rs
+++ b/src/sampler/trapdoor/gpu.rs
@@ -12,8 +12,19 @@ use std::{
     time::Instant,
 };
 
-const SIGMA: f64 = 4.578;
 const SPECTRAL_CONSTANT: f64 = 1.8;
+
+fn preimage_c(base: u32, sigma: f64) -> f64 {
+    (base as f64 + 1.0) * sigma
+}
+
+fn preimage_smoothing_parameter(base: u32, sigma: f64, d: usize, n: usize, k: usize) -> f64 {
+    SPECTRAL_CONSTANT *
+        (base as f64 + 1.0) *
+        sigma *
+        sigma *
+        (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7)
+}
 
 fn coeff_cached_matrix(src: &GpuDCRTPolyMatrix) -> GpuDCRTPolyMatrix {
     src.clone().into_coeff_domain()
@@ -126,12 +137,8 @@ fn p1_covariance_parameters(
     let base = 1 << params.base_bits();
     let n = params.ring_dimension() as usize;
     let k = params.modulus_digits();
-    let c = (base as f64 + 1.0) * SIGMA;
-    let s = SPECTRAL_CONSTANT *
-        (base as f64 + 1.0) *
-        SIGMA *
-        SIGMA *
-        (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
+    let c = preimage_c(base, dgg_stddev);
+    let s = preimage_smoothing_parameter(base, dgg_stddev, d, n, k);
     (c, s, dgg_stddev)
 }
 
@@ -188,7 +195,7 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
 
     fn new(params: &<<Self::M as PolyMatrix>::P as Poly>::Params, sigma: f64) -> Self {
         let base = 1 << params.base_bits();
-        let c = (base as f64 + 1.0) * SIGMA;
+        let c = preimage_c(base, sigma);
         Self { sigma, base, c }
     }
 
@@ -238,11 +245,7 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
         let param_start = Instant::now();
         let n = params.ring_dimension() as usize;
         let k = params.modulus_digits();
-        let s = SPECTRAL_CONSTANT *
-            (self.base as f64 + 1.0) *
-            SIGMA *
-            SIGMA *
-            (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
+        let s = preimage_smoothing_parameter(self.base, self.sigma, d, n, k);
         let dgg_large_std = (s * s - self.c * self.c).sqrt();
         tracing::debug!(
             elapsed_ms = param_start.elapsed().as_secs_f64() * 1_000.0,
@@ -406,11 +409,7 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
         let target_ncol = target.col_size();
         let n = params.ring_dimension() as usize;
         let k = params.modulus_digits();
-        let s = SPECTRAL_CONSTANT *
-            (self.base as f64 + 1.0) *
-            SIGMA *
-            SIGMA *
-            (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
+        let s = preimage_smoothing_parameter(self.base, self.sigma, d, n, k);
 
         let dist = DistType::GaussDist { sigma: s };
         let uniform_sampler = GpuDCRTPolyUniformSampler::new();
@@ -665,6 +664,31 @@ mod tests {
 
     #[test]
     #[sequential]
+    fn test_gpu_preimage_sampler_parameters_follow_instance_sigma() {
+        let cpu_params = DCRTPolyParams::new(1 << 10, 5, 51, 17);
+        let params = gpu_params_from_cpu(&cpu_params);
+        let base = 1u32 << params.base_bits();
+        let default_sampler = GpuDCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let larger_sigma = SIGMA * 1.5;
+        let larger_sampler = GpuDCRTPolyTrapdoorSampler::new(&params, larger_sigma);
+        let n = params.ring_dimension() as usize;
+        let k = params.modulus_digits();
+        let size = 2usize;
+        let default_s = preimage_smoothing_parameter(base, default_sampler.sigma, size, n, k);
+        let larger_s = preimage_smoothing_parameter(base, larger_sampler.sigma, size, n, k);
+
+        assert_eq!(default_sampler.c, preimage_c(base, SIGMA));
+        assert_eq!(larger_sampler.c, preimage_c(base, larger_sigma));
+        assert_eq!(
+            p1_covariance_parameters(&params, size, larger_sigma),
+            (larger_sampler.c, larger_s, larger_sigma)
+        );
+        assert!(larger_sampler.c > default_sampler.c);
+        assert!(larger_s > default_s);
+    }
+
+    #[test]
+    #[sequential]
     fn test_gpu_preimage_coefficients_below_compute_preimage_norm() {
         gpu_device_sync();
         let size = 2usize;
@@ -680,7 +704,7 @@ mod tests {
             .expect("ring dimension sqrt should exist");
         let base = BigDecimal::from_biguint(BigUint::from(1u32) << params.base_bits(), 0);
         let m_g = (size * params.modulus_digits()) as u64;
-        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None);
+        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, None);
         let modulus = params.modulus();
 
         for sample_idx in 0..4usize {
@@ -728,24 +752,21 @@ mod tests {
             .expect("ring dimension sqrt should exist");
         let base = BigDecimal::from_biguint(BigUint::from(1u32) << params.base_bits(), 0);
         let m_g = (size * params.modulus_digits()) as u64;
-        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None);
+        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, None);
         let modulus = params.modulus();
         let n = params.ring_dimension() as usize;
         let k = params.modulus_digits();
-        let s = SPECTRAL_CONSTANT *
-            ((1u32 << params.base_bits()) as f64 + 1.0) *
-            SIGMA *
-            SIGMA *
-            (((size * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
-        let dgg_large_std =
-            (s * s - (((1u32 << params.base_bits()) as f64 + 1.0) * SIGMA).powi(2)).sqrt();
+        let base_u32 = 1u32 << params.base_bits();
+        let c = preimage_c(base_u32, SIGMA);
+        let s = preimage_smoothing_parameter(base_u32, SIGMA, size, n, k);
+        let dgg_large_std = (s * s - c.powi(2)).sqrt();
 
         for sample_idx in 0..4usize {
             let p_hat = sample_pert_square_mat_gpu_native(
                 &params,
                 &trapdoor,
                 s,
-                ((1u32 << params.base_bits()) as f64 + 1.0) * SIGMA,
+                c,
                 SIGMA,
                 dgg_large_std,
                 size,
@@ -795,7 +816,7 @@ mod tests {
             .expect("ring dimension sqrt should exist");
         let base = BigDecimal::from_biguint(BigUint::from(1u32) << base_params.base_bits(), 0);
         let m_g = (size * base_params.modulus_digits()) as u64;
-        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None);
+        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, None);
         let modulus = base_params.modulus();
 
         struct DeviceCase {

--- a/src/sampler/trapdoor/sampler.rs
+++ b/src/sampler/trapdoor/sampler.rs
@@ -21,9 +21,20 @@ use std::{
 };
 use tracing::debug;
 
-const SIGMA: f64 = 4.578;
 const SPECTRAL_CONSTANT: f64 = 1.8;
 static GAUSS_SAMP_GQ_ARB_BASE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn preimage_c(base: u32, sigma: f64) -> f64 {
+    (base as f64 + 1.0) * sigma
+}
+
+fn preimage_smoothing_parameter(base: u32, sigma: f64, d: usize, n: usize, k: usize) -> f64 {
+    SPECTRAL_CONSTANT *
+        (base as f64 + 1.0) *
+        sigma *
+        sigma *
+        (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7)
+}
 
 #[derive(Debug, Clone)]
 pub struct DCRTPolyTrapdoorSampler {
@@ -38,7 +49,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
 
     fn new(params: &<<Self::M as PolyMatrix>::P as Poly>::Params, sigma: f64) -> Self {
         let base = 1 << params.base_bits();
-        let c = (base as f64 + 1.0) * SIGMA;
+        let c = preimage_c(base, sigma);
         Self { sigma, base, c }
     }
 
@@ -95,11 +106,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
 
         let n = params.ring_dimension() as usize;
         let k = params.modulus_digits();
-        let s = SPECTRAL_CONSTANT *
-            (self.base as f64 + 1.0) *
-            SIGMA *
-            SIGMA *
-            (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
+        let s = preimage_smoothing_parameter(self.base, self.sigma, d, n, k);
         let dgg_large_std = (s * s - self.c * self.c).sqrt();
         let peikert = dgg_large_std < KARNEY_THRESHOLD;
         let (dgg_large_mean, dgg_large_table) = if dgg_large_std > KARNEY_THRESHOLD {
@@ -202,11 +209,7 @@ impl PolyTrapdoorSampler for DCRTPolyTrapdoorSampler {
         let target_ncol = target.col_size();
         let n = params.ring_dimension() as usize;
         let k = params.modulus_digits();
-        let s = SPECTRAL_CONSTANT *
-            (self.base as f64 + 1.0) *
-            SIGMA *
-            SIGMA *
-            (((d * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
+        let s = preimage_smoothing_parameter(self.base, self.sigma, d, n, k);
         let dist = DistType::GaussDist { sigma: s };
         let uniform_sampler = DCRTPolyUniformSampler::new();
         let preimage_right = uniform_sampler.sample_uniform(params, ext_ncol, target_ncol, dist);
@@ -602,6 +605,26 @@ mod test {
 
     #[test]
     #[sequential_test::sequential]
+    fn test_preimage_sampler_parameters_follow_instance_sigma() {
+        let params = DCRTPolyParams::new(1 << 10, 5, 51, 17);
+        let base = 1u32 << params.base_bits();
+        let default_sampler = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let larger_sigma = SIGMA * 1.5;
+        let larger_sampler = DCRTPolyTrapdoorSampler::new(&params, larger_sigma);
+        let n = params.ring_dimension() as usize;
+        let k = params.modulus_digits();
+        let size = 2usize;
+        let default_s = preimage_smoothing_parameter(base, default_sampler.sigma, size, n, k);
+        let larger_s = preimage_smoothing_parameter(base, larger_sampler.sigma, size, n, k);
+
+        assert_eq!(default_sampler.c, preimage_c(base, SIGMA));
+        assert_eq!(larger_sampler.c, preimage_c(base, larger_sigma));
+        assert!(larger_sampler.c > default_sampler.c);
+        assert!(larger_s > default_s);
+    }
+
+    #[test]
+    #[sequential_test::sequential]
     fn test_preimage_coefficients_below_compute_preimage_norm() {
         let size = 2usize;
         let params = DCRTPolyParams::new(1 << 10, 5, 51, 17);
@@ -615,7 +638,7 @@ mod test {
             .expect("ring dimension sqrt should exist");
         let base = BigDecimal::from_biguint(BigUint::from(1u32) << params.base_bits(), 0);
         let m_g = (size * params.modulus_digits()) as u64;
-        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None);
+        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, None);
         let modulus = params.modulus();
 
         for sample_idx in 0..4usize {
@@ -661,17 +684,13 @@ mod test {
             .expect("ring dimension sqrt should exist");
         let base = BigDecimal::from_biguint(BigUint::from(1u32) << params.base_bits(), 0);
         let m_g = (size * params.modulus_digits()) as u64;
-        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None);
+        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, None);
         let modulus = params.modulus();
         let n = params.ring_dimension() as usize;
         let k = params.modulus_digits();
         let base = 1u32 << params.base_bits();
-        let c = (base as f64 + 1.0) * SIGMA;
-        let s = SPECTRAL_CONSTANT *
-            (base as f64 + 1.0) *
-            SIGMA *
-            SIGMA *
-            (((size * n * k) as f64).sqrt() + ((2 * n) as f64).sqrt() + 4.7);
+        let c = preimage_c(base, SIGMA);
+        let s = preimage_smoothing_parameter(base, SIGMA, size, n, k);
         let dgg_large_std = (s * s - c * c).sqrt();
         let peikert = dgg_large_std < KARNEY_THRESHOLD;
         let (dgg_large_mean, dgg_large_table) = if dgg_large_std > KARNEY_THRESHOLD {

--- a/src/sampler/trapdoor/sampler.rs
+++ b/src/sampler/trapdoor/sampler.rs
@@ -623,12 +623,13 @@ mod test {
         assert!(larger_s > default_s);
     }
 
-    #[test]
-    #[sequential_test::sequential]
-    fn test_preimage_coefficients_below_compute_preimage_norm() {
+    fn assert_preimage_reconstructs_target_and_respects_norm_bound(
+        sigma: f64,
+        bound_sigma: Option<f64>,
+    ) {
         let size = 2usize;
         let params = DCRTPolyParams::new(1 << 10, 5, 51, 17);
-        let trapdoor_sampler = DCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let trapdoor_sampler = DCRTPolyTrapdoorSampler::new(&params, sigma);
         let (trapdoor, public_matrix) = trapdoor_sampler.trapdoor(&params, size);
         let uniform_sampler = DCRTPolyUniformSampler::new();
 
@@ -638,7 +639,8 @@ mod test {
             .expect("ring dimension sqrt should exist");
         let base = BigDecimal::from_biguint(BigUint::from(1u32) << params.base_bits(), 0);
         let m_g = (size * params.modulus_digits()) as u64;
-        let preimage_norm_bound = compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, None);
+        let preimage_norm_bound =
+            compute_preimage_norm(&ring_dim_sqrt, m_g, &base, None, bound_sigma);
         let modulus = params.modulus();
 
         for sample_idx in 0..4usize {
@@ -668,6 +670,19 @@ mod test {
                 }
             }
         }
+    }
+
+    #[test]
+    #[sequential_test::sequential]
+    fn test_preimage_coefficients_below_compute_preimage_norm() {
+        assert_preimage_reconstructs_target_and_respects_norm_bound(SIGMA, None);
+    }
+
+    #[test]
+    #[sequential_test::sequential]
+    fn test_preimage_coefficients_below_compute_preimage_norm_non_default_sigma() {
+        let sigma = SIGMA * 1.25;
+        assert_preimage_reconstructs_target_and_respects_norm_bound(sigma, Some(sigma));
     }
 
     #[test]

--- a/src/simulator/eval_error/evaluators.rs
+++ b/src/simulator/eval_error/evaluators.rs
@@ -21,7 +21,7 @@ impl NormBggPolyEncodingSTEvaluator {
         );
 
         let b0_preimage_norm =
-            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(1));
+            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(1), None);
         info!(
             "{}",
             format!(
@@ -73,7 +73,7 @@ impl NormBggPolyEncodingSTEvaluator {
             PolyMatrixNorm::new(ctx.clone(), ctx.m_b, 2 * ctx.m_b, b0_preimage_norm.clone(), None);
         log_matrix_norm_bits("slot_preimage_b0", &slot_preimage_b0);
         let b1_preimage_norm =
-            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(2));
+            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(2), None);
         // `preimage_b1` targets the `B1` basis, whose trapdoor size is `2 * secret_size`.
         let slot_preimage_b1 =
             PolyMatrixNorm::new(ctx.clone(), ctx.m_b * 2, ctx.m_g, b1_preimage_norm.clone(), None);
@@ -184,7 +184,7 @@ pub struct NormPltLWEEvaluator {
 impl NormPltLWEEvaluator {
     pub fn new(ctx: Arc<SimulatorContext>, e_b_sigma: &BigDecimal) -> Self {
         let k_high_norm =
-            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None);
+            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, None);
         let k_high_norm_bits = bigdecimal_bits_ceil(&k_high_norm);
         let k_low = PolyMatrixNorm::gadget_decomposed(ctx.clone(), ctx.m_g);
         info!("{}", format!("preimage norm bits {}", k_high_norm_bits));
@@ -265,7 +265,7 @@ impl NormPltGGH15Evaluator {
         let gaussian_bound = gaussian_tail_bound_factor();
 
         let preimage_norm =
-            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None);
+            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, None);
         info!("{}", format!("preimage norm bits {}", bigdecimal_bits_ceil(&preimage_norm)));
         let e_b_init =
             PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_b, e_b_sigma * &gaussian_bound, None);
@@ -506,7 +506,7 @@ impl NormPltCommitEvaluator {
             padded_len, lut_vector_len
         );
         let preimage_norm =
-            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None);
+            compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, None);
         let t_bottom = PolyMatrixNorm::new(
             ctx.clone(),
             ctx.m_b,
@@ -628,10 +628,11 @@ pub fn compute_preimage_norm(
     m_g: u64,
     base: &BigDecimal,
     b_nrow: Option<usize>,
+    sigma: Option<f64>,
 ) -> BigDecimal {
     let c_0 = BigDecimal::from_f64(1.8).unwrap();
     let c_1 = BigDecimal::from_f64(4.7).unwrap();
-    let sigma = BigDecimal::from_f64(4.578).unwrap();
+    let sigma = BigDecimal::from_f64(sigma.unwrap_or(4.578)).unwrap();
     let two_sqrt = BigDecimal::from(2).sqrt().unwrap();
     let m_g_sqrt = BigDecimal::from(m_g).sqrt().expect("sqrt(m_g) failed");
     let b_nrow = b_nrow.unwrap_or(1);

--- a/src/simulator/eval_error/tests.rs
+++ b/src/simulator/eval_error/tests.rs
@@ -46,6 +46,20 @@ const E_B_SIGMA: f64 = 4.0;
 const E_INIT_NORM: u32 = 1 << 14;
 
 #[test]
+fn test_compute_preimage_norm_uses_optional_sigma() {
+    let ctx = make_ctx();
+    let default_norm =
+        compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, None);
+    let explicit_default_norm =
+        compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, Some(4.578));
+    let larger_sigma_norm =
+        compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, Some(6.0));
+
+    assert_eq!(default_norm, explicit_default_norm);
+    assert!(larger_sigma_norm > default_norm);
+}
+
+#[test]
 fn test_wire_norm_addition() {
     let ctx = make_ctx();
     let mut circuit = PolyCircuit::<DCRTPoly>::new();
@@ -236,7 +250,7 @@ fn test_wire_norm_slot_transfer_matches_bgg_poly_encoding_bound() {
     let out = evaluator.slot_transfer(&(), &input, &src_slots, GateId(0));
 
     let b0_preimage_norm =
-        compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(1));
+        compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(1), None);
     let s_vec = PolyMatrixNorm::new(ctx.clone(), 1, ctx.secret_size, BigDecimal::one(), None);
     let gate_preimage =
         PolyMatrixNorm::new(ctx.clone(), ctx.m_b, ctx.m_g, b0_preimage_norm.clone(), None);
@@ -250,7 +264,7 @@ fn test_wire_norm_slot_transfer_matches_bgg_poly_encoding_bound() {
     let slot_preimage_b0 =
         PolyMatrixNorm::new(ctx.clone(), ctx.m_b, 2 * ctx.m_b, b0_preimage_norm.clone(), None);
     let b1_preimage_norm =
-        compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(2));
+        compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(2), None);
     let slot_preimage_b1 =
         PolyMatrixNorm::new(ctx.clone(), ctx.m_b * 2, ctx.m_g, b1_preimage_norm.clone(), None);
     let slot_preimage_b0_target_error = PolyMatrixNorm::new(


### PR DESCRIPTION
## Summary
- Allow `compute_preimage_norm` to use either the default sigma or a caller-supplied value via `Option<f64>`
- Thread the updated API through input injector simulation call sites while preserving existing default behavior
- Update CPU and GPU trapdoor sampler preimage parameter derivation to use each sampler instance’s sigma
- Add unit tests for explicit-sigma preimage bounds and for non-default-sigma preimage correctness and coefficient bounds

## Testing
- `cargo +nightly fmt --all`
- Targeted unit tests passed for simulator preimage bounds, CPU sampler sigma handling, GPU sampler sigma handling, and non-default-sigma preimage correctness/bound checks
- GPU-targeted tests were rerun outside the sandbox multiple times and passed on every run