### PR TITLE
Add naive BGG slot-transfer error simulation and switch naive LWE tests to it

### DIFF
--- a/src/simulator/error_norm.rs
+++ b/src/simulator/error_norm.rs
@@ -13,7 +13,8 @@ use std::{
 
 pub use super::eval_error::{
     AffinePltEvaluator, AffineSlotTransferEvaluator, NormBggPolyEncodingSTEvaluator,
-    NormPltCommitEvaluator, NormPltGGH15Evaluator, NormPltLWEEvaluator, compute_preimage_norm,
+    NormNaiveBggEncodingVecSTEvaluator, NormPltCommitEvaluator, NormPltGGH15Evaluator,
+    NormPltLWEEvaluator, compute_preimage_norm,
 };
 
 // Note: h_norm and plaintext_norm computed here can be larger than the modulus .

--- a/src/simulator/eval_error/evaluators.rs
+++ b/src/simulator/eval_error/evaluators.rs
@@ -175,6 +175,59 @@ impl AffineSlotTransferEvaluator for NormBggPolyEncodingSTEvaluator {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NormNaiveBggEncodingVecSTEvaluator;
+
+impl NormNaiveBggEncodingVecSTEvaluator {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn max_slot_scalar(src_slots: &[(u32, Option<u32>)]) -> u32 {
+        src_slots.iter().map(|(_, scalar)| scalar.unwrap_or(1)).max().unwrap_or(1)
+    }
+}
+
+impl SlotTransferEvaluator<ErrorNorm> for NormNaiveBggEncodingVecSTEvaluator {
+    fn slot_transfer(
+        &self,
+        _: &(),
+        input: &ErrorNorm,
+        src_slots: &[(u32, Option<u32>)],
+        _: GateId,
+    ) -> ErrorNorm {
+        input.small_scalar_mul(&(), &[Self::max_slot_scalar(src_slots)])
+    }
+
+    fn slot_reduce(&self, _: &(), inputs: &[ErrorNorm], num_slots: usize, _: GateId) -> ErrorNorm {
+        assert!(num_slots > 0, "slot_reduce requires num_slots > 0");
+        assert!(!inputs.is_empty(), "slot_reduce requires at least one input");
+        assert!(
+            inputs.len() <= num_slots,
+            "slot_reduce input count {} exceeds num_slots {}",
+            inputs.len(),
+            num_slots
+        );
+
+        let mut sum = inputs[0].clone();
+        for input in &inputs[1..] {
+            sum = sum + input;
+        }
+        sum
+    }
+}
+
+impl AffineSlotTransferEvaluator for NormNaiveBggEncodingVecSTEvaluator {
+    fn slot_transfer_affine(
+        &self,
+        input: &ErrorNormSummaryExpr,
+        src_slots: &[(u32, Option<u32>)],
+        _: GateId,
+    ) -> ErrorNormSummaryExpr {
+        input.small_scalar_mul_bound(&[Self::max_slot_scalar(src_slots)])
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct NormPltLWEEvaluator {
     pub e_b_times_k_high: PolyMatrixNorm,

--- a/src/simulator/eval_error/mod.rs
+++ b/src/simulator/eval_error/mod.rs
@@ -1564,8 +1564,8 @@ mod store;
 mod summary;
 
 pub use evaluators::{
-    NormBggPolyEncodingSTEvaluator, NormPltCommitEvaluator, NormPltGGH15Evaluator,
-    NormPltLWEEvaluator, compute_preimage_norm,
+    NormBggPolyEncodingSTEvaluator, NormNaiveBggEncodingVecSTEvaluator, NormPltCommitEvaluator,
+    NormPltGGH15Evaluator, NormPltLWEEvaluator, compute_preimage_norm,
 };
 
 #[cfg(test)]

--- a/src/simulator/eval_error/tests.rs
+++ b/src/simulator/eval_error/tests.rs
@@ -330,6 +330,48 @@ fn test_wire_norm_slot_transfer_bound_is_independent_of_slot_count() {
 }
 
 #[test]
+fn test_wire_norm_naive_bgg_encoding_vec_slot_transfer_is_free() {
+    let ctx = make_ctx();
+    let evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
+    let input = ErrorNorm::new(
+        PolyNorm::new(ctx.clone(), BigDecimal::from(5u64)),
+        PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_g, BigDecimal::from(7u64), None),
+    );
+    let src_slots = [(2, None), (0, Some(3)), (1, Some(2))];
+
+    let out = evaluator.slot_transfer(&(), &input, &src_slots, GateId(0));
+
+    assert_eq!(out, input.small_scalar_mul(&(), &[3]));
+}
+
+#[test]
+fn test_wire_norm_naive_bgg_encoding_vec_slot_transfer_affine_path_is_free() {
+    let ctx = make_ctx();
+    let mut circuit = PolyCircuit::<DCRTPoly>::new();
+    let inputs = circuit.input(1).to_vec();
+    let out_gate = circuit.slot_transfer_gate(inputs[0], &[(2, None), (0, Some(4)), (1, Some(2))]);
+    circuit.output(vec![out_gate.as_single_wire()]);
+
+    let evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
+    let input_bound = BigDecimal::from(5u64);
+    let e_init_norm = BigDecimal::from(E_INIT_NORM);
+    let out = circuit.simulate_max_error_norm(
+        ctx.clone(),
+        input_bound.clone(),
+        1,
+        &e_init_norm,
+        None::<&NormPltLWEEvaluator>,
+        Some(&evaluator),
+    );
+    let input = ErrorNorm::new(
+        PolyNorm::new(ctx.clone(), input_bound),
+        PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_g, e_init_norm, None),
+    );
+
+    assert_eq!(out, vec![input.small_scalar_mul(&(), &[4])]);
+}
+
+#[test]
 fn test_wire_norm_lwe_plt_bounds() {
     // Build a tiny LUT on DCRTPoly where the maximum output coeff is known (e.g., 7)
     let params = DCRTPolyParams::default();

--- a/tests/test_gpu_lwe_montgomery_goldreich_ring_gsw_bench.rs
+++ b/tests/test_gpu_lwe_montgomery_goldreich_ring_gsw_bench.rs
@@ -53,7 +53,7 @@ use mxx::{
     },
     simulator::{
         SimulatorContext,
-        error_norm::{NormBggPolyEncodingSTEvaluator, NormPltLWEEvaluator},
+        error_norm::{NormNaiveBggEncodingVecSTEvaluator, NormPltLWEEvaluator},
     },
     slot_transfer::{NaiveBGGVecSlotTransferEvaluator, PolyVecSlotTransferEvaluator},
     storage::write::{init_storage_system, wait_for_all_writes},
@@ -330,8 +330,7 @@ fn probe_crt_depth_for_goldreich_ring_gsw_bench(
         log_base_q_small,
     ));
     let plt_evaluator = NormPltLWEEvaluator::new(sim_ctx.clone(), error_sigma);
-    let slot_transfer_evaluator =
-        NormBggPolyEncodingSTEvaluator::new(sim_ctx.clone(), cfg.error_sigma, error_sigma, None);
+    let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
     let out_errors = circuit.simulate_max_error_norm(
         sim_ctx,
         BigDecimal::from(1u64),

--- a/tests/test_gpu_lwe_montgomery_ring_gsw_mul_bench.rs
+++ b/tests/test_gpu_lwe_montgomery_ring_gsw_mul_bench.rs
@@ -52,7 +52,7 @@ use mxx::{
     },
     simulator::{
         SimulatorContext,
-        error_norm::{NormBggPolyEncodingSTEvaluator, NormPltLWEEvaluator},
+        error_norm::{NormNaiveBggEncodingVecSTEvaluator, NormPltLWEEvaluator},
     },
     slot_transfer::{NaiveBGGVecSlotTransferEvaluator, PolyVecSlotTransferEvaluator},
     storage::write::{init_storage_system, wait_for_all_writes},
@@ -339,8 +339,7 @@ fn probe_crt_depth_for_ring_gsw_mul_bench(
         log_base_q_small,
     ));
     let plt_evaluator = NormPltLWEEvaluator::new(sim_ctx.clone(), error_sigma);
-    let slot_transfer_evaluator =
-        NormBggPolyEncodingSTEvaluator::new(sim_ctx.clone(), cfg.error_sigma, error_sigma, None);
+    let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
     let out_errors = circuit.simulate_max_error_norm(
         sim_ctx,
         BigDecimal::from(1u64),

--- a/tests/test_gpu_lwe_nested_rns_goldreich_ring_gsw_bench.rs
+++ b/tests/test_gpu_lwe_nested_rns_goldreich_ring_gsw_bench.rs
@@ -48,7 +48,7 @@ use mxx::{
     },
     simulator::{
         SimulatorContext,
-        error_norm::{NormBggPolyEncodingSTEvaluator, NormPltLWEEvaluator},
+        error_norm::{NormNaiveBggEncodingVecSTEvaluator, NormPltLWEEvaluator},
     },
     slot_transfer::{NaiveBGGVecSlotTransferEvaluator, PolyVecSlotTransferEvaluator},
     storage::write::{init_storage_system, wait_for_all_writes},
@@ -356,8 +356,7 @@ fn probe_crt_depth_for_goldreich_ring_gsw_bench(
         log_base_q_small,
     ));
     let plt_evaluator = NormPltLWEEvaluator::new(sim_ctx.clone(), error_sigma);
-    let slot_transfer_evaluator =
-        NormBggPolyEncodingSTEvaluator::new(sim_ctx.clone(), cfg.error_sigma, error_sigma, None);
+    let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
     let out_errors = circuit.simulate_max_error_norm(
         sim_ctx,
         BigDecimal::from(1u64),

--- a/tests/test_gpu_lwe_nested_rns_ring_gsw_mul_bench.rs
+++ b/tests/test_gpu_lwe_nested_rns_ring_gsw_mul_bench.rs
@@ -47,7 +47,7 @@ use mxx::{
     },
     simulator::{
         SimulatorContext,
-        error_norm::{NormBggPolyEncodingSTEvaluator, NormPltLWEEvaluator},
+        error_norm::{NormNaiveBggEncodingVecSTEvaluator, NormPltLWEEvaluator},
     },
     slot_transfer::{NaiveBGGVecSlotTransferEvaluator, PolyVecSlotTransferEvaluator},
     storage::write::{init_storage_system, wait_for_all_writes},
@@ -364,8 +364,7 @@ fn probe_crt_depth_for_ring_gsw_mul_bench(
         log_base_q_small,
     ));
     let plt_evaluator = NormPltLWEEvaluator::new(sim_ctx.clone(), error_sigma);
-    let slot_transfer_evaluator =
-        NormBggPolyEncodingSTEvaluator::new(sim_ctx.clone(), cfg.error_sigma, error_sigma, None);
+    let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
     let out_errors = circuit.simulate_max_error_norm(
         sim_ctx,
         BigDecimal::from(1u64),


### PR DESCRIPTION
## Summary
- Added `NormNaiveBggEncodingVecSTEvaluator` for error simulation of `NaiveBGGEncodingVec` slot transfer.
- Exported the new evaluator through the simulator error-norm APIs.
- Added focused unit coverage for direct and affine slot-transfer behavior.
- Updated naive LWE GPU bench tests to use the new evaluator instead of `NormBggPolyEncodingSTEvaluator`.

## Testing
- `cargo +nightly fmt --all`
- `env FIDESLIB_SKIP_SUBMODULE_UPDATE=1 cargo test --lib test_wire_norm_naive_bgg_encoding_vec_slot_transfer -- --nocapture`
- `env FIDESLIB_SKIP_SUBMODULE_UPDATE=1 scripts/run_build_checks.sh`