### PR TITLE
Parallelize BGG benchmark estimation

### DIFF
--- a/src/bench_estimator/bgg_encoding.rs
+++ b/src/bench_estimator/bgg_encoding.rs
@@ -1,7 +1,10 @@
 use std::marker::PhantomData;
 
 use crate::{
-    bench_estimator::{BenchEstimator, CircuitBenchEstimate, benchmark_gate_operation},
+    bench_estimator::{
+        BenchEstimator, CircuitBenchEstimate, benchmark_gate_operation,
+        column_parallel_gate_estimate,
+    },
     bgg::{encoding::BggEncoding, public_key::BggPublicKey},
     circuit::Evaluable,
     matrix::PolyMatrix,
@@ -30,10 +33,12 @@ where
     pub sub_peak_vram: usize,
     pub mul_time: f64,
     pub mul_peak_vram: usize,
+    pub mul_rhs_column_count: usize,
     pub small_scalar_mul_time: f64,
     pub small_scalar_mul_peak_vram: usize,
     pub large_scalar_mul_time: f64,
     pub large_scalar_mul_peak_vram: usize,
+    pub large_scalar_mul_rhs_column_count: usize,
     pub public_lut_time: f64,
     pub public_lut_peak_vram: usize,
     pub slot_transfer_time: f64,
@@ -56,11 +61,13 @@ where
         let add = benchmark_gate_operation(iterations, || enc_a.clone() + &enc_b);
         let sub = benchmark_gate_operation(iterations, || enc_a.clone() - &enc_b);
         let mul = benchmark_gate_operation(iterations, || enc_a.clone() * &enc_b);
+        let mul_rhs_column_count = enc_b.pubkey.matrix.col_size();
         let small_scalar_mul =
             benchmark_gate_operation(iterations, || enc_a.small_scalar_mul(params, &[3u32]));
         let large_scalar_mul = benchmark_gate_operation(iterations, || {
             enc_a.large_scalar_mul(params, &[BigUint::from(5u32)])
         });
+        let large_scalar_mul_rhs_column_count = enc_a.pubkey.matrix.col_size();
 
         // Scalar `BggEncoding` does not have its own slot-transfer or public-LUT benchmark
         // evaluator. The naive-vector wrapper supplies the slot structure, so these single-scalar
@@ -78,10 +85,12 @@ where
             sub_peak_vram: sub.peak_vram,
             mul_time: mul.time,
             mul_peak_vram: mul.peak_vram,
+            mul_rhs_column_count,
             small_scalar_mul_time: small_scalar_mul.time,
             small_scalar_mul_peak_vram: small_scalar_mul.peak_vram,
             large_scalar_mul_time: large_scalar_mul.time,
             large_scalar_mul_peak_vram: large_scalar_mul.peak_vram,
+            large_scalar_mul_rhs_column_count,
             public_lut_time: public_lut.time,
             public_lut_peak_vram: public_lut.peak_vram,
             slot_transfer_time: slot_transfer.time,
@@ -108,7 +117,7 @@ where
     }
 
     fn estimate_mul(&self) -> CircuitBenchEstimate {
-        per_gate_time_estimate(self.mul_time, self.mul_peak_vram)
+        column_parallel_gate_estimate(self.mul_time, self.mul_peak_vram, self.mul_rhs_column_count)
     }
 
     fn estimate_small_scalar_mul(&self, _scalar: &[u32]) -> CircuitBenchEstimate {
@@ -116,7 +125,11 @@ where
     }
 
     fn estimate_large_scalar_mul(&self, _scalar: &[BigUint]) -> CircuitBenchEstimate {
-        per_gate_time_estimate(self.large_scalar_mul_time, self.large_scalar_mul_peak_vram)
+        column_parallel_gate_estimate(
+            self.large_scalar_mul_time,
+            self.large_scalar_mul_peak_vram,
+            self.large_scalar_mul_rhs_column_count,
+        )
     }
 
     fn estimate_slot_transfer(&self, src_slots: &[(u32, Option<u32>)]) -> CircuitBenchEstimate {
@@ -158,10 +171,12 @@ mod tests {
             sub_peak_vram: 0,
             mul_time: 3.0,
             mul_peak_vram: 0,
+            mul_rhs_column_count: 3,
             small_scalar_mul_time: 4.0,
             small_scalar_mul_peak_vram: 0,
             large_scalar_mul_time: 5.0,
             large_scalar_mul_peak_vram: 0,
+            large_scalar_mul_rhs_column_count: 5,
             public_lut_time: 6.0,
             public_lut_peak_vram: 0,
             slot_transfer_time: 7.0,
@@ -172,6 +187,14 @@ mod tests {
         let add = <BggEncodingBenchEstimator<DCRTPolyMatrix> as BenchEstimator<
             BggEncoding<DCRTPolyMatrix>,
         >>::estimate_add(&estimator);
+        let mul = <BggEncodingBenchEstimator<DCRTPolyMatrix> as BenchEstimator<
+            BggEncoding<DCRTPolyMatrix>,
+        >>::estimate_mul(&estimator);
+        let large_scalar_mul = <BggEncodingBenchEstimator<DCRTPolyMatrix> as BenchEstimator<
+            BggEncoding<DCRTPolyMatrix>,
+        >>::estimate_large_scalar_mul(
+            &estimator, &[num_bigint::BigUint::from(7u32)]
+        );
         let public_lookup = <BggEncodingBenchEstimator<DCRTPolyMatrix> as BenchEstimator<
             BggEncoding<DCRTPolyMatrix>,
         >>::estimate_public_lookup(&estimator, 0);
@@ -181,6 +204,12 @@ mod tests {
         assert!(public_lookup.total_time.is_finite());
         assert!(public_lookup.latency.is_finite());
         assert_eq!(add.total_time, 1.0);
+        assert_eq!(mul.total_time, 3.0);
+        assert_eq!(mul.latency, 1.0);
+        assert_eq!(mul.max_parallelism, 3);
+        assert_eq!(large_scalar_mul.total_time, 5.0);
+        assert_eq!(large_scalar_mul.latency, 1.0);
+        assert_eq!(large_scalar_mul.max_parallelism, 5);
         assert_eq!(public_lookup.total_time, 6.0);
     }
 }

--- a/src/bench_estimator/bgg_poly_encoding.rs
+++ b/src/bench_estimator/bgg_poly_encoding.rs
@@ -3,6 +3,7 @@ use std::{marker::PhantomData, sync::Arc};
 use crate::{
     bench_estimator::{
         BenchEstimator, BenchOperationMeasurement, CircuitBenchEstimate, benchmark_gate_operation,
+        column_parallel_gate_estimate,
     },
     bgg::{poly_encoding::BggPolyEncoding, public_key::BggPublicKey},
     circuit::{Evaluable, gate::GateId},
@@ -30,6 +31,29 @@ fn measured_slot_gate_estimate(
     peak_vram: usize,
 ) -> CircuitBenchEstimate {
     CircuitBenchEstimate::new(total_time * num_slots as f64, latency).with_peak_vram(peak_vram)
+}
+
+fn per_slot_column_parallel_gate_estimate(
+    total_time: f64,
+    num_slots: usize,
+    peak_vram: usize,
+    rhs_column_count: usize,
+) -> CircuitBenchEstimate {
+    let slot_estimate = column_parallel_gate_estimate(total_time, peak_vram, rhs_column_count);
+    let total_time = slot_estimate.total_time * num_slots as f64;
+    let max_parallelism = slot_estimate.max_parallelism.checked_mul(num_slots as u128).expect(
+        "BGG poly encoding column-parallel gate parallelism overflowed while scaling by slot count",
+    );
+    let estimate = CircuitBenchEstimate::new(total_time, slot_estimate.latency)
+        .with_max_parallelism(max_parallelism);
+    #[cfg(feature = "gpu")]
+    {
+        estimate.with_peak_vram(slot_estimate.peak_vram)
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        estimate
+    }
 }
 
 fn benchmark_single_slot_operation<R, F>(iterations: usize, f: F) -> BenchOperationMeasurement
@@ -269,10 +293,12 @@ where
     pub sub_peak_vram: usize,
     pub mul_time: f64,
     pub mul_peak_vram: usize,
+    pub mul_rhs_column_count: usize,
     pub small_scalar_mul_time: f64,
     pub small_scalar_mul_peak_vram: usize,
     pub large_scalar_mul_time: f64,
     pub large_scalar_mul_peak_vram: usize,
+    pub large_scalar_mul_rhs_column_count: usize,
     pub public_lut_latency: f64,
     pub public_lut_max_parallelism: u128,
     pub public_lut_total_time: f64,
@@ -346,6 +372,7 @@ where
         let mul_bench = benchmark_single_slot_operation(iterations, || {
             samples.mul_lhs.clone() * samples.mul_rhs
         });
+        let mul_rhs_column_count = samples.mul_rhs.pubkey.matrix.col_size();
         debug!("BggPolyEncodingBenchEstimator::benchmark mul_bench={:?}", mul_bench);
         let small_scalar_mul_bench = benchmark_single_slot_operation(iterations, || {
             samples.small_scalar_input.small_scalar_mul(samples.params, samples.small_scalar)
@@ -357,6 +384,7 @@ where
         let large_scalar_mul_bench = benchmark_single_slot_operation(iterations, || {
             samples.large_scalar_input.large_scalar_mul(samples.params, samples.large_scalar)
         });
+        let large_scalar_mul_rhs_column_count = samples.large_scalar_input.pubkey.matrix.col_size();
         debug!(
             "BggPolyEncodingBenchEstimator::benchmark large_scalar_mul_bench={:?}",
             large_scalar_mul_bench
@@ -381,10 +409,12 @@ where
             sub_peak_vram: sub_bench.peak_vram,
             mul_time: mul_bench.time,
             mul_peak_vram: mul_bench.peak_vram,
+            mul_rhs_column_count,
             small_scalar_mul_time: small_scalar_mul_bench.time,
             small_scalar_mul_peak_vram: small_scalar_mul_bench.peak_vram,
             large_scalar_mul_time: large_scalar_mul_bench.time,
             large_scalar_mul_peak_vram: large_scalar_mul_bench.peak_vram,
+            large_scalar_mul_rhs_column_count,
             public_lut_latency: public_lut_bench.latency,
             public_lut_max_parallelism: public_lut_bench.max_parallelism,
             public_lut_total_time: public_lut_bench.total_time,
@@ -415,7 +445,12 @@ where
     }
 
     fn estimate_mul(&self) -> CircuitBenchEstimate {
-        per_slot_gate_estimate(self.mul_time, self.num_slots, self.mul_peak_vram)
+        per_slot_column_parallel_gate_estimate(
+            self.mul_time,
+            self.num_slots,
+            self.mul_peak_vram,
+            self.mul_rhs_column_count,
+        )
     }
 
     fn estimate_small_scalar_mul(&self, _scalar: &[u32]) -> CircuitBenchEstimate {
@@ -427,10 +462,11 @@ where
     }
 
     fn estimate_large_scalar_mul(&self, _scalar: &[BigUint]) -> CircuitBenchEstimate {
-        per_slot_gate_estimate(
+        per_slot_column_parallel_gate_estimate(
             self.large_scalar_mul_time,
             self.num_slots,
             self.large_scalar_mul_peak_vram,
+            self.large_scalar_mul_rhs_column_count,
         )
     }
 
@@ -510,10 +546,12 @@ mod tests {
             sub_peak_vram: 73,
             mul_time: 3.0,
             mul_peak_vram: 79,
+            mul_rhs_column_count: 3,
             small_scalar_mul_time: 4.0,
             small_scalar_mul_peak_vram: 83,
             large_scalar_mul_time: 5.0,
             large_scalar_mul_peak_vram: 89,
+            large_scalar_mul_rhs_column_count: 5,
             public_lut_latency: 6.0,
             public_lut_max_parallelism: 2,
             public_lut_total_time: 12.0,
@@ -551,8 +589,9 @@ mod tests {
         let mul = estimator.estimate_mul();
         assert_eq!(
             mul,
-            CircuitBenchEstimate::new(9.0, 3.0).with_peak_vram(estimator.mul_peak_vram)
+            CircuitBenchEstimate::new(9.0, 1.0).with_peak_vram(estimator.mul_peak_vram.div_ceil(3))
         );
+        assert_eq!(mul.max_parallelism, 3 * estimator.num_slots as u128);
 
         let small_scalar = estimator.estimate_small_scalar_mul(&[3u32, 5u32]);
         assert_eq!(
@@ -564,9 +603,10 @@ mod tests {
         let large_scalar = estimator.estimate_large_scalar_mul(&[BigUint::from(7u32)]);
         assert_eq!(
             large_scalar,
-            CircuitBenchEstimate::new(15.0, 5.0)
-                .with_peak_vram(estimator.large_scalar_mul_peak_vram)
+            CircuitBenchEstimate::new(15.0, 1.0)
+                .with_peak_vram(estimator.large_scalar_mul_peak_vram.div_ceil(5))
         );
+        assert_eq!(large_scalar.max_parallelism, 5 * estimator.num_slots as u128);
 
         let public_lookup = estimator.estimate_public_lookup(7);
         assert_eq!(

--- a/src/bench_estimator/bgg_pubkey.rs
+++ b/src/bench_estimator/bgg_pubkey.rs
@@ -13,7 +13,8 @@ use num_traits::ToPrimitive;
 use tracing::debug;
 
 use super::{
-    BenchEstimator, CircuitBenchEstimate, benchmark_gate_operation, measure_bench_operation,
+    BenchEstimator, CircuitBenchEstimate, benchmark_gate_operation, column_parallel_gate_estimate,
+    measure_bench_operation,
 };
 
 pub(crate) fn per_gate_time_estimate(time: f64, peak_vram: usize) -> CircuitBenchEstimate {
@@ -166,10 +167,12 @@ where
     pub sub_peak_vram: usize,
     pub mul_time: f64,
     pub mul_peak_vram: usize,
+    pub mul_rhs_column_count: usize,
     pub small_scalar_mul_time: f64,
     pub small_scalar_mul_peak_vram: usize,
     pub large_scalar_mul_time: f64,
     pub large_scalar_mul_peak_vram: usize,
+    pub large_scalar_mul_rhs_column_count: usize,
     pub public_lut_time: f64,
     pub public_lut_peak_vram: usize,
     pub slot_transfer_time: f64,
@@ -205,6 +208,7 @@ where
         debug!("BggPublicKeyBenchEstimator::benchmark sub_bench={:?}", sub_bench);
         let mul_bench =
             benchmark_gate_operation(iterations, || samples.mul_lhs.clone() * samples.mul_rhs);
+        let mul_rhs_column_count = samples.mul_rhs.matrix.col_size();
         debug!("BggPublicKeyBenchEstimator::benchmark mul_bench={:?}", mul_bench);
         let small_scalar_mul_bench = benchmark_gate_operation(iterations, || {
             samples.small_scalar_input.small_scalar_mul(samples.params, samples.small_scalar)
@@ -216,6 +220,7 @@ where
         let large_scalar_mul_bench = benchmark_gate_operation(iterations, || {
             samples.large_scalar_input.large_scalar_mul(samples.params, samples.large_scalar)
         });
+        let large_scalar_mul_rhs_column_count = samples.large_scalar_input.matrix.col_size();
         debug!(
             "BggPublicKeyBenchEstimator::benchmark large_scalar_mul_bench={:?}",
             large_scalar_mul_bench
@@ -253,10 +258,12 @@ where
             sub_peak_vram: sub_bench.peak_vram,
             mul_time: mul_bench.time,
             mul_peak_vram: mul_bench.peak_vram,
+            mul_rhs_column_count,
             small_scalar_mul_time: small_scalar_mul_bench.time,
             small_scalar_mul_peak_vram: small_scalar_mul_bench.peak_vram,
             large_scalar_mul_time: large_scalar_mul_bench.time,
             large_scalar_mul_peak_vram: large_scalar_mul_bench.peak_vram,
+            large_scalar_mul_rhs_column_count,
             public_lut_time: public_lut_bench.time,
             public_lut_peak_vram: public_lut_bench.peak_vram,
             slot_transfer_time: slot_transfer_bench.time,
@@ -331,7 +338,7 @@ where
     }
 
     fn estimate_mul(&self) -> CircuitBenchEstimate {
-        per_gate_time_estimate(self.mul_time, self.mul_peak_vram)
+        column_parallel_gate_estimate(self.mul_time, self.mul_peak_vram, self.mul_rhs_column_count)
     }
 
     fn estimate_small_scalar_mul(&self, _scalar: &[u32]) -> CircuitBenchEstimate {
@@ -339,7 +346,11 @@ where
     }
 
     fn estimate_large_scalar_mul(&self, _scalar: &[num_bigint::BigUint]) -> CircuitBenchEstimate {
-        per_gate_time_estimate(self.large_scalar_mul_time, self.large_scalar_mul_peak_vram)
+        column_parallel_gate_estimate(
+            self.large_scalar_mul_time,
+            self.large_scalar_mul_peak_vram,
+            self.large_scalar_mul_rhs_column_count,
+        )
     }
 
     fn estimate_slot_transfer(&self, src_slots: &[(u32, Option<u32>)]) -> CircuitBenchEstimate {
@@ -515,10 +526,12 @@ mod tests {
             sub_peak_vram: 43,
             mul_time: 3.0,
             mul_peak_vram: 47,
+            mul_rhs_column_count: 3,
             small_scalar_mul_time: 4.0,
             small_scalar_mul_peak_vram: 53,
             large_scalar_mul_time: 5.0,
             large_scalar_mul_peak_vram: 59,
+            large_scalar_mul_rhs_column_count: 4,
             public_lut_time: 6.0,
             public_lut_peak_vram: 61,
             slot_transfer_time: 7.0,
@@ -576,8 +589,18 @@ mod tests {
         );
         assert_eq!(
             estimator.estimate_mul(),
-            CircuitBenchEstimate::new(estimator.mul_time, estimator.mul_time)
-                .with_peak_vram(estimator.mul_peak_vram)
+            CircuitBenchEstimate::new(estimator.mul_time, estimator.mul_time / 3.0)
+                .with_max_parallelism(3)
+                .with_peak_vram(estimator.mul_peak_vram.div_ceil(3))
+        );
+        assert_eq!(
+            estimator.estimate_large_scalar_mul(&[BigUint::from(7u32)]),
+            CircuitBenchEstimate::new(
+                estimator.large_scalar_mul_time,
+                estimator.large_scalar_mul_time / 4.0
+            )
+            .with_max_parallelism(4)
+            .with_peak_vram(estimator.large_scalar_mul_peak_vram.div_ceil(4))
         );
         assert!(estimator.public_lut_time >= 0.0);
         assert!(estimator.slot_transfer_time >= 0.0);

--- a/src/bench_estimator/mod.rs
+++ b/src/bench_estimator/mod.rs
@@ -149,6 +149,23 @@ impl CircuitBenchSummary {
     }
 }
 
+pub(crate) fn column_parallel_gate_estimate(
+    total_time: f64,
+    peak_vram: usize,
+    rhs_column_count: usize,
+) -> CircuitBenchEstimate {
+    assert!(rhs_column_count > 0, "column-parallel gate estimates require at least one RHS column");
+    const NANOS_PER_SECOND: f64 = 1_000_000_000.0;
+    const NANOS_PER_SECOND_U128: u128 = 1_000_000_000;
+
+    let total_nanos = (total_time * NANOS_PER_SECOND).ceil() as u128;
+    let latency =
+        total_nanos.div_ceil(rhs_column_count as u128) as f64 / NANOS_PER_SECOND_U128 as f64;
+    CircuitBenchEstimate::new(total_time, latency)
+        .with_max_parallelism(rhs_column_count as u128)
+        .with_peak_vram(peak_vram.div_ceil(rhs_column_count))
+}
+
 fn bench_summary_cache_get(
     summary_cache: &BenchSummaryCache,
     cache_key: &BenchSummaryCacheKey,
@@ -698,7 +715,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary, measure_samples_with_interval,
+        BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary, column_parallel_gate_estimate,
+        measure_samples_with_interval,
     };
     use crate::{
         __PAIR, __TestState,
@@ -727,6 +745,17 @@ mod tests {
         peak_vram: usize,
     ) -> CircuitBenchSummary {
         CircuitBenchSummary::new(total_time, latency, max_parallelism).with_peak_vram(peak_vram)
+    }
+
+    #[test]
+    fn column_parallel_gate_estimate_uses_ceiling_division_for_latency() {
+        let estimate = column_parallel_gate_estimate(0.000000010, 10, 3);
+
+        assert_eq!(estimate.total_time, 0.000000010);
+        assert_eq!(estimate.latency, 0.000000004);
+        assert_eq!(estimate.max_parallelism, 3);
+        #[cfg(feature = "gpu")]
+        assert_eq!(estimate.peak_vram, 4);
     }
 
     struct TestBenchEstimator;


### PR DESCRIPTION
## Summary
- Update BGG benchmark estimator modules to support parallel evaluation in the mul benchmark path.
- Apply the estimator changes across encoding, polynomial encoding, and public key benchmark code.
- Keep the shared benchmark estimator module aligned with the new parallel flow.

## Testing
- Not run (not requested)