### PR TITLE
Add a Runpod workflow skill for mxx remote execution

### DIFF
--- a/.codex/skills/bench-on-runpod/SKILL.md
+++ b/.codex/skills/bench-on-runpod/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: bench-on-runpod
+description: Run mxx repository programs, tests, or benchmarks on Runpod instances with GPU machine selection, network volume setup, SSH/scp configuration, branch push and remote checkout synchronization, durable log capture, log retrieval, instance cleanup, and failed-test fix/push/pull/rerun loops. Use when Codex is asked to execute mxx work on a Runpod machine or instance, including requests that mention Runpod GPUs such as RTX5090, RTX PRO 6000, H200, remote benchmarking, remote tests, or running a command on a Runpod pod.
+---
+
+# Bench on Runpod
+
+## Overview
+
+Use this workflow to run mxx commands on Runpod machines while keeping the local branch, remote checkout, logs, and instance lifecycle controlled.
+
+Prefer repo-local Runpod helper skills and CLIs when available, but keep the required state transitions below intact.
+
+## Required Inputs
+
+Before provisioning, determine these values from the user request or local context. Ask the user for any value that remains unclear.
+
+- Machine type, such as `RTX5090`, `RTX PRO 6000`, or `H200`.
+- Machine count.
+- Container volume size.
+- Network volume. Prefer an existing Runpod network volume whose name contains `mxx`; ask before creating or using a non-mxx volume.
+- The exact program, test, benchmark, or command to run.
+- Whether the selected network volume is new for mxx setup purposes.
+
+## Local Preparation
+
+1. Inspect the current branch name. If the checkout is detached or the current branch name is not decided, ask the user to choose a branch name before continuing.
+2. Ensure every local change needed for the remote run is committed and pushed. If there are uncommitted changes and the user has not already authorized committing them, ask before creating a commit.
+3. Push the current branch to the remote repository.
+4. Record the pushed branch name and latest commit SHA. The remote checkout must be synchronized to this exact commit before running the command.
+
+## Provision and Connect
+
+1. Launch the requested Runpod machine configuration with the chosen machine type, machine count, container volume size, and network volume.
+2. Ensure SSH is configured with `scp` support enabled. Do not proceed with a machine that cannot receive files through `scp`.
+3. SSH into the machine and confirm the mounted workspace path is `/workspace`.
+4. Record the machine or pod name because it must be included in the run log filename or metadata.
+
+## Remote Setup
+
+1. If the network volume is new for this mxx environment, copy `scripts/setup.sh` from this skill to the remote `/workspace` directory with `scp`, then run it on the remote machine from `/workspace`.
+2. In every remote shell that runs commands, execute:
+
+```bash
+source /workspace/env.sh
+```
+
+3. Move to `/workspace/mxx`.
+4. Align `/workspace/mxx` to the pushed local branch and commit:
+
+```bash
+git fetch origin
+git checkout <branch-name>
+git reset --hard <commit-sha>
+git submodule update --init --recursive
+```
+
+Use the actual pushed branch and commit from local preparation. Do not run against a stale remote checkout.
+
+## Run and Log
+
+Always write command output to a durable log file while the command runs.
+
+Construct a log filename or header that includes:
+
+- Machine name or pod name.
+- Machine count.
+- Git commit SHA.
+- Date and time, preferably in JST.
+- A command summary of seven words or fewer.
+
+Use `tee` for foreground commands. For long-running tests, benchmarks, or commands likely to outlive the SSH session, use `nohup` in the background and redirect both stdout and stderr to the log while preserving the command exit status where practical.
+
+Example foreground shape:
+
+```bash
+set -o pipefail
+<command> 2>&1 | tee <log-file>
+```
+
+Example background shape:
+
+```bash
+nohup bash -lc 'set -o pipefail; <command>' > <log-file> 2>&1 &
+echo $!
+```
+
+Poll or reconnect until the result is known. When a background command finishes, inspect the log tail and exit-status evidence before reporting success or failure.
+
+## Retrieve Logs
+
+After the run completes or reaches a useful failure point, copy the log back to the local machine under `~/codes/mxx/logs` in an appropriate subdirectory for the run type, date, branch, or command family. Preserve the original remote log name when practical.
+
+## Failure Loop
+
+When a test or benchmark fails and the user has not instructed otherwise, use this default loop:
+
+1. Diagnose from the retrieved log.
+2. Fix the issue locally in the mxx workspace.
+3. Commit and push the local fix.
+4. SSH to the same remote machine when it is still running.
+5. Pull or fetch the updated branch in `/workspace/mxx` and reset to the new commit.
+6. Rerun the command with a new durable log.
+
+Repeat until the run succeeds or user input is needed.
+
+## Instance Lifecycle
+
+After collecting logs:
+
+- Keep the Runpod instance running if a failure means the same machine is likely to be reused within one hour.
+- Stop or terminate the Runpod instance if the run succeeded.
+- Stop or terminate the instance if the run failed but progress is blocked on user help and reuse within one hour is uncertain.
+
+Report the final instance state, local log path, remote log path, branch, commit, and command result to the user.

--- a/.codex/skills/bench-on-runpod/agents/openai.yaml
+++ b/.codex/skills/bench-on-runpod/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bench on Runpod"
+  short_description: "Run mxx commands on Runpod GPUs."
+  default_prompt: "Run an mxx command on Runpod using the bench-on-runpod workflow."

--- a/.codex/skills/bench-on-runpod/scripts/setup.sh
+++ b/.codex/skills/bench-on-runpod/scripts/setup.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKTREE="/workspace"
+OPENFHE_PREFIX="${WORKTREE}/openfhe"
+ENV_FILE="${WORKTREE}/env.sh"
+
+RUSTUP_HOME="${WORKTREE}/rustup"
+CARGO_HOME="${WORKTREE}/cargo"
+N_PREFIX="${WORKTREE}/n"
+NPM_GLOBAL_PREFIX="${WORKTREE}/npm-global"
+NPM_CONFIG_CACHE="${WORKTREE}/.npm-cache"
+CODEX_HOME="${WORKTREE}/.codex"
+
+log() { echo -e "\n==> $*\n"; }
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root (no sudo is used)."
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+mkdir -p "${WORKTREE}"
+
+# 1) Setup Kitware APT repo (latest CMake)
+log "1) Setup Kitware APT repo"
+apt-get update -y
+apt-get install -y ca-certificates gpg wget curl
+
+# (Same flow as before) temporary key -> add repo -> install keyring package
+if [ ! -f /usr/share/doc/kitware-archive-keyring/copyright ]; then
+  wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+    | gpg --dearmor - \
+    | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+fi
+
+CODENAME="$(. /etc/os-release && echo "${VERSION_CODENAME:-jammy}")"
+echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${CODENAME} main" \
+  > /etc/apt/sources.list.d/kitware.list
+
+apt-get update -y
+
+if [ ! -f /usr/share/doc/kitware-archive-keyring/copyright ]; then
+  rm -f /usr/share/keyrings/kitware-archive-keyring.gpg
+  apt-get install -y kitware-archive-keyring
+  apt-get update -y
+fi
+
+# 2) apt packages install
+log "2) Install apt packages"
+apt-get install -y \
+  cmake htop nvtop libtbb-dev \
+  git build-essential make
+
+# 3) Install Rust under /workspace (rustup)
+log "3) Install Rust under ${WORKTREE}"
+mkdir -p "${RUSTUP_HOME}" "${CARGO_HOME}"
+export RUSTUP_HOME CARGO_HOME
+export PATH="${CARGO_HOME}/bin:${PATH}"
+
+if [ ! -x "${CARGO_HOME}/bin/rustup" ]; then
+  # rustup official installer; we avoid modifying shell profiles
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+fi
+
+rustc --version
+cargo --version
+
+# 4) Install Node.js (via n) and Codex under /workspace
+log "4) Install Node.js (via n) and Codex under ${WORKTREE}"
+mkdir -p "${N_PREFIX}/bin" "${NPM_GLOBAL_PREFIX}" "${NPM_CONFIG_CACHE}" "${CODEX_HOME}"
+export N_PREFIX NPM_GLOBAL_PREFIX NPM_CONFIG_CACHE CODEX_HOME
+export NPM_CONFIG_PREFIX="${NPM_GLOBAL_PREFIX}"
+export PATH="${N_PREFIX}/bin:${NPM_GLOBAL_PREFIX}/bin:${PATH}"
+
+if [ ! -x "${N_PREFIX}/bin/n" ]; then
+  curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n -o "${N_PREFIX}/bin/n"
+  chmod +x "${N_PREFIX}/bin/n"
+fi
+
+if [ ! -x "${N_PREFIX}/bin/node" ]; then
+  "${N_PREFIX}/bin/n" lts
+fi
+
+if [ ! -x "${NPM_GLOBAL_PREFIX}/bin/codex" ]; then
+  npm install -g @openai/codex
+fi
+
+# Keep codex discoverable even when /workspace env vars are not loaded yet.
+if [ -x "${NPM_GLOBAL_PREFIX}/bin/codex" ]; then
+  ln -sfn "${NPM_GLOBAL_PREFIX}/bin/codex" /usr/local/bin/codex
+fi
+
+node --version
+npm --version
+codex --version
+
+# 5) Clone repositories into /workspace
+log "5) Clone git repositories into ${WORKTREE}"
+cd "${WORKTREE}"
+
+if [ ! -d openfhe-development ]; then
+  git clone https://github.com/MachinaIO/openfhe-development
+fi
+
+if [ ! -d mxx ]; then
+  git clone https://github.com/MachinaIO/mxx
+fi
+
+# 6) Build & install OpenFHE to /workspace/openfhe (if not already installed)
+log "6) Build & install OpenFHE to ${OPENFHE_PREFIX}"
+if [ -f "${OPENFHE_PREFIX}/lib/libOPENFHEcore.so" ] || [ -f "${OPENFHE_PREFIX}/lib/libOPENFHEcore.so.1" ]; then
+  echo "OpenFHE seems already installed at ${OPENFHE_PREFIX}; skipping build."
+else
+  cd "${WORKTREE}/openfhe-development"
+  git submodule update --init --recursive || true
+
+  mkdir -p build
+  cd build
+
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${OPENFHE_PREFIX}" \
+    -DBUILD_SHARED=ON \
+    -DBUILD_STATIC=OFF
+
+  make -j"$(nproc)"
+  make install
+fi
+
+# env.sh: source this on every shell/session.
+log "7) Write ${ENV_FILE} (quiet, automation-safe defaults)"
+cat > "${ENV_FILE}" <<'EOF'
+# Source this on every new instance / shell:
+#   source /workspace/env.sh
+#
+# This file is intentionally quiet and side-effect-free by default so that
+# non-interactive automation (for example MCP bridge scripts) can source it
+# safely without polluting stdout/stderr.
+#
+# Optional maintenance operations are provided as functions:
+# - workspace_bootstrap_system_deps_once
+# - workspace_link_openfhe_usr_local
+# - workspace_codex_login_if_needed
+# - workspace_configure_git_push_auth
+# Auto-run hooks are enabled by default; set WORKSPACE_ENV_AUTO_*=0 to disable.
+
+export WORKTREE="/workspace"
+export OPENFHE_PREFIX="/workspace/openfhe"
+
+export RUSTUP_HOME="/workspace/rustup"
+export CARGO_HOME="/workspace/cargo"
+export N_PREFIX="/workspace/n"
+export NPM_GLOBAL_PREFIX="/workspace/npm-global"
+export NPM_CONFIG_PREFIX="${NPM_GLOBAL_PREFIX}"
+export NPM_CONFIG_CACHE="/workspace/.npm-cache"
+export CODEX_HOME="/workspace/.codex"
+export NODE_PATH="${NPM_GLOBAL_PREFIX}/lib/node_modules:${NODE_PATH:-}"
+
+mkdir -p "${NPM_GLOBAL_PREFIX}" "${NPM_CONFIG_CACHE}" "${CODEX_HOME}"
+export PATH="${N_PREFIX}/bin:${NPM_GLOBAL_PREFIX}/bin:${CARGO_HOME}/bin:${PATH}"
+export LD_LIBRARY_PATH="/usr/local/lib:${OPENFHE_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+
+workspace_bootstrap_system_deps_once() {
+  local sentinel="/tmp/.workspace_bootstrap_apt_done_v4"
+  if [ -f "${sentinel}" ]; then
+    return 0
+  fi
+
+  if [ "$(id -u)" -ne 0 ]; then
+    return 1
+  fi
+
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -y
+  apt-get install -y ca-certificates gpg wget curl
+
+  test -f /usr/share/doc/kitware-archive-keyring/copyright || \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+      | gpg --dearmor - \
+      | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+
+  local codename
+  codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-jammy}")"
+  echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${codename} main" \
+    > /etc/apt/sources.list.d/kitware.list
+
+  apt-get update -y
+
+  test -f /usr/share/doc/kitware-archive-keyring/copyright || \
+    rm -f /usr/share/keyrings/kitware-archive-keyring.gpg
+
+  apt-get install -y kitware-archive-keyring
+  apt-get update -y
+
+  apt-get install -y \
+    cmake htop nvtop libtbb-dev \
+    git build-essential vim
+
+  touch "${sentinel}"
+}
+
+workspace_link_openfhe_usr_local() {
+  if [ ! -d "${OPENFHE_PREFIX}" ]; then
+    return 1
+  fi
+
+  if [ "$(id -u)" -ne 0 ]; then
+    return 1
+  fi
+
+  mkdir -p /usr/local/include /usr/local/lib /usr/local/lib/cmake
+
+  ln -sfn "${OPENFHE_PREFIX}/include/openfhe" /usr/local/include/openfhe
+
+  for f in "${OPENFHE_PREFIX}"/lib/libOPENFHE*.so*; do
+    [ -e "$f" ] || continue
+    ln -sf "$f" "/usr/local/lib/$(basename "$f")"
+  done
+
+  cfg_file="$(find "${OPENFHE_PREFIX}" -type f \( -name 'OpenFHEConfig.cmake' -o -name 'openfhe-config.cmake' \) -print -quit 2>/dev/null || true)"
+  if [ -n "${cfg_file}" ]; then
+    ln -sfn "$(dirname "${cfg_file}")" /usr/local/lib/cmake/OpenFHE
+  fi
+
+  command -v ldconfig >/dev/null 2>&1 && ldconfig >/dev/null 2>&1 || true
+}
+
+# workspace_codex_login_if_needed() {
+#   if ! command -v codex >/dev/null 2>&1; then
+#     return 1
+#   fi
+
+#   if codex login status >/dev/null 2>&1; then
+#     return 0
+#   fi
+
+#   if [ ! -t 0 ] || [ ! -t 1 ]; then
+#     return 1
+#   fi
+
+#   codex login --device-auth
+# }
+
+workspace_configure_git_push_auth() {
+  if ! command -v git >/dev/null 2>&1; then
+    return 1
+  fi
+
+  # Optional git identity for commits.
+  if [ -n "${RUNPOD_SECRET_GIT_USER_NAME:-}" ]; then
+    git config --global user.name "${RUNPOD_SECRET_GIT_USER_NAME}"
+  fi
+  if [ -n "${RUNPOD_SECRET_GIT_USER_EMAIL:-}" ]; then
+    git config --global user.email "${RUNPOD_SECRET_GIT_USER_EMAIL}"
+  fi
+
+  # Optional remote rewrite (HTTPS URL recommended for token-based auth).
+  local repo_dir="${WORKSPACE_GIT_REPO_DIR:-/workspace/mxx}"
+  local remote_name="${WORKSPACE_GIT_REMOTE:-origin}"
+  if [ -n "${WORKSPACE_GIT_REMOTE_URL:-}" ] && [ -d "${repo_dir}/.git" ]; then
+    if git -C "${repo_dir}" remote get-url "${remote_name}" >/dev/null 2>&1; then
+      git -C "${repo_dir}" remote set-url "${remote_name}" "${WORKSPACE_GIT_REMOTE_URL}"
+    else
+      git -C "${repo_dir}" remote add "${remote_name}" "${WORKSPACE_GIT_REMOTE_URL}"
+    fi
+  fi
+
+  # Token auth setup without persisting token to git config files.
+  if [ -z "${RUNPOD_SECRET_GIT_ACCESS_TOKEN:-}" ]; then
+    return 0
+  fi
+
+  local askpass_path="${WORKSPACE_GIT_ASKPASS_PATH:-/workspace/.git-askpass.sh}"
+  local askpass_dir
+  askpass_dir="$(dirname "${askpass_path}")"
+  mkdir -p "${askpass_dir}"
+
+  cat > "${askpass_path}" <<'EOS'
+#!/usr/bin/env bash
+case "${1:-}" in
+  *Username*) printf '%s\n' "${WORKSPACE_GIT_USERNAME:-x-access-token}" ;;
+  *Password*) printf '%s\n' "${RUNPOD_SECRET_GIT_ACCESS_TOKEN:-}" ;;
+  *) printf '\n' ;;
+esac
+EOS
+  chmod 700 "${askpass_path}"
+
+  export GIT_ASKPASS="${askpass_path}"
+  export GIT_TERMINAL_PROMPT=0
+
+  # Keep git behavior deterministic for automation sessions.
+  git config --global core.askPass "${askpass_path}"
+  git config --global --unset-all credential.helper >/dev/null 2>&1 || true
+}
+
+if [ "${WORKSPACE_ENV_AUTO_BOOTSTRAP:-1}" = "1" ]; then
+  workspace_bootstrap_system_deps_once || true
+fi
+if [ "${WORKSPACE_ENV_AUTO_LINK_OPENFHE:-1}" = "1" ]; then
+  workspace_link_openfhe_usr_local || true
+fi
+# if [ "${WORKSPACE_ENV_AUTO_CODEX_LOGIN:-1}" = "1" ]; then
+#   workspace_codex_login_if_needed || true
+# fi
+if [ "${WORKSPACE_ENV_AUTO_GIT_PUSH_AUTH:-1}" = "1" ]; then
+  workspace_configure_git_push_auth || true
+fi
+EOF
+
+# Apply env in current shell and create OpenFHE symlinks now.
+. "${ENV_FILE}"
+workspace_link_openfhe_usr_local || true
+
+log "DONE"
+echo "On every new instance/session, run:  source ${ENV_FILE}"


### PR DESCRIPTION
## Summary
- Add a new `bench-on-runpod` Codex skill for running mxx commands, tests, and benchmarks on Runpod instances
- Document the required workflow: confirm machine settings, push local changes, provision with scp-enabled SSH, sync `/workspace/mxx`, log runs, retrieve logs, and handle retry/cleanup decisions
- Bundle `scripts/setup.sh` into the skill and generate the skill metadata for discovery

## Testing
- `python3 /home/sora/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/bench-on-runpod` passed
- Verified the copied `scripts/setup.sh` matches the source file