### PR TITLE
Add DiamondIO error simulation and tighten noise-refresh bounds

### DIFF
--- a/src/bench_estimator/bgg_pubkey.rs
+++ b/src/bench_estimator/bgg_pubkey.rs
@@ -13,8 +13,8 @@ use num_traits::ToPrimitive;
 use tracing::debug;
 
 use super::{
-    BenchEstimator, CircuitBenchEstimate, benchmark_gate_operation, column_parallel_gate_estimate,
-    measure_bench_operation,
+    BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary, PublicKeyAuxBenchEstimator,
+    benchmark_gate_operation, column_parallel_gate_estimate, measure_bench_operation,
 };
 
 pub(crate) fn per_gate_time_estimate(time: f64, peak_vram: usize) -> CircuitBenchEstimate {
@@ -85,6 +85,15 @@ impl SampleAuxBenchEstimate {
             chunk_compact_bytes,
             base_compact_bytes,
         )
+    }
+
+    pub(crate) fn to_summary(&self) -> CircuitBenchSummary {
+        let max_parallelism = if self.total_time <= 0.0 || self.latency <= 0.0 {
+            0
+        } else {
+            (self.total_time / self.latency).ceil() as u128
+        };
+        CircuitBenchSummary::new(self.total_time, self.latency, max_parallelism)
     }
 }
 
@@ -370,6 +379,33 @@ where
     fn estimate_public_lookup(&self, lut_id: usize) -> CircuitBenchEstimate {
         let _ = lut_id;
         per_gate_time_estimate(self.public_lut_time, self.public_lut_peak_vram)
+    }
+}
+
+impl<M, PLE, STE> PublicKeyAuxBenchEstimator<M::P> for BggPublicKeyBenchEstimator<M, PLE, STE>
+where
+    M: PolyMatrix,
+    PLE: PublicLutSampleAuxBenchEstimator<M, Params = <M::P as Poly>::Params>,
+    STE: SlotTransferSampleAuxBenchEstimator<M, Params = <M::P as Poly>::Params>,
+{
+    fn estimate_public_lut_sample_aux_matrices_for_circuit(
+        &self,
+        params: &<M::P as Poly>::Params,
+        circuit: &crate::circuit::PolyCircuit<M::P>,
+    ) -> SampleAuxBenchEstimate {
+        let total_lut_gates = circuit
+            .count_gates_by_type_vec()
+            .get(&crate::circuit::PolyGateKind::PubLut)
+            .copied()
+            .unwrap_or(0);
+        if total_lut_gates == 0 {
+            return SampleAuxBenchEstimate::default();
+        }
+        self.estimate_public_lut_sample_aux_matrices(
+            params,
+            circuit.total_registered_public_lut_entries(),
+            total_lut_gates,
+        )
     }
 }
 

--- a/src/bench_estimator/bgg_pubkey.rs
+++ b/src/bench_estimator/bgg_pubkey.rs
@@ -21,6 +21,10 @@ pub(crate) fn per_gate_time_estimate(time: f64, peak_vram: usize) -> CircuitBenc
     CircuitBenchEstimate::new(time, time).with_peak_vram(peak_vram)
 }
 
+pub(crate) fn total_lut_preimage_count(total_lut_entries: usize, total_lut_gates: usize) -> u128 {
+    (total_lut_entries as u128) * (total_lut_gates as u128)
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SampleAuxBenchEstimate {
     pub total_time: f64,
@@ -371,7 +375,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::BggPublicKeyBenchEstimator;
+    use super::{BggPublicKeyBenchEstimator, total_lut_preimage_count};
     use crate::{
         __PAIR, __TestState,
         bench_estimator::{
@@ -424,6 +428,14 @@ mod tests {
         assert!(estimate.total_time.is_finite());
         assert_eq!(estimate.latency, 0.25);
         assert_eq!(estimate.compact_bytes, total_chunk_count * BigUint::from(3u8));
+    }
+
+    #[test]
+    fn total_lut_preimage_count_uses_u128_for_large_estimates() {
+        assert_eq!(
+            total_lut_preimage_count(usize::MAX, usize::MAX),
+            (usize::MAX as u128) * (usize::MAX as u128)
+        );
     }
 
     impl PublicLutSampleAuxBenchEstimator<DCRTPolyMatrix> for DummyPublicLutEstimator {

--- a/src/bench_estimator/mod.rs
+++ b/src/bench_estimator/mod.rs
@@ -37,8 +37,8 @@ use tracing::debug;
 
 use crate::{
     circuit::{
-        Evaluable, GroupedCallExecutionLayer, GroupedExecutionPlan, PolyCircuit, PolyGateType,
-        SubCircuitParamValue,
+        Evaluable, GroupedCallExecutionLayer, GroupedExecutionPlan, PolyCircuit, PolyGateKind,
+        PolyGateType, SubCircuitParamValue,
     },
     poly::Poly,
 };
@@ -396,6 +396,49 @@ pub trait BenchEstimator<E: Evaluable> {
             start.elapsed().as_secs_f64() * 1000.0
         );
         estimate
+    }
+}
+
+pub trait PublicKeyAuxBenchEstimator<P: Poly> {
+    fn estimate_public_lut_sample_aux_matrices_for_circuit(
+        &self,
+        params: &P::Params,
+        circuit: &PolyCircuit<P>,
+    ) -> SampleAuxBenchEstimate;
+}
+
+pub(crate) fn estimate_public_key_circuit_bench_with_aux<E, B>(
+    estimator: &B,
+    params: &<E::P as Poly>::Params,
+    circuit: &PolyCircuit<E::P>,
+) -> CircuitBenchSummary
+where
+    E: Evaluable,
+    B: BenchEstimator<E> + PublicKeyAuxBenchEstimator<E::P> + Sync,
+{
+    let circuit_eval = estimator.estimate_circuit_bench(circuit);
+    let aux = estimator.estimate_public_lut_sample_aux_matrices_for_circuit(params, circuit);
+    let aux_summary = aux.to_summary();
+    debug!(
+        public_lut_gate_count =
+            circuit.count_gates_by_type_vec().get(&PolyGateKind::PubLut).copied().unwrap_or(0),
+        public_lut_entry_count = circuit.total_registered_public_lut_entries(),
+        ?aux,
+        ?aux_summary,
+        "estimated public-key circuit Public LUT auxiliary sampling"
+    );
+    let summary = CircuitBenchSummary::new(
+        circuit_eval.total_time + aux_summary.total_time,
+        circuit_eval.latency + aux_summary.latency,
+        circuit_eval.max_parallelism.max(aux_summary.max_parallelism),
+    );
+    #[cfg(feature = "gpu")]
+    {
+        summary.with_peak_vram(circuit_eval.peak_vram.max(aux_summary.peak_vram))
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        summary
     }
 }
 

--- a/src/bench_estimator/naive_vec.rs
+++ b/src/bench_estimator/naive_vec.rs
@@ -1,11 +1,15 @@
 use crate::{
-    bench_estimator::{BenchEstimator, CircuitBenchEstimate, benchmark_gate_operation},
+    bench_estimator::{
+        BenchEstimator, CircuitBenchEstimate, PublicKeyAuxBenchEstimator, SampleAuxBenchEstimate,
+        benchmark_gate_operation,
+    },
     bgg::{
         encoding::BggEncoding,
         naive_vec::{NaiveBGGEncodingVec, NaiveBGGPublicKeyVec},
         public_key::BggPublicKey,
     },
     matrix::PolyMatrix,
+    poly::Poly,
 };
 use num_bigint::BigUint;
 
@@ -29,6 +33,20 @@ fn scale_single_slot_estimate(
     #[cfg(not(feature = "gpu"))]
     {
         scaled
+    }
+}
+
+fn scale_single_slot_sample_aux(
+    estimate: SampleAuxBenchEstimate,
+    num_slots: usize,
+) -> SampleAuxBenchEstimate {
+    SampleAuxBenchEstimate {
+        total_time: estimate.total_time * num_slots as f64,
+        // Public LUT auxiliary matrices for different naive-vector slots are independent. With
+        // enough GPUs, all slots can be sampled in the same wave, so latency stays at the scalar
+        // slot latency while total work and persisted compact bytes scale by slot count.
+        latency: estimate.latency,
+        compact_bytes: estimate.compact_bytes * BigUint::from(num_slots),
     }
 }
 
@@ -218,6 +236,23 @@ where
 
     fn estimate_public_lookup(&self, lut_id: usize) -> CircuitBenchEstimate {
         self.scale_with_io(self.inner.estimate_public_lookup(lut_id), self.num_slots, 1, 1)
+    }
+}
+
+impl<P, BE> PublicKeyAuxBenchEstimator<P> for NaiveBGGVecBenchEstimator<BE>
+where
+    P: Poly,
+    BE: PublicKeyAuxBenchEstimator<P>,
+{
+    fn estimate_public_lut_sample_aux_matrices_for_circuit(
+        &self,
+        params: &P::Params,
+        circuit: &crate::circuit::PolyCircuit<P>,
+    ) -> SampleAuxBenchEstimate {
+        scale_single_slot_sample_aux(
+            self.inner.estimate_public_lut_sample_aux_matrices_for_circuit(params, circuit),
+            self.num_slots,
+        )
     }
 }
 

--- a/src/func_enc/aky24/dec_bench.rs
+++ b/src/func_enc/aky24/dec_bench.rs
@@ -9,6 +9,7 @@ use crate::{
     gadgets::arith::{DecomposeArithmeticGadget, ModularArithmeticPlanner, NestedRnsPoly},
     matrix::PolyMatrix,
     noise_refresh::NoiseRefresherNaiveVec,
+    sampler::PolyHashSampler,
 };
 
 /// Shape parameters needed to estimate AKY24 decryption.
@@ -93,6 +94,7 @@ impl<'a, EncBE> Aky24DecBenchEstimator<'a, EncBE> {
         M: PolyMatrix + Send + Sync + 'static,
         M::P: 'static,
         EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        SH: PolyHashSampler<[u8; 32], M = M>,
         NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
     {
         assert!(shape.wire_count > 0, "wire_count must be positive");
@@ -164,6 +166,7 @@ impl<'a, EncBE> Aky24DecBenchEstimator<'a, EncBE> {
         M: PolyMatrix + Send + Sync + 'static,
         M::P: 'static,
         EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        SH: PolyHashSampler<[u8; 32], M = M>,
         NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
     {
         let generated_seed_bits =

--- a/src/func_enc/aky24/error_simulation.rs
+++ b/src/func_enc/aky24/error_simulation.rs
@@ -38,8 +38,6 @@ pub struct Aky24CrtDepthSearchCandidate<TD> {
     pub params: Aky24Params<DCRTPolyMatrix, TD>,
     /// Decryption error-simulation inputs that use the same simulator context as `params`.
     pub inputs: Aky24DecErrorSimulationInputs,
-    /// Bound for the secret term used by the noise-refresh rounding check.
-    pub secret_norm: PolyMatrixNorm,
     /// Error-norm representation of the circuit constant one.
     pub one: ErrorNorm,
     /// Error bound for the Ring-GSW decryption-key input.
@@ -235,7 +233,6 @@ pub fn simulate_aky24_dec_error<TD, PE, ST>(
     inputs: Aky24DecErrorSimulationInputs,
     ring_gsw_error_sigma: f64,
     num_slots: usize,
-    secret_norm: &PolyMatrixNorm,
     one: ErrorNorm,
     decryption_key: ErrorNorm,
     decoders: &[ErrorNorm],
@@ -303,7 +300,6 @@ where
             params.noise_refresh_cbd_n,
             ring_gsw_error_sigma,
             num_slots,
-            secret_norm,
             one.clone(),
             prg_output_error,
             &current_seed_errors,
@@ -393,7 +389,6 @@ pub fn max_safe_aky24_prf_mask_output_coeff_bits<TD, PE, ST>(
     inputs: Aky24DecErrorSimulationInputs,
     ring_gsw_error_sigma: f64,
     num_slots: usize,
-    secret_norm: &PolyMatrixNorm,
     one: ErrorNorm,
     decryption_key: ErrorNorm,
     decoders: &[ErrorNorm],
@@ -421,7 +416,6 @@ where
             inputs.clone(),
             ring_gsw_error_sigma,
             num_slots,
-            secret_norm,
             one.clone(),
             decryption_key.clone(),
             decoders,
@@ -502,7 +496,6 @@ where
             candidate.inputs.clone(),
             ring_gsw_error_sigma,
             num_slots,
-            &candidate.secret_norm,
             candidate.one.clone(),
             candidate.decryption_key.clone(),
             &candidate.decoders,
@@ -521,7 +514,6 @@ where
         if aky24_security_margins_hold(
             &checked_params,
             &mask_search.simulation,
-            &candidate.secret_norm,
             mask_bits,
             security_bit,
         ) {
@@ -547,7 +539,6 @@ where
 fn aky24_security_margins_hold<TD>(
     params: &Aky24Params<DCRTPolyMatrix, TD>,
     simulation: &Aky24DecErrorSimulation,
-    secret_norm: &PolyMatrixNorm,
     prf_mask_output_coeff_bits: usize,
     security_bit: usize,
 ) -> bool {
@@ -564,8 +555,7 @@ fn aky24_security_margins_hold<TD>(
         return false;
     }
     simulation.prf_seed_bit_refreshes.iter().all(|refresh| {
-        let Some(threshold) =
-            noise_refresh_pre_round_margin(&params.poly_params, secret_norm, refresh.v_bits)
+        let Some(threshold) = noise_refresh_pre_round_margin(&params.poly_params, refresh.v_bits)
         else {
             return false;
         };
@@ -593,7 +583,6 @@ fn aky24_final_decode_margin(
 
 fn noise_refresh_pre_round_margin(
     params: &<DCRTPoly as crate::poly::Poly>::Params,
-    secret_norm: &PolyMatrixNorm,
     v_bits: usize,
 ) -> Option<BigDecimal> {
     let (q_moduli, _crt_bits, _crt_depth) = params.to_crt();
@@ -602,8 +591,7 @@ fn noise_refresh_pre_round_margin(
     let threshold =
         biguint_to_decimal(full_q.as_ref()) / (BigDecimal::from(2u32) * BigDecimal::from(q_max));
     let mask = biguint_to_decimal(&(BigUint::from(1u32) << v_bits));
-    let used_margin = &secret_norm.poly_norm.norm + mask;
-    (threshold > used_margin).then_some(threshold - used_margin)
+    (threshold > mask).then_some(threshold - mask)
 }
 
 /// Evaluates the AKY24 function circuit and returns the first decoded output's matrix error.
@@ -865,13 +853,6 @@ mod tests {
                     PolyNorm::one(ctx.clone()),
                     PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_g, BigDecimal::from(0u32), None),
                 );
-                let secret_norm = PolyMatrixNorm::new(
-                    ctx.clone(),
-                    1,
-                    ctx.secret_size,
-                    BigDecimal::from(0u32),
-                    None,
-                );
                 let decoder = ErrorNorm::new(
                     PolyNorm::one(ctx.clone()),
                     PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_g, BigDecimal::from(0u32), None),
@@ -879,7 +860,6 @@ mod tests {
                 Aky24CrtDepthSearchCandidate {
                     params,
                     inputs,
-                    secret_norm,
                     one,
                     decryption_key,
                     decoders: vec![decoder],

--- a/src/func_enc/aky24/keygen_bench.rs
+++ b/src/func_enc/aky24/keygen_bench.rs
@@ -1,5 +1,8 @@
 use crate::{
-    bench_estimator::{BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary},
+    bench_estimator::{
+        BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary, PublicKeyAuxBenchEstimator,
+        estimate_public_key_circuit_bench_with_aux,
+    },
     bgg::naive_vec::NaiveBGGPublicKeyVec,
     func_enc::aky24::{
         Aky24Func, Aky24Params, build_func_circuit, build_goldreich_prg_circuit,
@@ -9,6 +12,7 @@ use crate::{
     matrix::PolyMatrix,
     noise_refresh::NoiseRefresherNaiveVec,
     poly::PolyParams,
+    sampler::PolyHashSampler,
 };
 
 /// Shape parameters that are not directly inferable from `Aky24Params` for keygen estimation.
@@ -85,13 +89,19 @@ impl<'a, PKBE> Aky24KeygenBenchEstimator<'a, PKBE> {
         M: PolyMatrix + Send + Sync + 'static,
         M::P: 'static,
         PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
+        SH: PolyHashSampler<[u8; 32], M = M>,
         NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
     {
         assert!(shape.wire_count > 0, "wire_count must be positive");
         assert!(shape.public_prf_seed_bits > 0, "public_prf_seed_bits must be positive");
 
         let function_circuit =
-            self.public_key_estimator.estimate_circuit_bench(&build_func_circuit(params, func));
+            estimate_public_key_circuit_bench_with_aux::<NaiveBGGPublicKeyVec<M>, PKBE>(
+                self.public_key_estimator,
+                &params.poly_params,
+                &build_func_circuit(params, func),
+            );
         let selected_half_prg = self.estimate_selected_half_prg(params, shape);
         let noise_refresh_preprocess =
             self.estimate_noise_refresh_preprocess::<M, SH, TD>(params, shape);
@@ -130,6 +140,7 @@ impl<'a, PKBE> Aky24KeygenBenchEstimator<'a, PKBE> {
         M: PolyMatrix + Send + Sync + 'static,
         M::P: 'static,
         PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
     {
         let generated_seed_bits =
             if params.debug_reuse_single_prg_sample() { 1 } else { params.prf_seed_bits() };
@@ -140,7 +151,11 @@ impl<'a, PKBE> Aky24KeygenBenchEstimator<'a, PKBE> {
             0,
             generated_seed_bits,
         );
-        let unit = self.public_key_estimator.estimate_circuit_bench(&circuit);
+        let unit = estimate_public_key_circuit_bench_with_aux::<NaiveBGGPublicKeyVec<M>, PKBE>(
+            self.public_key_estimator,
+            &params.poly_params,
+            &circuit,
+        );
         scale_summary(unit, shape.public_prf_seed_bits)
     }
 
@@ -157,6 +172,8 @@ impl<'a, PKBE> Aky24KeygenBenchEstimator<'a, PKBE> {
         M: PolyMatrix + Send + Sync + 'static,
         M::P: 'static,
         PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
+        SH: PolyHashSampler<[u8; 32], M = M>,
         NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
     {
         let generated_seed_bits =
@@ -187,6 +204,7 @@ impl<'a, PKBE> Aky24KeygenBenchEstimator<'a, PKBE> {
         M: PolyMatrix + Send + Sync + 'static,
         M::P: 'static,
         PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
     {
         let generated_mask_output_bits = if params.debug_reuse_single_prg_sample() {
             1
@@ -198,7 +216,11 @@ impl<'a, PKBE> Aky24KeygenBenchEstimator<'a, PKBE> {
             shape.public_prf_seed_bits,
             generated_mask_output_bits,
         );
-        self.public_key_estimator.estimate_circuit_bench(&circuit)
+        estimate_public_key_circuit_bench_with_aux::<NaiveBGGPublicKeyVec<M>, PKBE>(
+            self.public_key_estimator,
+            &params.poly_params,
+            &circuit,
+        )
     }
 
     /// Estimates the final scalar mask-decrypt circuit evaluated during keygen.
@@ -209,9 +231,14 @@ impl<'a, PKBE> Aky24KeygenBenchEstimator<'a, PKBE> {
         M: PolyMatrix + Send + Sync + 'static,
         M::P: 'static,
         PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
     {
         let circuit = build_prf_mask_circuit(params);
-        self.public_key_estimator.estimate_circuit_bench(&circuit)
+        estimate_public_key_circuit_bench_with_aux::<NaiveBGGPublicKeyVec<M>, PKBE>(
+            self.public_key_estimator,
+            &params.poly_params,
+            &circuit,
+        )
     }
 
     /// Estimates all trapdoor preimage samplings performed by keygen.

--- a/src/gadgets/fhe/ring_gsw.rs
+++ b/src/gadgets/fhe/ring_gsw.rs
@@ -374,7 +374,21 @@ impl<P: Poly + 'static, A: DecomposeArithmeticGadget<P> + ModularArithmeticPlann
             circuit.register_sub_circuit(Arc::clone(&super_batch_subcircuit));
         let width_tail_columns = width % super_batch_columns;
         let width_tail_subcircuit_id = if width_tail_columns > 0 {
-            let width_tail_batch_tail_columns = width_tail_columns % batch_columns;
+            let width_tail_batch_columns = batch_columns.min(width_tail_columns);
+            let width_tail_batch_subcircuit = if width_tail_batch_columns == batch_columns {
+                Arc::clone(&batch_subcircuit)
+            } else {
+                Arc::new(Self::mul_columns_batch_subcircuit(
+                    source_circuit,
+                    template_ctx,
+                    active_levels,
+                    level_offset,
+                    width,
+                    width_tail_batch_columns,
+                    Arc::clone(&mul_column_subcircuit),
+                ))
+            };
+            let width_tail_batch_tail_columns = width_tail_columns % width_tail_batch_columns;
             let width_tail_batch_tail_subcircuit = (width_tail_batch_tail_columns > 0).then(|| {
                 Arc::new(Self::mul_columns_batch_subcircuit(
                     source_circuit,
@@ -393,8 +407,8 @@ impl<P: Poly + 'static, A: DecomposeArithmeticGadget<P> + ModularArithmeticPlann
                 level_offset,
                 width,
                 width_tail_columns,
-                batch_columns,
-                Arc::clone(&batch_subcircuit),
+                width_tail_batch_columns,
+                width_tail_batch_subcircuit,
                 width_tail_batch_tail_subcircuit,
             ))))
         } else {
@@ -2860,6 +2874,24 @@ mod tests {
             expected_coeffs_for_slots(expected, ctx.num_slots),
             "Montgomery-backed chained Ring-GSW multiplication should decrypt to the plaintext-modulus product for x1={x1}, x2={x2}, x3={x3}",
         );
+    }
+
+    #[test]
+    fn test_nested_rns_ring_gsw_mul_context_handles_width_tail_narrower_than_batch() {
+        let mut circuit = PolyCircuit::<DCRTPoly>::new();
+        let active_levels = 15usize;
+
+        let (_params, ctx) = create_test_context_with(
+            &mut circuit,
+            NUM_SLOTS as u32,
+            NUM_SLOTS,
+            active_levels,
+            CRT_BITS,
+            P_MODULI_BITS,
+            DEFAULT_MAX_UNREDUCED_MULS,
+        );
+
+        assert_eq!(ctx.width() % (MUL_COLUMN_SUBCIRCUIT_BATCH * MUL_COLUMN_SUBCIRCUIT_BATCH), 2);
     }
 
     #[sequential_test::sequential]

--- a/src/input_injector/mod.rs
+++ b/src/input_injector/mod.rs
@@ -1092,6 +1092,7 @@ mod tests {
         }
 
         assert_eq!(simulated.state_errors, expected_state_errors);
+        assert_eq!(simulated.secret_state_factors, expected_secret_factors);
         assert_eq!(simulated.output_preimage, expected_output);
     }
 

--- a/src/input_injector/simulation.rs
+++ b/src/input_injector/simulation.rs
@@ -23,6 +23,13 @@ use tracing::debug;
 pub struct DiamondInputErrorSimulation {
     /// Final propagated error for each Diamond state branch.
     pub state_errors: Vec<PolyMatrixNorm>,
+    /// Final secret-selector norm for each Diamond state branch.
+    ///
+    /// These factors model the product of the secret transition matrices that
+    /// multiply the sampled Gaussian target errors. Callers that need a bound
+    /// on the final online secret, such as noise-refresh rounding analysis,
+    /// should use the factor for the branch they decode from.
+    pub secret_state_factors: Vec<PolyMatrixNorm>,
     /// Generic final projection preimage norm from the final state basis to a
     /// single BGG output public key.
     pub output_preimage: PolyMatrixNorm,
@@ -150,11 +157,12 @@ where
         }
 
         debug!(
+            ?secret_state_factors,
             ?state_errors,
             ?output_preimage,
             "diamond input-insertion simulator final state bounds",
         );
 
-        DiamondInputErrorSimulation { state_errors, output_preimage }
+        DiamondInputErrorSimulation { state_errors, secret_state_factors, output_preimage }
     }
 }

--- a/src/io/diamond_io.rs
+++ b/src/io/diamond_io.rs
@@ -46,7 +46,10 @@ use crate::{
 use super::Obfuscation;
 
 mod circuits;
+pub mod simulation;
 mod utils;
+
+pub use simulation::{DiamondIOErrorSimulation, DiamondIOPrfRoundErrorSimulation};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Function families supported by the Diamond iO wrapper.

--- a/src/io/diamond_io.rs
+++ b/src/io/diamond_io.rs
@@ -49,7 +49,11 @@ mod circuits;
 pub mod simulation;
 mod utils;
 
-pub use simulation::{DiamondIOErrorSimulation, DiamondIOPrfRoundErrorSimulation};
+pub use simulation::{
+    DiamondIOCrtDepthSearchResult, DiamondIOErrorSimulation,
+    DiamondIOPrfMaskOutputCoeffBitsSearchResult, DiamondIOPrfRoundErrorSimulation,
+    diamond_io_find_crt_depth,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Function families supported by the Diamond iO wrapper.

--- a/src/io/diamond_io.rs
+++ b/src/io/diamond_io.rs
@@ -45,10 +45,16 @@ use crate::{
 
 use super::Obfuscation;
 
+pub mod bench_estimator;
 mod circuits;
 pub mod simulation;
 mod utils;
 
+#[cfg(feature = "gpu")]
+pub use bench_estimator::GpuDCRTPolyMatrixNativeBenchEstimator;
+pub use bench_estimator::{
+    DiamondIOBenchEstimate, DiamondIOBenchEstimator, DiamondIONativeBenchEstimator,
+};
 pub use simulation::{
     DiamondIOCrtDepthSearchResult, DiamondIOErrorSimulation,
     DiamondIOPrfMaskOutputCoeffBitsSearchResult, DiamondIOPrfRoundErrorSimulation,

--- a/src/io/diamond_io/bench_estimator.rs
+++ b/src/io/diamond_io/bench_estimator.rs
@@ -1,0 +1,950 @@
+#[path = "bench_estimator_native.rs"]
+mod bench_estimator_native;
+#[path = "bench_estimator_shape.rs"]
+mod bench_estimator_shape;
+#[path = "bench_estimator_utils.rs"]
+mod bench_estimator_utils;
+
+use num_bigint::BigUint;
+use tracing::debug;
+
+use crate::{
+    bench_estimator::{
+        BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary, PublicKeyAuxBenchEstimator,
+        benchmark_gate_operation, estimate_public_key_circuit_bench_with_aux,
+    },
+    bgg::{
+        naive_vec::{NaiveBGGEncodingVec, NaiveBGGPublicKeyVec},
+        sampler::BGGPublicKeySampler,
+    },
+    gadgets::{
+        arith::{DecomposeArithmeticGadget, ModularArithmeticPlanner, NestedRnsPoly},
+        fhe::ring_gsw_nested_rns::{encrypt_plaintext_bit, sample_public_key},
+    },
+    matrix::PolyMatrix,
+    noise_refresh::NoiseRefresherNaiveVec,
+    poly::{Poly, PolyParams, dcrt::poly::DCRTPoly},
+    sampler::{DistType, PolyHashSampler, PolyTrapdoorSampler, PolyUniformSampler},
+    slot_transfer::bgg_pubkey::column_chunk_bounds,
+};
+
+pub use bench_estimator_native::DiamondIONativeBenchEstimator;
+#[cfg(feature = "gpu")]
+pub use bench_estimator_native::GpuDCRTPolyMatrixNativeBenchEstimator;
+
+use bench_estimator_shape::{
+    DiamondIOBenchShape, DiamondIOStorageEstimate, diamond_function_circuit,
+};
+use bench_estimator_utils::{
+    estimate_summary, parallel_summaries, repeat_sequential_summary, scale_estimate, scale_summary,
+    sequential_summaries,
+};
+
+use super::{DIAMOND_SECRET_SIZE, DiamondIO, DiamondIOFuncType};
+
+/// Combined DiamondIO benchmark estimate for `obfuscation` and `eval`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiamondIOBenchEstimate {
+    /// Final benchmark estimate for `DiamondIO::obfuscation`.
+    pub obfuscate: CircuitBenchSummary,
+    /// Final benchmark estimate for `DiamondIO::eval`.
+    pub eval: CircuitBenchSummary,
+    /// Input-injection work performed by `DiamondInjector::preprocess` during obfuscation.
+    pub obfuscate_input_injection: CircuitBenchSummary,
+    /// Input-injection online evaluation work performed during `DiamondIO::eval`.
+    pub eval_input_injection: CircuitBenchSummary,
+    /// Total compact bytes written as the persisted obfuscated circuit artifacts.
+    pub obfuscated_circuit_bytes: BigUint,
+    /// Compact bytes contributed by the Diamond input-injection artifacts.
+    pub input_injection_bytes: BigUint,
+}
+
+/// Composes existing circuit and noise-refresh estimators into DiamondIO estimates.
+///
+/// The constructor benchmarks the DiamondIO-specific sampler and native Ring-GSW unit costs from
+/// the supplied `DiamondIO` parameters. The estimator then composes those measured units with the
+/// caller-supplied circuit and native arithmetic estimators according to the DiamondIO dependency
+/// graph and task counts.
+#[derive(Debug, Clone)]
+pub struct DiamondIOBenchEstimator<'a, PKBE, EncBE, NBE> {
+    /// Benchmark estimator for public-key circuit operations used by obfuscation.
+    pub public_key_estimator: &'a PKBE,
+    /// Benchmark estimator for encoding circuit operations used by eval.
+    pub encoding_estimator: &'a EncBE,
+    /// Cost model for sampling one Diamond trapdoor/public-matrix checkpoint.
+    pub trapdoor_checkpoint: CircuitBenchEstimate,
+    /// Cost model for one `preimage_extend` call.
+    pub trapdoor_preimage_extend: CircuitBenchEstimate,
+    /// Cost model for one ordinary final-output `preimage_extend` call.
+    pub final_output_preimage_extend: CircuitBenchEstimate,
+    /// Cost model for the lookup-table bridge `preimage_extend` call.
+    pub lookup_bridge_preimage_extend: CircuitBenchEstimate,
+    /// Cost model for hashing one full Diamond W block.
+    pub full_w_block_hash_sample: CircuitBenchEstimate,
+    /// Cost model for hashing one W-column chunk used while building transition targets.
+    pub transition_w_chunk_hash_sample: CircuitBenchEstimate,
+    /// Size-aware estimator for native polynomial-vector arithmetic.
+    pub native_estimator: &'a NBE,
+    /// Cost model for sampling one scalar BGG public key.
+    pub bgg_public_key_sample: CircuitBenchEstimate,
+    /// Cost model for sampling one native Ring-GSW public key.
+    pub ring_gsw_public_key_sample: CircuitBenchEstimate,
+    /// Cost model for encrypting one native Ring-GSW seed bit.
+    pub ring_gsw_encrypt_bit: CircuitBenchEstimate,
+}
+
+impl<'a, PKBE, EncBE, NBE> DiamondIOBenchEstimator<'a, PKBE, EncBE, NBE>
+where
+    NBE: DiamondIONativeBenchEstimator,
+{
+    /// Creates a DiamondIO estimator and measures DiamondIO-specific unit costs.
+    pub fn new<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        public_key_estimator: &'a PKBE,
+        encoding_estimator: &'a EncBE,
+        native_estimator: &'a NBE,
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        iterations: usize,
+    ) -> Self
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+    {
+        let units = Self::benchmark_unit_costs(diamond, iterations);
+        Self {
+            public_key_estimator,
+            encoding_estimator,
+            native_estimator,
+            trapdoor_checkpoint: units.trapdoor_checkpoint,
+            trapdoor_preimage_extend: units.trapdoor_preimage_extend,
+            final_output_preimage_extend: units.final_output_preimage_extend,
+            lookup_bridge_preimage_extend: units.lookup_bridge_preimage_extend,
+            full_w_block_hash_sample: units.full_w_block_hash_sample,
+            transition_w_chunk_hash_sample: units.transition_w_chunk_hash_sample,
+            bgg_public_key_sample: units.bgg_public_key_sample,
+            ring_gsw_public_key_sample: units.ring_gsw_public_key_sample,
+            ring_gsw_encrypt_bit: units.ring_gsw_encrypt_bit,
+        }
+    }
+
+    fn benchmark_unit_costs<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        iterations: usize,
+    ) -> DiamondIOBenchUnitEstimates
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+    {
+        let iterations = iterations.max(1);
+        let params = &diamond.injector.params;
+        let shape = DiamondIOBenchShape::from_diamond(diamond);
+        let state_row_size = 2usize
+            .checked_mul(DIAMOND_SECRET_SIZE)
+            .expect("DiamondIO benchmark state row size overflow");
+        let gadget_col_size = DIAMOND_SECRET_SIZE
+            .checked_mul(params.modulus_digits())
+            .expect("DiamondIO benchmark gadget column count overflow");
+
+        // Mirrors `DiamondInjector::load_or_sample_b_checkpoint`: sample one trapdoor/public
+        // matrix pair for the Diamond state row size, then serialize both artifacts because the
+        // concrete preprocessing path persists them as checkpoint files.
+        let trapdoor_checkpoint = bench_estimate(iterations, || {
+            let trap_sampler = TS::new(params, diamond.injector.trapdoor_sigma);
+            let (trapdoor, matrix) = trap_sampler.trapdoor(params, state_row_size);
+            (TS::trapdoor_to_bytes(&trapdoor), matrix.to_compact_bytes())
+        });
+
+        let trap_sampler = TS::new(params, diamond.injector.trapdoor_sigma);
+        let (trapdoor, public_matrix) = trap_sampler.trapdoor(params, state_row_size);
+        let ext_matrix = HS::new().sample_hash(
+            params,
+            [0x51u8; 32],
+            b"diamond_io_bench_preimage_extend_ext",
+            state_row_size,
+            gadget_col_size,
+            DistType::FinRingDist,
+        );
+        let transition_chunk_len = column_chunk_bounds(shape.state_col_size, 0).1;
+        let transition_target = M::zero(params, state_row_size, transition_chunk_len);
+
+        // Mirrors one chunked `preimage_extend` call in Diamond input injection and final decoder
+        // preprocessing. The target has one maximum-size persisted chunk; narrower tail chunks are
+        // conservatively charged at this same unit cost by the higher-level estimator.
+        let trapdoor_preimage_extend = bench_estimate(iterations, || {
+            let preimage = trap_sampler.preimage_extend(
+                params,
+                &trapdoor,
+                &public_matrix,
+                &ext_matrix,
+                &transition_target,
+            );
+            preimage.to_compact_bytes()
+        });
+
+        let final_output_target = M::zero(params, state_row_size, gadget_col_size);
+        let final_output_preimage_extend = bench_estimate(iterations, || {
+            let preimage = trap_sampler.preimage_extend(
+                params,
+                &trapdoor,
+                &public_matrix,
+                &ext_matrix,
+                &final_output_target,
+            );
+            preimage.to_compact_bytes()
+        });
+
+        let lookup_bridge_target = M::zero(params, state_row_size, shape.lookup_bridge_cols);
+        let lookup_bridge_preimage_extend = bench_estimate(iterations, || {
+            let preimage = trap_sampler.preimage_extend(
+                params,
+                &trapdoor,
+                &public_matrix,
+                &ext_matrix,
+                &lookup_bridge_target,
+            );
+            preimage.to_compact_bytes()
+        });
+
+        let full_w_block_hash_sample = bench_estimate(iterations, || {
+            let matrix = HS::new().sample_hash(
+                params,
+                [0x52u8; 32],
+                b"diamond_io_bench_full_w_block_hash",
+                state_row_size,
+                gadget_col_size,
+                DistType::FinRingDist,
+            );
+            matrix.to_compact_bytes()
+        });
+
+        let transition_w_chunk_hash_sample = bench_estimate(iterations, || {
+            let matrix = HS::new().sample_hash_columns(
+                params,
+                [0x53u8; 32],
+                b"diamond_io_bench_transition_w_chunk_hash",
+                state_row_size,
+                gadget_col_size,
+                0,
+                shape.transition_w_hash_max_col_len,
+                DistType::FinRingDist,
+            );
+            matrix.to_compact_bytes()
+        });
+
+        let mut bgg_public_key_tag = diamond.bgg_tag.clone();
+        bgg_public_key_tag.extend_from_slice(b":public_keys");
+        let bgg_public_key_sample = bench_estimate(iterations, || {
+            BGGPublicKeySampler::<[u8; 32], HS>::new([0x5au8; 32], 1).sample(
+                params,
+                &bgg_public_key_tag,
+                &[],
+            )
+        });
+
+        let native_secret =
+            sample_native_ternary_secret::<M, US>(params, &diamond.native_poly_params);
+        let ring_gsw_public_key = sample_public_key(
+            &diamond.native_poly_params,
+            diamond.ring_gsw_width,
+            &native_secret,
+            [0x6du8; 32],
+            b"diamond_io_bench_ring_gsw_public_key",
+            diamond.ring_gsw_public_key_error_sigma,
+        );
+
+        let ring_gsw_public_key_sample = bench_estimate(iterations, || {
+            sample_public_key(
+                &diamond.native_poly_params,
+                diamond.ring_gsw_width,
+                &native_secret,
+                [0x6du8; 32],
+                b"diamond_io_bench_ring_gsw_public_key",
+                diamond.ring_gsw_public_key_error_sigma,
+            )
+        });
+
+        let ring_gsw_encrypt_bit = bench_estimate(iterations, || {
+            encrypt_plaintext_bit(
+                &diamond.native_poly_params,
+                diamond.ring_gsw_context.as_ref(),
+                &ring_gsw_public_key,
+                true,
+            )
+        });
+
+        debug!(
+            ?trapdoor_checkpoint,
+            ?trapdoor_preimage_extend,
+            ?final_output_preimage_extend,
+            ?lookup_bridge_preimage_extend,
+            ?full_w_block_hash_sample,
+            ?transition_w_chunk_hash_sample,
+            ?bgg_public_key_sample,
+            ?ring_gsw_public_key_sample,
+            ?ring_gsw_encrypt_bit,
+            "measured DiamondIO benchmark unit costs"
+        );
+
+        DiamondIOBenchUnitEstimates {
+            trapdoor_checkpoint,
+            trapdoor_preimage_extend,
+            final_output_preimage_extend,
+            lookup_bridge_preimage_extend,
+            full_w_block_hash_sample,
+            transition_w_chunk_hash_sample,
+            bgg_public_key_sample,
+            ring_gsw_public_key_sample,
+            ring_gsw_encrypt_bit,
+        }
+    }
+
+    /// Estimates DiamondIO `obfuscation` and `eval` for the selected function family.
+    pub fn estimate<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        &self,
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        func: DiamondIOFuncType,
+    ) -> DiamondIOBenchEstimate
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+        PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
+        EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
+    {
+        match func {
+            DiamondIOFuncType::DebugDecryption => {
+                assert_eq!(
+                    diamond.output_size, diamond.seed_bits,
+                    "DebugDecryption output_size must equal seed_bits for benchmark estimation"
+                );
+            }
+        }
+        assert!(
+            diamond.prf_mask_output_coeff_bits > 0,
+            "DiamondIO bench estimation requires positive prf_mask_output_coeff_bits"
+        );
+
+        let shape = DiamondIOBenchShape::from_diamond(diamond);
+        let input_injection = self.estimate_input_injection(diamond, shape.clone());
+        let storage = self.estimate_storage(diamond, shape.clone());
+        let obfuscate =
+            self.estimate_obfuscate(diamond, func, shape.clone(), &input_injection, &storage);
+        let eval = self.estimate_eval(diamond, func, shape, &storage);
+        DiamondIOBenchEstimate {
+            obfuscate,
+            eval,
+            obfuscate_input_injection: input_injection.obfuscate,
+            eval_input_injection: input_injection.eval,
+            obfuscated_circuit_bytes: storage.total_bytes,
+            input_injection_bytes: storage.input_injection_bytes,
+        }
+    }
+
+    fn estimate_obfuscate<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        &self,
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        func: DiamondIOFuncType,
+        shape: DiamondIOBenchShape,
+        input_injection: &DiamondIOInputInjectionBenchEstimateParts,
+        persisted_storage: &DiamondIOStorageEstimate,
+    ) -> CircuitBenchSummary
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+        PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
+        EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
+    {
+        let params = &diamond.injector.params;
+        let ring_dim = params.ring_dimension() as usize;
+        let scalar_one = vec![BigUint::from(1u32); ring_dim];
+
+        // Corresponds to `sample_bgg_public_keys`: one scalar key for constant one, one for `k`,
+        // and one per explicit Diamond input bit. The implementation uses one hash-sampler call,
+        // but the produced columns are independent public matrices, so the GPU estimate scales the
+        // supplied one-key unit across all keys.
+        let bgg_public_key_sampling =
+            scale_estimate(self.bgg_public_key_sample, diamond.input_size + 2);
+
+        // Corresponds to `sample_public_key` for the native Ring-GSW key encrypting the private
+        // seed bits.
+        let ring_gsw_public_key_sampling = estimate_summary(self.ring_gsw_public_key_sample);
+
+        // Corresponds to the seed loop in `obfuscation`: each private seed bit is encrypted
+        // natively, then the resulting native Ring-GSW ciphertext is decomposed into nested-RNS
+        // input wires and lifted with `one_vec.key(slot_idx).large_scalar_mul(...)`.
+        let seed_encrypt = scale_estimate(self.ring_gsw_encrypt_bit, diamond.seed_bits);
+        let seed_lift_unit =
+            self.public_key_estimator.estimate_large_scalar_mul(scalar_one.as_slice());
+        let seed_lift = scale_estimate(
+            seed_lift_unit,
+            diamond
+                .seed_bits
+                .checked_mul(shape.ring_gsw_wire_count)
+                .expect("DiamondIO seed lift count overflow"),
+        );
+        let seed_encryption_and_lift = sequential_summaries(&[seed_encrypt, seed_lift]);
+
+        let prf_public_key_path = self
+            .estimate_prf_path::<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+                diamond,
+                shape.clone(),
+                PrfBenchMode::PublicKeyPreprocess,
+            );
+
+        // Corresponds to `circuit.eval(... public keys ...)` for the selected function. For
+        // DebugDecryption this is the Ring-GSW decrypt circuit over `k` and all encrypted seed
+        // wires.
+        let function_circuit = diamond_function_circuit(diamond, func);
+        let function_public_key_eval = estimate_public_key_circuit_bench_with_aux::<
+            NaiveBGGPublicKeyVec<M>,
+            PKBE,
+        >(
+            self.public_key_estimator, params, &function_circuit
+        );
+
+        let final_projection_standard_preimages = shape.final_projection_standard_preimage_count();
+        let lookup_bridge_hash_sampling = estimate_summary(self.full_w_block_hash_sample);
+        let lookup_bridge_preimage = estimate_summary(self.lookup_bridge_preimage_extend);
+        let lookup_bridge_work =
+            sequential_summaries(&[lookup_bridge_hash_sampling, lookup_bridge_preimage]);
+        let final_projection_hash_sampling =
+            scale_estimate(self.full_w_block_hash_sample, final_projection_standard_preimages);
+        let final_projection_target_building =
+            shape.estimate_final_projection_target_building(self.native_estimator);
+        let final_projection_preimages =
+            scale_estimate(self.final_output_preimage_extend, final_projection_standard_preimages);
+        let final_projection_inputs =
+            parallel_summaries(&[final_projection_hash_sampling, final_projection_target_building]);
+        let final_projection_work =
+            sequential_summaries(&[final_projection_inputs, final_projection_preimages]);
+
+        // After the scalar BGG public keys exist, the input-injection trapdoor chain and the
+        // native seed-encryption/lifting branch have no data dependency. The PRF and function
+        // public-key circuit evaluations depend on the lifted seed wires, while projection
+        // preimages wait for the final input-injection trapdoor basis. With enough GPUs, the
+        // lookup bridge can run on the input-injection branch while the PRF/function branch is
+        // still producing public keys; only the refresh-decoder and final-output projection
+        // preimages require both branches to have finished.
+        let seed_public_side =
+            sequential_summaries(&[ring_gsw_public_key_sampling, seed_encryption_and_lift]);
+        let public_circuit_work = sequential_summaries(&[
+            seed_public_side,
+            parallel_summaries(&[
+                prf_public_key_path.compute_without_refresh_decoder,
+                function_public_key_eval,
+            ]),
+        ]);
+        let input_injection_and_lookup =
+            sequential_summaries(&[input_injection.obfuscate, lookup_bridge_work]);
+        let public_and_input_branches =
+            parallel_summaries(&[input_injection_and_lookup, public_circuit_work]);
+        let post_join_projection_work =
+            parallel_summaries(&[prf_public_key_path.refresh_decoder_work, final_projection_work]);
+        let total = sequential_summaries(&[
+            bgg_public_key_sampling,
+            public_and_input_branches,
+            post_join_projection_work,
+        ]);
+
+        debug!(
+            ?bgg_public_key_sampling,
+            ?ring_gsw_public_key_sampling,
+            ?seed_encryption_and_lift,
+            input_injection = ?input_injection.obfuscate,
+            ?prf_public_key_path,
+            ?function_public_key_eval,
+            final_projection_standard_preimages,
+            ?lookup_bridge_hash_sampling,
+            ?lookup_bridge_preimage,
+            ?lookup_bridge_work,
+            ?final_projection_hash_sampling,
+            ?final_projection_target_building,
+            ?final_projection_preimages,
+            ?final_projection_work,
+            obfuscated_circuit_bytes = ?persisted_storage.total_bytes,
+            ?total,
+            "estimated DiamondIO obfuscation benchmark"
+        );
+
+        total
+    }
+
+    fn estimate_eval<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        &self,
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        func: DiamondIOFuncType,
+        shape: DiamondIOBenchShape,
+        _persisted_storage: &DiamondIOStorageEstimate,
+    ) -> CircuitBenchSummary
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+        PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
+        EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
+    {
+        let params = &diamond.injector.params;
+        let ring_dim = params.ring_dimension() as usize;
+        let scalar_one = vec![BigUint::from(1u32); ring_dim];
+
+        let input_injection = shape.estimate_online_input_injection(self.native_estimator);
+
+        // Corresponds to reading one/k/input/lookup preimages and multiplying `states[0]` (or the
+        // selected bit state) by each preimage to build BGG encodings for the remaining circuit.
+        let input_encoding_projection =
+            shape.estimate_input_encoding_projection(self.native_estimator, diamond.input_size);
+
+        // Corresponds to `seed_plaintext_inputs -> seed_encoding_inputs`: every native Ring-GSW
+        // ciphertext wire is lifted by a slotwise large scalar multiplication of the one encoding.
+        let seed_lift_unit =
+            self.encoding_estimator.estimate_large_scalar_mul(scalar_one.as_slice());
+        let seed_ciphertext_lift = scale_estimate(
+            seed_lift_unit,
+            diamond
+                .seed_bits
+                .checked_mul(shape.ring_gsw_wire_count)
+                .expect("DiamondIO eval seed lift count overflow"),
+        );
+
+        let prf_encoding_path = self.estimate_prf_path::<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+            diamond,
+            shape.clone(),
+            PrfBenchMode::EncodingOnline,
+        );
+
+        let function_encoding_eval = self
+            .encoding_estimator
+            .estimate_circuit_bench(&diamond_function_circuit(diamond, func));
+
+        // The concrete eval computes PRF mask encodings and function encodings independently after
+        // all input encodings and lookup evaluators are available. With enough GPUs, these two
+        // branches can occupy separate devices; the final decoder waits for both.
+        let prf_and_function =
+            parallel_summaries(&[prf_encoding_path.total, function_encoding_eval]);
+
+        // Corresponds to `decoder_outputs`: one `states[0] * decoder_preimage` per final
+        // secret-dependent output slot.
+        let decoder_projection = scale_summary(
+            self.native_estimator
+                .estimate_vector_matrix_product(shape.state_col_size, shape.modulus_digits),
+            shape.final_decoder_count(),
+        );
+
+        // Corresponds to `decoder - evaluated.vector.mul_decompose(identity_selector) +
+        // public_bottom`. The `mul_decompose` is modeled by the native matrix-mul unit because it
+        // is the same gadget-decomposed projection shape used by the surrounding native matrix
+        // operations.
+        let final_decode_unit = sequential_summaries(&[
+            estimate_summary(
+                self.native_estimator.estimate_vector_inner_product(shape.modulus_digits),
+            ),
+            estimate_summary(self.native_estimator.estimate_vector_sub(DIAMOND_SECRET_SIZE)),
+            estimate_summary(self.native_estimator.estimate_vector_add(DIAMOND_SECRET_SIZE)),
+        ]);
+        let final_decode = scale_summary(final_decode_unit, diamond.output_size);
+
+        let total = sequential_summaries(&[
+            input_injection,
+            input_encoding_projection,
+            seed_ciphertext_lift,
+            prf_and_function,
+            decoder_projection,
+            final_decode,
+        ]);
+
+        debug!(
+            ?input_injection,
+            ?input_encoding_projection,
+            ?seed_ciphertext_lift,
+            ?prf_encoding_path,
+            ?function_encoding_eval,
+            ?decoder_projection,
+            ?final_decode,
+            ?total,
+            "estimated DiamondIO eval benchmark"
+        );
+
+        total
+    }
+
+    fn estimate_input_injection<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        &self,
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        shape: DiamondIOBenchShape,
+    ) -> DiamondIOInputInjectionBenchEstimateParts
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+    {
+        // Corresponds to `load_or_sample_b_checkpoint` for levels `0..=input_count`. Checkpoints
+        // do not depend on each other, so enough GPUs can sample them concurrently.
+        let checkpoint_sampling =
+            scale_estimate(self.trapdoor_checkpoint, diamond.injector.input_count + 1);
+
+        // Corresponds to `build_initial_encoding`: one native product plus an error addition for
+        // the empty prefix state. The W block is deterministic hash-derived public data, so it is
+        // regenerated rather than stored, but preprocessing still pays the sampling cost.
+        let initial_state = sequential_summaries(&[
+            estimate_summary(self.full_w_block_hash_sample),
+            self.native_estimator
+                .estimate_vector_matrix_product(shape.state_row_size, shape.state_col_size),
+            estimate_summary(self.native_estimator.estimate_vector_add(shape.state_col_size)),
+        ]);
+
+        // Corresponds to `build_k_target_chunk_with_params` for every level/digit/state/chunk.
+        // Target construction precedes the matching preimage sample, but all chunks in a stage are
+        // independent.
+        let transition_ext_w_hash_sampling =
+            scale_estimate(self.full_w_block_hash_sample, shape.transition_ext_w_hash_count);
+        let transition_target_w_hash_sampling = scale_estimate(
+            self.transition_w_chunk_hash_sample,
+            shape.transition_target_w_hash_chunk_count,
+        );
+        let transition_target_building =
+            shape.estimate_transition_target_building(self.native_estimator);
+
+        // Corresponds to the chunked `preimage_extend` calls inside `DiamondInjector::preprocess`.
+        let transition_preimages =
+            scale_estimate(self.trapdoor_preimage_extend, shape.transition_preimage_chunk_count);
+
+        let transition_public_hashing = parallel_summaries(&[
+            transition_ext_w_hash_sampling,
+            transition_target_w_hash_sampling,
+        ]);
+        let transition_stage = sequential_summaries(&[
+            transition_public_hashing,
+            transition_target_building,
+            transition_preimages,
+        ]);
+        let body = parallel_summaries(&[initial_state, transition_stage]);
+        let preprocess_total = sequential_summaries(&[checkpoint_sampling, body]);
+
+        let online_eval_total = shape.estimate_online_input_injection(self.native_estimator);
+
+        debug!(
+            ?checkpoint_sampling,
+            ?initial_state,
+            ?transition_ext_w_hash_sampling,
+            ?transition_target_w_hash_sampling,
+            ?transition_target_building,
+            ?transition_preimages,
+            ?preprocess_total,
+            ?online_eval_total,
+            "estimated DiamondIO input-injection benchmark"
+        );
+
+        DiamondIOInputInjectionBenchEstimateParts {
+            obfuscate: preprocess_total,
+            eval: online_eval_total,
+        }
+    }
+
+    fn estimate_prf_path<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        &self,
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        shape: DiamondIOBenchShape,
+        mode: PrfBenchMode,
+    ) -> DiamondIOPrfBenchEstimateParts
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+        PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: PublicKeyAuxBenchEstimator<M::P>,
+        EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        NestedRnsPoly<M::P>: DecomposeArithmeticGadget<M::P> + ModularArithmeticPlanner<M::P>,
+    {
+        let prg_circuit = diamond.build_goldreich_prg_range_circuit(0, 1, 0, 1);
+        let prg_unit = match mode {
+            PrfBenchMode::PublicKeyPreprocess => {
+                estimate_public_key_circuit_bench_with_aux::<NaiveBGGPublicKeyVec<M>, PKBE>(
+                    self.public_key_estimator,
+                    &diamond.injector.params,
+                    &prg_circuit,
+                )
+            }
+            PrfBenchMode::EncodingOnline => {
+                self.encoding_estimator.estimate_circuit_bench(&prg_circuit)
+            }
+        };
+        let selected_half_prg_per_round = scale_summary(
+            prg_unit,
+            2usize
+                .checked_mul(diamond.seed_bits)
+                .expect("DiamondIO selected-half PRG output count overflow"),
+        );
+        let selected_half_prg =
+            repeat_sequential_summary(selected_half_prg_per_round, diamond.input_size);
+
+        let selected_wire_count_per_round = diamond
+            .seed_bits
+            .checked_mul(shape.ring_gsw_wire_count)
+            .expect("DiamondIO selected PRG wire count overflow");
+        let (sub, mul, add) = match mode {
+            PrfBenchMode::PublicKeyPreprocess => (
+                self.public_key_estimator.estimate_sub(),
+                self.public_key_estimator.estimate_mul(),
+                self.public_key_estimator.estimate_add(),
+            ),
+            PrfBenchMode::EncodingOnline => (
+                self.encoding_estimator.estimate_sub(),
+                self.encoding_estimator.estimate_mul(),
+                self.encoding_estimator.estimate_add(),
+            ),
+        };
+        let selected_half_mux_unit = sequential_summaries(&[
+            estimate_summary(sub),
+            estimate_summary(mul),
+            estimate_summary(add),
+        ]);
+        let selected_half_mux_per_round =
+            scale_summary(selected_half_mux_unit, selected_wire_count_per_round);
+        let selected_half_mux =
+            repeat_sequential_summary(selected_half_mux_per_round, diamond.input_size);
+
+        let mut refresh_context_circuit = crate::circuit::PolyCircuit::new();
+        let noise_refresher = NoiseRefresherNaiveVec::<M, NestedRnsPoly<M::P>, HS>::new(
+            diamond.build_ring_gsw_circuit_context(&mut refresh_context_circuit),
+            diamond.seed_bits,
+            diamond.noise_refresh_v_bits,
+            diamond.goldreich_graph_seed,
+            diamond.noise_refresh_cbd_n,
+            diamond.noise_refresh_hash_key,
+        );
+        let refresh_parts = match mode {
+            PrfBenchMode::PublicKeyPreprocess => {
+                noise_refresher.estimate_preprocess_bench_parts(self.public_key_estimator)
+            }
+            PrfBenchMode::EncodingOnline => {
+                noise_refresher.estimate_online_eval_bench_parts(self.encoding_estimator)
+            }
+        };
+        let refresh_decoder_count_per_round = selected_wire_count_per_round
+            .checked_mul(shape.ring_dim)
+            .and_then(|count| count.checked_mul(shape.crt_depth))
+            .expect("DiamondIO refresh decoder count overflow");
+        let refresh_decoder_work_per_round = match mode {
+            PrfBenchMode::PublicKeyPreprocess => sequential_summaries(&[
+                scale_estimate(self.full_w_block_hash_sample, refresh_decoder_count_per_round),
+                scale_estimate(self.final_output_preimage_extend, refresh_decoder_count_per_round),
+            ]),
+            PrfBenchMode::EncodingOnline => scale_summary(
+                self.native_estimator
+                    .estimate_vector_matrix_product(shape.state_col_size, shape.modulus_digits),
+                refresh_decoder_count_per_round,
+            ),
+        };
+        let noise_refresh_per_round = sequential_summaries(&[
+            refresh_parts.material,
+            scale_summary(refresh_parts.per_refresh, selected_wire_count_per_round),
+        ]);
+        let noise_refresh = repeat_sequential_summary(noise_refresh_per_round, diamond.input_size);
+
+        // The final PRG output stream contains `output_size * ring_dim *
+        // prf_mask_output_coeff_bits` independent Ring-GSW ciphertext bits. A representative
+        // one-output Goldreich circuit keeps estimator memory bounded and preserves the
+        // enough-GPUs latency rule.
+        let final_mask_prg = scale_summary(prg_unit, shape.final_mask_prg_output_count());
+
+        let final_mask_circuit = diamond.build_prf_mask_circuit();
+        let final_mask_decrypt_unit = match mode {
+            PrfBenchMode::PublicKeyPreprocess => {
+                estimate_public_key_circuit_bench_with_aux::<NaiveBGGPublicKeyVec<M>, PKBE>(
+                    self.public_key_estimator,
+                    &diamond.injector.params,
+                    &final_mask_circuit,
+                )
+            }
+            PrfBenchMode::EncodingOnline => {
+                self.encoding_estimator.estimate_circuit_bench(&final_mask_circuit)
+            }
+        };
+        let final_mask_decrypt = scale_summary(final_mask_decrypt_unit, diamond.output_size);
+
+        // The PRF seed rounds are sequential, because each refresh produces the seed consumed by
+        // the next round. The noise-refresh material circuit is evaluated once per round; only the
+        // decoded per-refresh combine work and its decoder/preimage work scale with the selected
+        // Ring-GSW wire count.
+        let round_compute_per_round = match mode {
+            PrfBenchMode::PublicKeyPreprocess => sequential_summaries(&[
+                selected_half_prg_per_round,
+                selected_half_mux_per_round,
+                noise_refresh_per_round,
+            ]),
+            PrfBenchMode::EncodingOnline => sequential_summaries(&[
+                selected_half_prg_per_round,
+                selected_half_mux_per_round,
+                refresh_decoder_work_per_round,
+                noise_refresh_per_round,
+            ]),
+        };
+        let round_summary_per_round = sequential_summaries(&[
+            selected_half_prg_per_round,
+            selected_half_mux_per_round,
+            refresh_decoder_work_per_round,
+            noise_refresh_per_round,
+        ]);
+        let round_compute = repeat_sequential_summary(round_compute_per_round, diamond.input_size);
+        let round_summary = repeat_sequential_summary(round_summary_per_round, diamond.input_size);
+        let refresh_decoder_work = match mode {
+            PrfBenchMode::PublicKeyPreprocess => {
+                scale_summary(refresh_decoder_work_per_round, diamond.input_size)
+            }
+            PrfBenchMode::EncodingOnline => {
+                repeat_sequential_summary(refresh_decoder_work_per_round, diamond.input_size)
+            }
+        };
+        let final_summary = sequential_summaries(&[final_mask_prg, final_mask_decrypt]);
+        let compute_without_refresh_decoder = sequential_summaries(&[round_compute, final_summary]);
+        let total = match mode {
+            PrfBenchMode::PublicKeyPreprocess => {
+                parallel_summaries(&[compute_without_refresh_decoder, refresh_decoder_work])
+            }
+            PrfBenchMode::EncodingOnline => sequential_summaries(&[round_summary, final_summary]),
+        };
+
+        let estimate = DiamondIOPrfBenchEstimateParts {
+            selected_half_prg,
+            selected_half_mux,
+            refresh_decoder_work,
+            noise_refresh,
+            final_mask_prg,
+            final_mask_decrypt,
+            compute_without_refresh_decoder,
+            total,
+        };
+        debug!(?mode, ?estimate, "estimated DiamondIO PRF benchmark");
+        estimate
+    }
+
+    fn estimate_storage<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        &self,
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        shape: DiamondIOBenchShape,
+    ) -> DiamondIOStorageEstimate
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+    {
+        let final_projection_preimage_bytes =
+            BigUint::from(shape.final_projection_preimage_bytes());
+        let prf_refresh_preimage_bytes = BigUint::from(shape.prf_refresh_preimage_bytes());
+        let input_injection_metadata_and_seed_bytes =
+            shape.input_injection_metadata_and_seed_bytes();
+        let input_injection_public_checkpoint_bytes =
+            BigUint::from(shape.input_injection_public_checkpoint_bytes());
+        let input_injection_transition_preimage_bytes =
+            BigUint::from(shape.input_injection_transition_preimage_bytes);
+        let input_injection_bytes = shape.input_injection_bytes();
+        let total_bytes = input_injection_bytes.clone() +
+            final_projection_preimage_bytes.clone() +
+            prf_refresh_preimage_bytes.clone();
+
+        debug!(
+            input_size = diamond.input_size,
+            output_size = diamond.output_size,
+            seed_bits = diamond.seed_bits,
+            ring_gsw_wire_count = shape.ring_gsw_wire_count,
+            ?input_injection_metadata_and_seed_bytes,
+            ?input_injection_public_checkpoint_bytes,
+            ?input_injection_transition_preimage_bytes,
+            ?final_projection_preimage_bytes,
+            ?prf_refresh_preimage_bytes,
+            ?input_injection_bytes,
+            ?total_bytes,
+            "estimated DiamondIO obfuscated-circuit storage"
+        );
+
+        DiamondIOStorageEstimate {
+            input_injection_metadata_and_seed_bytes,
+            input_injection_bytes,
+            final_projection_preimage_bytes,
+            prf_refresh_preimage_bytes,
+            total_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PrfBenchMode {
+    PublicKeyPreprocess,
+    EncodingOnline,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DiamondIOInputInjectionBenchEstimateParts {
+    obfuscate: CircuitBenchSummary,
+    eval: CircuitBenchSummary,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DiamondIOBenchUnitEstimates {
+    trapdoor_checkpoint: CircuitBenchEstimate,
+    trapdoor_preimage_extend: CircuitBenchEstimate,
+    final_output_preimage_extend: CircuitBenchEstimate,
+    lookup_bridge_preimage_extend: CircuitBenchEstimate,
+    full_w_block_hash_sample: CircuitBenchEstimate,
+    transition_w_chunk_hash_sample: CircuitBenchEstimate,
+    bgg_public_key_sample: CircuitBenchEstimate,
+    ring_gsw_public_key_sample: CircuitBenchEstimate,
+    ring_gsw_encrypt_bit: CircuitBenchEstimate,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DiamondIOPrfBenchEstimateParts {
+    selected_half_prg: CircuitBenchSummary,
+    selected_half_mux: CircuitBenchSummary,
+    refresh_decoder_work: CircuitBenchSummary,
+    noise_refresh: CircuitBenchSummary,
+    final_mask_prg: CircuitBenchSummary,
+    final_mask_decrypt: CircuitBenchSummary,
+    compute_without_refresh_decoder: CircuitBenchSummary,
+    total: CircuitBenchSummary,
+}
+
+fn bench_estimate<R, F>(iterations: usize, op: F) -> CircuitBenchEstimate
+where
+    F: FnMut() -> R,
+{
+    let measurement = benchmark_gate_operation(iterations.max(1), op);
+    CircuitBenchEstimate::new(measurement.time, measurement.time)
+        .with_peak_vram(measurement.peak_vram)
+}
+
+fn sample_native_ternary_secret<M, US>(
+    params: &<M::P as Poly>::Params,
+    native_params: &<DCRTPoly as Poly>::Params,
+) -> DCRTPoly
+where
+    M: PolyMatrix,
+    US: PolyUniformSampler<M = M>,
+{
+    let secret = US::new().sample_poly(params, &DistType::TernaryDist);
+    DCRTPoly::from_biguints(native_params, &secret.coeffs_biguints())
+}

--- a/src/io/diamond_io/bench_estimator_native.rs
+++ b/src/io/diamond_io/bench_estimator_native.rs
@@ -1,0 +1,225 @@
+use crate::bench_estimator::{CircuitBenchEstimate, CircuitBenchSummary};
+
+#[cfg(feature = "gpu")]
+use std::{collections::HashMap, sync::RwLock};
+
+#[cfg(feature = "gpu")]
+use crate::{
+    matrix::{PolyMatrix, gpu_dcrt_poly::GpuDCRTPolyMatrix},
+    poly::{
+        Poly, PolyParams,
+        dcrt::{
+            gpu::{GpuDCRTPoly, GpuDCRTPolyParams, gpu_device_sync},
+            params::DCRTPolyParams,
+        },
+    },
+    sampler::{DistType, PolyUniformSampler, uniform::DCRTPolyUniformSampler},
+};
+
+use super::bench_estimator_utils::{scale_estimate, scale_summary};
+
+/// Size-aware benchmark model for native polynomial-vector arithmetic.
+///
+/// Implementations should include the CPU-to-GPU upload of input data and GPU-to-CPU download of
+/// output data in each returned operation estimate. DiamondIO then composes these measured units by
+/// dependency structure rather than adding a separate transfer model.
+pub trait DiamondIONativeBenchEstimator {
+    /// Estimates multiplying one polynomial scalar into a vector of `vector_len` polynomials.
+    fn estimate_poly_vector_mul(&self, vector_len: usize) -> CircuitBenchEstimate;
+
+    /// Estimates one inner product between two vectors of `vector_len` polynomials.
+    fn estimate_vector_inner_product(&self, vector_len: usize) -> CircuitBenchEstimate;
+
+    /// Estimates adding two polynomial vectors of `vector_len` entries.
+    fn estimate_vector_add(&self, vector_len: usize) -> CircuitBenchEstimate;
+
+    /// Estimates subtracting two polynomial vectors of `vector_len` entries.
+    fn estimate_vector_sub(&self, vector_len: usize) -> CircuitBenchEstimate;
+
+    /// Estimates a row-vector by matrix product.
+    ///
+    /// The model computes each RHS column independently. The one-column inner-product estimate
+    /// includes uploading both input vectors and downloading the one-polynomial output, so this
+    /// composition still accounts for CPU/GPU transfer time per independent column.
+    fn estimate_vector_matrix_product(
+        &self,
+        inner_len: usize,
+        rhs_cols: usize,
+    ) -> CircuitBenchSummary {
+        scale_estimate(self.estimate_vector_inner_product(inner_len), rhs_cols)
+    }
+
+    /// Estimates an `lhs_rows x inner_len` by `inner_len x rhs_cols` product as independent row
+    /// vector products. DiamondIO only needs this for small selector matrices during target
+    /// construction; no dense matrix-matrix primitive is assumed.
+    fn estimate_row_parallel_matrix_product(
+        &self,
+        lhs_rows: usize,
+        inner_len: usize,
+        rhs_cols: usize,
+    ) -> CircuitBenchSummary {
+        scale_summary(self.estimate_vector_matrix_product(inner_len, rhs_cols), lhs_rows)
+    }
+}
+
+#[cfg(feature = "gpu")]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+enum GpuNativeBenchOp {
+    PolyVectorMul,
+    VectorInnerProduct,
+    VectorAdd,
+    VectorSub,
+}
+
+#[cfg(feature = "gpu")]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+struct GpuNativeBenchKey {
+    op: GpuNativeBenchOp,
+    vector_len: usize,
+}
+
+/// Measured native-operation estimator for `GpuDCRTPolyMatrix`.
+///
+/// Each measured operation starts from compact CPU bytes, uploads the inputs to GPU matrices,
+/// executes the GPU operation, and stores the result back to compact bytes. This deliberately
+/// includes CPU-to-GPU input transfer and GPU-to-CPU output transfer in the operation unit used by
+/// DiamondIO benchmark estimation.
+#[cfg(feature = "gpu")]
+#[derive(Debug)]
+pub struct GpuDCRTPolyMatrixNativeBenchEstimator {
+    pub params: GpuDCRTPolyParams,
+    pub iterations: usize,
+    cache: RwLock<HashMap<GpuNativeBenchKey, CircuitBenchEstimate>>,
+}
+
+#[cfg(feature = "gpu")]
+impl GpuDCRTPolyMatrixNativeBenchEstimator {
+    pub fn new(params: GpuDCRTPolyParams, iterations: usize) -> Self {
+        Self { params, iterations: iterations.max(1), cache: RwLock::new(HashMap::new()) }
+    }
+
+    fn cpu_params(&self) -> DCRTPolyParams {
+        DCRTPolyParams::new(
+            self.params.ring_dimension(),
+            self.params.crt_depth(),
+            self.params.crt_bits(),
+            self.params.base_bits(),
+        )
+    }
+
+    fn sample_matrix_bytes(&self, nrow: usize, ncol: usize) -> Vec<u8> {
+        let sampler = DCRTPolyUniformSampler::new();
+        sampler
+            .sample_uniform(&self.cpu_params(), nrow, ncol, DistType::FinRingDist)
+            .to_compact_bytes()
+    }
+
+    fn sample_poly_bytes(&self) -> Vec<u8> {
+        let sampler = DCRTPolyUniformSampler::new();
+        sampler.sample_poly(&self.cpu_params(), &DistType::FinRingDist).to_compact_bytes()
+    }
+
+    fn cached<F>(&self, key: GpuNativeBenchKey, measure: F) -> CircuitBenchEstimate
+    where
+        F: FnOnce(&Self) -> CircuitBenchEstimate,
+    {
+        if let Some(estimate) = self
+            .cache
+            .read()
+            .expect("DiamondIO native bench cache read lock poisoned")
+            .get(&key)
+            .copied()
+        {
+            return estimate;
+        }
+        let estimate = measure(self);
+        self.cache
+            .write()
+            .expect("DiamondIO native bench cache write lock poisoned")
+            .insert(key, estimate);
+        estimate
+    }
+
+    fn measured<F>(&self, op: F) -> CircuitBenchEstimate
+    where
+        F: FnMut(),
+    {
+        gpu_device_sync();
+        let measurement = crate::bench_estimator::benchmark_gate_operation(self.iterations, op);
+        gpu_device_sync();
+        CircuitBenchEstimate::new(measurement.time, measurement.time)
+            .with_peak_vram(measurement.peak_vram)
+    }
+}
+
+#[cfg(feature = "gpu")]
+impl DiamondIONativeBenchEstimator for GpuDCRTPolyMatrixNativeBenchEstimator {
+    fn estimate_poly_vector_mul(&self, vector_len: usize) -> CircuitBenchEstimate {
+        assert!(vector_len > 0, "poly-vector multiplication requires a nonempty vector");
+        self.cached(
+            GpuNativeBenchKey { op: GpuNativeBenchOp::PolyVectorMul, vector_len },
+            |estimator| {
+                let scalar_bytes = estimator.sample_poly_bytes();
+                let vector_bytes = estimator.sample_matrix_bytes(1, vector_len);
+                estimator.measured(move || {
+                    let scalar = GpuDCRTPoly::from_compact_bytes(&estimator.params, &scalar_bytes);
+                    let vector =
+                        GpuDCRTPolyMatrix::from_compact_bytes(&estimator.params, &vector_bytes);
+                    let out = &vector * &scalar;
+                    std::hint::black_box(out.into_compact_bytes());
+                })
+            },
+        )
+    }
+
+    fn estimate_vector_inner_product(&self, vector_len: usize) -> CircuitBenchEstimate {
+        assert!(vector_len > 0, "vector inner product requires a nonempty vector");
+        self.cached(
+            GpuNativeBenchKey { op: GpuNativeBenchOp::VectorInnerProduct, vector_len },
+            |estimator| {
+                let lhs_bytes = estimator.sample_matrix_bytes(1, vector_len);
+                let rhs_bytes = estimator.sample_matrix_bytes(vector_len, 1);
+                estimator.measured(move || {
+                    let lhs = GpuDCRTPolyMatrix::from_compact_bytes(&estimator.params, &lhs_bytes);
+                    let rhs = GpuDCRTPolyMatrix::from_compact_bytes(&estimator.params, &rhs_bytes);
+                    let out = &lhs * &rhs;
+                    std::hint::black_box(out.into_compact_bytes());
+                })
+            },
+        )
+    }
+
+    fn estimate_vector_add(&self, vector_len: usize) -> CircuitBenchEstimate {
+        assert!(vector_len > 0, "vector addition requires a nonempty vector");
+        self.cached(
+            GpuNativeBenchKey { op: GpuNativeBenchOp::VectorAdd, vector_len },
+            |estimator| {
+                let lhs_bytes = estimator.sample_matrix_bytes(1, vector_len);
+                let rhs_bytes = estimator.sample_matrix_bytes(1, vector_len);
+                estimator.measured(move || {
+                    let lhs = GpuDCRTPolyMatrix::from_compact_bytes(&estimator.params, &lhs_bytes);
+                    let rhs = GpuDCRTPolyMatrix::from_compact_bytes(&estimator.params, &rhs_bytes);
+                    let out = lhs + &rhs;
+                    std::hint::black_box(out.into_compact_bytes());
+                })
+            },
+        )
+    }
+
+    fn estimate_vector_sub(&self, vector_len: usize) -> CircuitBenchEstimate {
+        assert!(vector_len > 0, "vector subtraction requires a nonempty vector");
+        self.cached(
+            GpuNativeBenchKey { op: GpuNativeBenchOp::VectorSub, vector_len },
+            |estimator| {
+                let lhs_bytes = estimator.sample_matrix_bytes(1, vector_len);
+                let rhs_bytes = estimator.sample_matrix_bytes(1, vector_len);
+                estimator.measured(move || {
+                    let lhs = GpuDCRTPolyMatrix::from_compact_bytes(&estimator.params, &lhs_bytes);
+                    let rhs = GpuDCRTPolyMatrix::from_compact_bytes(&estimator.params, &rhs_bytes);
+                    let out = lhs - &rhs;
+                    std::hint::black_box(out.into_compact_bytes());
+                })
+            },
+        )
+    }
+}

--- a/src/io/diamond_io/bench_estimator_shape.rs
+++ b/src/io/diamond_io/bench_estimator_shape.rs
@@ -1,0 +1,496 @@
+use num_bigint::BigUint;
+
+use crate::{
+    bench_estimator::CircuitBenchSummary,
+    matrix::PolyMatrix,
+    poly::{Poly, PolyParams},
+    sampler::{PolyHashSampler, PolyTrapdoorSampler, PolyUniformSampler},
+    slot_transfer::bgg_pubkey::{column_chunk_bounds, column_chunk_count},
+};
+
+use super::{
+    DIAMOND_SECRET_SIZE, DiamondIO, DiamondIOFuncType,
+    bench_estimator_native::DiamondIONativeBenchEstimator,
+    bench_estimator_utils::{
+        estimate_summary, parallel_summaries, scale_summary, sequential_summaries,
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DiamondIOStorageEstimate {
+    pub(super) input_injection_metadata_and_seed_bytes: BigUint,
+    pub(super) input_injection_bytes: BigUint,
+    pub(super) final_projection_preimage_bytes: BigUint,
+    pub(super) prf_refresh_preimage_bytes: BigUint,
+    pub(super) total_bytes: BigUint,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct DiamondIOBenchShape {
+    pub(super) ring_dim: usize,
+    pub(super) input_size: usize,
+    pub(super) output_size: usize,
+    pub(super) seed_bits: usize,
+    pub(super) prf_mask_output_coeff_bits: usize,
+    pub(super) crt_depth: usize,
+    pub(super) modulus_digits: usize,
+    pub(super) modulus_bits: u16,
+    pub(super) state_row_size: usize,
+    pub(super) state_col_size: usize,
+    pub(super) b_public_col_size: usize,
+    pub(super) checkpoint_count: usize,
+    pub(super) transition_matrix_count: usize,
+    pub(super) transition_preimage_chunk_count: usize,
+    pub(super) transition_ext_w_hash_count: usize,
+    pub(super) transition_target_w_hash_chunk_count: usize,
+    pub(super) transition_w_hash_max_col_len: usize,
+    pub(super) input_injection_transition_preimage_bytes: usize,
+    pub(super) online_level_state_counts: Vec<usize>,
+    pub(super) transition_chunk_col_lens: Vec<usize>,
+    pub(super) output_preimage_bytes: usize,
+    pub(super) lookup_bridge_cols: usize,
+    pub(super) lookup_bridge_preimage_bytes: usize,
+    pub(super) ring_gsw_wire_count: usize,
+}
+
+impl DiamondIOBenchShape {
+    pub(super) fn from_diamond<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+    ) -> Self
+    where
+        M: PolyMatrix + Send + Sync + 'static,
+        M::P: 'static,
+        US: PolyUniformSampler<M = M> + Send + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+        TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+    {
+        let params = &diamond.injector.params;
+        let ring_dim = params.ring_dimension() as usize;
+        let (_, _, crt_depth) = params.to_crt();
+        let modulus_digits = params.modulus_digits();
+        let modulus_bits = params
+            .modulus_bits()
+            .try_into()
+            .expect("DiamondIO modulus bits must fit in u16 for compact-byte estimates");
+        let state_row_size =
+            2usize.checked_mul(DIAMOND_SECRET_SIZE).expect("DiamondIO state row size overflow");
+        let gadget_col_size = DIAMOND_SECRET_SIZE
+            .checked_mul(modulus_digits)
+            .expect("DiamondIO gadget column count overflow");
+        let b_public_col_size = state_row_size
+            .checked_mul(modulus_digits + 2)
+            .expect("DiamondIO B public column count overflow");
+        let state_col_size =
+            b_public_col_size.checked_add(gadget_col_size).expect("DiamondIO state cols overflow");
+        let chunk_count = column_chunk_count(state_col_size);
+        let transition_chunk_col_lens = (0..chunk_count)
+            .map(|chunk_idx| column_chunk_bounds(state_col_size, chunk_idx).1)
+            .collect::<Vec<_>>();
+        let transition_chunk_bytes = transition_chunk_col_lens
+            .iter()
+            .map(|&col_len| {
+                matrix_compact_bytes::<M>(params, state_col_size, col_len, modulus_bits)
+            })
+            .collect::<Vec<_>>();
+        let transition_preimage_bytes_per_matrix = transition_chunk_bytes.iter().sum::<usize>();
+        let transition_w_chunk_lens = (0..chunk_count)
+            .filter_map(|chunk_idx| {
+                let (col_start, col_len) = column_chunk_bounds(state_col_size, chunk_idx);
+                let col_end = col_start + col_len;
+                let w_start = b_public_col_size;
+                (col_end > w_start)
+                    .then_some(col_end - col_start.max(w_start))
+                    .filter(|&w_len| w_len > 0)
+            })
+            .collect::<Vec<_>>();
+        let transition_w_hash_chunks_per_matrix = transition_w_chunk_lens.len();
+        let transition_w_hash_max_col_len =
+            transition_w_chunk_lens.iter().copied().max().unwrap_or(1);
+
+        let mut transition_preimage_chunk_count = 0usize;
+        let mut transition_matrix_count = 0usize;
+        let mut transition_ext_w_hash_count = 0usize;
+        let mut online_level_state_counts = Vec::with_capacity(diamond.injector.input_count);
+        for level in 1..=diamond.injector.input_count {
+            let state_count = expanded_state_count_after_level(diamond, level);
+            let old_state_count = state_count.saturating_sub(diamond.injector.batch_bits());
+            transition_matrix_count = transition_matrix_count
+                .checked_add(
+                    diamond
+                        .injector
+                        .base
+                        .checked_mul(state_count)
+                        .expect("DiamondIO transition matrix count overflow"),
+                )
+                .expect("DiamondIO transition matrix count overflow");
+            transition_preimage_chunk_count = transition_preimage_chunk_count
+                .checked_add(
+                    diamond
+                        .injector
+                        .base
+                        .checked_mul(state_count)
+                        .and_then(|count| count.checked_mul(chunk_count))
+                        .expect("DiamondIO transition chunk count overflow"),
+                )
+                .expect("DiamondIO transition chunk count overflow");
+            // `DiamondInjector::preprocess` materializes one full hashed W block for the previous
+            // empty-prefix state before iterating states, then one more full W block for every
+            // non-new state. New states reuse that first previous-level block. These matrices are
+            // deterministic hash-derived public data, so storage does not count them, but their
+            // sampling work is part of preprocessing latency and total work.
+            transition_ext_w_hash_count = transition_ext_w_hash_count
+                .checked_add(
+                    diamond
+                        .injector
+                        .base
+                        .checked_mul(
+                            old_state_count
+                                .checked_add(1)
+                                .expect("DiamondIO transition W hash count overflow"),
+                        )
+                        .expect("DiamondIO transition W hash count overflow"),
+                )
+                .expect("DiamondIO transition W hash count overflow");
+            online_level_state_counts.push(state_count);
+        }
+        let transition_target_w_hash_chunk_count = transition_matrix_count
+            .checked_mul(transition_w_hash_chunks_per_matrix)
+            .expect("DiamondIO transition target W hash chunk count overflow");
+
+        let input_injection_transition_preimage_bytes = transition_preimage_bytes_per_matrix
+            .checked_mul(transition_matrix_count)
+            .expect("DiamondIO transition preimage byte count overflow");
+        let output_preimage_bytes =
+            matrix_compact_bytes::<M>(params, state_col_size, modulus_digits, modulus_bits);
+        let lookup_cols = diamond
+            .enc_lookup_base_matrix
+            .as_ref()
+            .map(PolyMatrix::col_size)
+            .unwrap_or(modulus_digits);
+        let lookup_bridge_preimage_bytes =
+            matrix_compact_bytes::<M>(params, state_col_size, lookup_cols, modulus_bits);
+        let ring_gsw_wire_count =
+            diamond.build_goldreich_prg_range_circuit(0, 1, 0, 1).num_output();
+
+        Self {
+            ring_dim,
+            input_size: diamond.input_size,
+            output_size: diamond.output_size,
+            seed_bits: diamond.seed_bits,
+            prf_mask_output_coeff_bits: diamond.prf_mask_output_coeff_bits,
+            crt_depth,
+            modulus_digits,
+            modulus_bits,
+            state_row_size,
+            state_col_size,
+            b_public_col_size,
+            checkpoint_count: diamond.injector.input_count + 1,
+            transition_matrix_count,
+            transition_preimage_chunk_count,
+            transition_ext_w_hash_count,
+            transition_target_w_hash_chunk_count,
+            transition_w_hash_max_col_len,
+            input_injection_transition_preimage_bytes,
+            online_level_state_counts,
+            transition_chunk_col_lens,
+            output_preimage_bytes,
+            lookup_bridge_cols: lookup_cols,
+            lookup_bridge_preimage_bytes,
+            ring_gsw_wire_count,
+        }
+    }
+
+    pub(super) fn input_injection_metadata_and_seed_bytes(&self) -> BigUint {
+        // This term covers the small non-matrix files plus the persisted empty-prefix state used
+        // to start `DiamondInjector::online_eval`.
+        //
+        // * `metadata_estimate` is a fixed conservative allowance for the JSON metadata written by
+        //   `DiamondInjector::write_metadata`; it stores only `input_count` and `base`, so the
+        //   actual encoded file is tiny and independent of the polynomial parameters.
+        // * `hash_key_bytes` is the 32-byte `diamond_preprocess_hash_key`. It is needed at eval
+        //   time to check that the selected preprocessed transition chunks belong to the same
+        //   deterministic hash-derived public side.
+        // * `p_epsilon_bytes` estimates `diamond_p_epsilon_tensor_0`, the initial empty-prefix
+        //   state read before the first input digit is applied. Its shape is `(state_row_size / 2)
+        //   x state_col_size`, matching the secret-side half-state produced by
+        //   `build_initial_encoding`.
+        let metadata_estimate = 128usize;
+        let hash_key_bytes = 32usize;
+        let p_epsilon_bytes = matrix_compact_bytes_for_shape(
+            self.state_row_size / 2,
+            self.state_col_size,
+            self.ring_dim,
+            self.modulus_bits,
+        );
+        BigUint::from(metadata_estimate + hash_key_bytes + p_epsilon_bytes)
+    }
+
+    pub(super) fn input_injection_public_checkpoint_bytes(&self) -> usize {
+        // This counts the public `B` checkpoint matrices persisted by
+        // `DiamondInjector::load_or_sample_b_checkpoint` for levels `0..=input_count`. The matching
+        // trapdoors are intentionally not counted because they are preprocessing secrets rather
+        // than obfuscated-circuit data. Online eval does not multiply by these checkpoints
+        // directly; they are counted here only because the current preprocessing implementation
+        // persists the public matrices as reusable checkpoint artifacts.
+        matrix_compact_bytes_for_shape(
+            self.state_row_size,
+            self.b_public_col_size,
+            self.ring_dim,
+            self.modulus_bits,
+        )
+        .checked_mul(self.checkpoint_count)
+        .expect("DiamondIO B checkpoint byte count overflow")
+    }
+
+    pub(super) fn input_injection_bytes(&self) -> BigUint {
+        // Input-injection persisted bytes are grouped by the artifacts that survive preprocessing:
+        //
+        // 1. Small metadata, the 32-byte hash key, and the empty-prefix seed state `p_epsilon`.
+        // 2. Public `B` checkpoint matrices for the per-level trapdoor chain, excluding trapdoors.
+        // 3. Chunked transition preimages `diamond_k_bit_tensor_*`, which are the large artifacts
+        //    read by online eval to advance the selected input-dependent branch states.
+        self.input_injection_metadata_and_seed_bytes() +
+            BigUint::from(self.input_injection_public_checkpoint_bytes()) +
+            BigUint::from(self.input_injection_transition_preimage_bytes)
+    }
+
+    pub(super) fn estimate_transition_target_building<NBE>(
+        &self,
+        native_estimator: &NBE,
+    ) -> CircuitBenchSummary
+    where
+        NBE: DiamondIONativeBenchEstimator,
+    {
+        let per_transition_matrix = self
+            .transition_chunk_col_lens
+            .iter()
+            .map(|&col_len| {
+                sequential_summaries(&[
+                    native_estimator.estimate_row_parallel_matrix_product(
+                        self.state_row_size,
+                        self.state_row_size,
+                        col_len,
+                    ),
+                    estimate_summary(
+                        native_estimator
+                            .estimate_vector_add(self.state_row_size.saturating_mul(col_len)),
+                    ),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let per_transition_matrix = parallel_summaries(per_transition_matrix.as_slice());
+        scale_summary(per_transition_matrix, self.transition_matrix_count)
+    }
+
+    pub(super) fn estimate_online_input_injection<NBE>(
+        &self,
+        native_estimator: &NBE,
+    ) -> CircuitBenchSummary
+    where
+        NBE: DiamondIONativeBenchEstimator,
+    {
+        let per_state = self
+            .transition_chunk_col_lens
+            .iter()
+            .map(|&col_len| {
+                native_estimator.estimate_vector_matrix_product(self.state_col_size, col_len)
+            })
+            .collect::<Vec<_>>();
+        let per_state = parallel_summaries(per_state.as_slice());
+        let levels = self
+            .online_level_state_counts
+            .iter()
+            .map(|&state_count| scale_summary(per_state, state_count))
+            .collect::<Vec<_>>();
+        sequential_summaries(levels.as_slice())
+    }
+
+    pub(super) fn estimate_input_encoding_projection<NBE>(
+        &self,
+        native_estimator: &NBE,
+        input_size: usize,
+    ) -> CircuitBenchSummary
+    where
+        NBE: DiamondIONativeBenchEstimator,
+    {
+        let ordinary_projection_count =
+            input_size.checked_add(2).expect("DiamondIO ordinary input projection count overflow");
+        parallel_summaries(&[
+            scale_summary(
+                native_estimator
+                    .estimate_vector_matrix_product(self.state_col_size, self.modulus_digits),
+                ordinary_projection_count,
+            ),
+            native_estimator
+                .estimate_vector_matrix_product(self.state_col_size, self.lookup_bridge_cols),
+        ])
+    }
+
+    pub(super) fn estimate_final_projection_target_building<NBE>(
+        &self,
+        native_estimator: &NBE,
+    ) -> CircuitBenchSummary
+    where
+        NBE: DiamondIONativeBenchEstimator,
+    {
+        let ordinary_count = 2usize
+            .checked_add(self.input_size)
+            .expect("DiamondIO ordinary projection count overflow");
+        let ordinary_targets = scale_summary(
+            sequential_summaries(&[
+                // `sample_final_output_preimage` subtracts a one-row gadget term from the top or
+                // bottom half for the one/k/input projection targets. This is native polynomial
+                // matrix arithmetic performed before the trapdoor preimage sampler sees the
+                // target.
+                native_estimator.estimate_row_parallel_matrix_product(
+                    DIAMOND_SECRET_SIZE,
+                    DIAMOND_SECRET_SIZE,
+                    self.modulus_digits,
+                ),
+                estimate_summary(
+                    native_estimator.estimate_vector_sub(
+                        DIAMOND_SECRET_SIZE
+                            .checked_mul(self.modulus_digits)
+                            .expect("DiamondIO ordinary final target size overflow"),
+                    ),
+                ),
+            ]),
+            ordinary_count,
+        );
+        let decoder_targets = scale_summary(
+            sequential_summaries(&[
+                // Decoder targets first add function and PRF-mask public keys, then project the
+                // secret-dependent evaluated vector through the identity selector by
+                // `mul_decompose`. The zero bottom row and concatenation are bookkeeping rather
+                // than arithmetic-heavy GPU work.
+                estimate_summary(
+                    native_estimator.estimate_vector_add(
+                        DIAMOND_SECRET_SIZE
+                            .checked_mul(self.modulus_digits)
+                            .expect("DiamondIO decoder public-key matrix size overflow"),
+                    ),
+                ),
+                native_estimator
+                    .estimate_vector_matrix_product(self.modulus_digits, DIAMOND_SECRET_SIZE),
+            ]),
+            self.final_decoder_count(),
+        );
+        parallel_summaries(&[ordinary_targets, decoder_targets])
+    }
+
+    pub(super) fn final_projection_preimage_count(&self) -> usize {
+        // one, k, every explicit input bit, the lookup bridge, and every final decoder slot.
+        3usize
+            .checked_add(self.input_size)
+            .expect("DiamondIO final projection preimage count overflow")
+            .checked_add(self.final_decoder_count())
+            .expect("DiamondIO final projection preimage count overflow")
+    }
+
+    pub(super) fn final_projection_standard_preimage_count(&self) -> usize {
+        // All final projection preimages except the lookup bridge have the ordinary
+        // `modulus_digits` column count: one, k, each explicit input bit, and the final decoder
+        // preimages. The lookup bridge is excluded because its column count is determined by the
+        // lookup evaluator matrix and may be wider.
+        self.final_projection_preimage_count()
+            .checked_sub(1)
+            .expect("DiamondIO final projection count must include the lookup bridge")
+    }
+
+    pub(super) fn final_projection_preimage_bytes(&self) -> usize {
+        self.lookup_bridge_preimage_bytes
+            .checked_add(
+                self.output_preimage_bytes
+                    .checked_mul(self.final_projection_preimage_count() - 1)
+                    .expect("DiamondIO output preimage byte count overflow"),
+            )
+            .expect("DiamondIO final projection byte count overflow")
+    }
+
+    pub(super) fn final_decoder_count(&self) -> usize {
+        self.output_size.checked_mul(self.ring_dim).expect("DiamondIO final decoder count overflow")
+    }
+
+    pub(super) fn final_mask_prg_output_count(&self) -> usize {
+        self.final_decoder_count()
+            .checked_mul(self.prf_mask_output_coeff_bits)
+            .expect("DiamondIO final mask PRG output count overflow")
+    }
+
+    pub(super) fn prf_refresh_decoder_preimage_count(&self) -> usize {
+        self.input_size
+            .checked_mul(self.seed_bits)
+            .and_then(|count| count.checked_mul(self.ring_gsw_wire_count))
+            .and_then(|count| count.checked_mul(self.ring_dim))
+            .and_then(|count| count.checked_mul(self.crt_depth))
+            .expect("DiamondIO PRF refresh decoder count overflow")
+    }
+
+    pub(super) fn prf_refresh_preimage_bytes(&self) -> usize {
+        self.output_preimage_bytes
+            .checked_mul(self.prf_refresh_decoder_preimage_count())
+            .expect("DiamondIO PRF refresh preimage byte count overflow")
+    }
+}
+
+pub(super) fn diamond_function_circuit<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+    diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+    func: DiamondIOFuncType,
+) -> crate::circuit::PolyCircuit<M::P>
+where
+    M: PolyMatrix + Send + Sync + 'static,
+    M::P: 'static,
+    US: PolyUniformSampler<M = M> + Send + Sync,
+    HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+    TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+{
+    match func {
+        DiamondIOFuncType::DebugDecryption => diamond.build_debug_decryption_circuit(),
+    }
+}
+
+fn expanded_state_count_after_level<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+    diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+    level: usize,
+) -> usize
+where
+    M: PolyMatrix,
+    US: PolyUniformSampler<M = M> + Send + Sync,
+    HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+    TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+{
+    1usize
+        .checked_add(
+            level
+                .checked_mul(diamond.injector.batch_bits())
+                .expect("DiamondIO expanded state count overflow"),
+        )
+        .expect("DiamondIO expanded state count overflow")
+}
+
+fn matrix_compact_bytes<M>(
+    params: &<M::P as Poly>::Params,
+    nrow: usize,
+    ncol: usize,
+    modulus_bits: u16,
+) -> usize
+where
+    M: PolyMatrix,
+{
+    M::zero_compact_bytes(params, nrow, ncol, 0, false, modulus_bits).len()
+}
+
+fn matrix_compact_bytes_for_shape(
+    nrow: usize,
+    ncol: usize,
+    ring_dim: usize,
+    modulus_bits: u16,
+) -> usize {
+    let coeff_count =
+        nrow.checked_mul(ncol).and_then(|count| count.checked_mul(ring_dim)).unwrap_or(usize::MAX);
+    let payload = coeff_count.checked_mul(modulus_bits as usize).unwrap_or(usize::MAX).div_ceil(8);
+    // This is a compact upper-ish estimate for places where we cannot call the concrete matrix
+    // type. It is only used for small metadata-side estimates; concrete persisted matrix artifacts
+    // use `M::zero_compact_bytes` above.
+    payload + 128
+}

--- a/src/io/diamond_io/bench_estimator_utils.rs
+++ b/src/io/diamond_io/bench_estimator_utils.rs
@@ -1,0 +1,86 @@
+use crate::bench_estimator::{CircuitBenchEstimate, CircuitBenchSummary};
+
+pub(super) fn estimate_summary(estimate: CircuitBenchEstimate) -> CircuitBenchSummary {
+    let summary =
+        CircuitBenchSummary::new(estimate.total_time, estimate.latency, estimate.max_parallelism);
+    #[cfg(feature = "gpu")]
+    {
+        summary.with_peak_vram(estimate.peak_vram)
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        summary
+    }
+}
+
+pub(super) fn scale_estimate(estimate: CircuitBenchEstimate, count: usize) -> CircuitBenchSummary {
+    scale_summary(estimate_summary(estimate), count)
+}
+
+pub(super) fn scale_summary(summary: CircuitBenchSummary, count: usize) -> CircuitBenchSummary {
+    let total_time = summary.total_time * count as f64;
+    let max_parallelism = summary
+        .max_parallelism
+        .checked_mul(count as u128)
+        .expect("DiamondIO benchmark parallelism overflow while scaling summary");
+    let scaled = CircuitBenchSummary::new(total_time, summary.latency, max_parallelism);
+    #[cfg(feature = "gpu")]
+    {
+        scaled.with_peak_vram(summary.peak_vram)
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        scaled
+    }
+}
+
+pub(super) fn repeat_sequential_summary(
+    summary: CircuitBenchSummary,
+    count: usize,
+) -> CircuitBenchSummary {
+    let total_time = summary.total_time * count as f64;
+    let latency = summary.latency * count as f64;
+    let repeated = CircuitBenchSummary::new(total_time, latency, summary.max_parallelism);
+    #[cfg(feature = "gpu")]
+    {
+        repeated.with_peak_vram(summary.peak_vram)
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        repeated
+    }
+}
+
+pub(super) fn sequential_summaries(parts: &[CircuitBenchSummary]) -> CircuitBenchSummary {
+    let total_time = parts.iter().map(|part| part.total_time).sum::<f64>();
+    let latency = parts.iter().map(|part| part.latency).sum::<f64>();
+    let max_parallelism = parts.iter().map(|part| part.max_parallelism).max().unwrap_or(0);
+    let summary = CircuitBenchSummary::new(total_time, latency, max_parallelism);
+    #[cfg(feature = "gpu")]
+    {
+        summary.with_peak_vram(parts.iter().map(|part| part.peak_vram).max().unwrap_or(0))
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        summary
+    }
+}
+
+pub(super) fn parallel_summaries(parts: &[CircuitBenchSummary]) -> CircuitBenchSummary {
+    let total_time = parts.iter().map(|part| part.total_time).sum::<f64>();
+    let latency = parts.iter().map(|part| part.latency).fold(0.0f64, f64::max);
+    let max_parallelism = parts
+        .iter()
+        .map(|part| part.max_parallelism)
+        .try_fold(0u128, |acc, value| acc.checked_add(value))
+        .expect("DiamondIO benchmark parallelism overflow while parallelizing summaries");
+    let summary = CircuitBenchSummary::new(total_time, latency, max_parallelism);
+    #[cfg(feature = "gpu")]
+    {
+        summary.with_peak_vram(parts.iter().map(|part| part.peak_vram).sum::<usize>())
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        summary
+    }
+}

--- a/src/io/diamond_io/simulation.rs
+++ b/src/io/diamond_io/simulation.rs
@@ -22,6 +22,7 @@ use crate::{
             decrypt_bit_decomposed_polynomial, mask_plaintext_moduli_from_full_modulus,
         },
         simulate_noise_refresh_error_growth,
+        simulation::validate_error_bound_security_margin,
     },
     poly::{
         PolyParams,
@@ -60,6 +61,114 @@ pub struct DiamondIOPrfRoundErrorSimulation {
     pub noise_refresh: NoiseRefreshErrorSimulation,
 }
 
+/// Largest safe PRF mask bit-width together with the simulation that certified it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiamondIOPrfMaskOutputCoeffBitsSearchResult {
+    /// Largest PRF mask coefficient bit-width satisfying the final decode margin.
+    pub prf_mask_output_coeff_bits: usize,
+    /// Error simulation evaluated with `prf_mask_output_coeff_bits`.
+    pub simulation: DiamondIOErrorSimulation,
+}
+
+/// Successful DiamondIO CRT-depth search result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiamondIOCrtDepthSearchResult {
+    /// Smallest CRT depth found by the search.
+    pub crt_depth: usize,
+    /// Largest PRF mask coefficient bit-width that was safe at `crt_depth`.
+    pub prf_mask_output_coeff_bits: usize,
+    /// Final noisy-plaintext error bound certified for the selected candidate.
+    pub total_noisy_plaintext_error: PolyMatrixNorm,
+    /// Representative input-injection contribution used to seed the DiamondIO simulation.
+    ///
+    /// This is `input_injection.state_errors[0] * input_injection.output_preimage`, matching the
+    /// projected state error used as the `one`, decryption-key, and decoder input bound.
+    pub input_injection_projection_error: PolyMatrixNorm,
+}
+
+/// Finds the smallest CRT depth whose correctness and security checks pass.
+///
+/// The search is binary over the inclusive range `[min_crt_depth, max_crt_depth]`. For each
+/// candidate depth, `build_candidate` must construct a DiamondIO instance with matching polynomial
+/// parameters and Ring-GSW context. The candidate first runs
+/// `DiamondIO::max_safe_prf_mask_output_coeff_bits`; if no mask width is valid, the search moves to
+/// larger CRT depths. If mask search succeeds, the certified simulation is checked with
+/// `validate_error_bound_security_margin` for both the final noisy-plaintext bound and every
+/// noise-refresh pre-rounding bound. Passing candidates are recorded and the search continues
+/// toward smaller CRT depths.
+pub fn diamond_io_find_crt_depth<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST, PE, ST, BuildCandidate>(
+    min_crt_depth: usize,
+    max_crt_depth: usize,
+    max_prf_mask_output_coeff_bits: usize,
+    security_bit: usize,
+    func_type: DiamondIOFuncType,
+    mut build_candidate: BuildCandidate,
+    plt_evaluator: &PE,
+    slot_transfer_evaluator: &ST,
+) -> Option<DiamondIOCrtDepthSearchResult>
+where
+    M: PolyMatrix,
+    US: PolyUniformSampler<M = M> + Send + Sync,
+    HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+    TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+    BuildCandidate: FnMut(usize) -> DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+{
+    info!(
+        min_crt_depth,
+        max_crt_depth,
+        max_prf_mask_output_coeff_bits,
+        security_bit,
+        "starting DiamondIO CRT-depth search"
+    );
+    assert!(min_crt_depth > 0, "minimum CRT depth must be positive");
+    assert!(min_crt_depth <= max_crt_depth, "CRT-depth search range must be non-empty");
+    let mut low = min_crt_depth;
+    let mut high = max_crt_depth;
+    let mut found = Vec::new();
+    while low <= high {
+        let crt_depth = low + (high - low) / 2;
+        info!(crt_depth, low, high, "evaluating DiamondIO CRT-depth candidate");
+        let candidate = build_candidate(crt_depth);
+        let Some(mask_search) = candidate.max_safe_prf_mask_output_coeff_bits(
+            func_type,
+            plt_evaluator,
+            slot_transfer_evaluator,
+            max_prf_mask_output_coeff_bits,
+        ) else {
+            info!(crt_depth, "DiamondIO CRT-depth candidate failed correctness mask-bit search");
+            low = crt_depth + 1;
+            continue;
+        };
+        let mask_bits = mask_search.prf_mask_output_coeff_bits;
+        let cpu_params = cpu_params_from_poly_params(&candidate.injector.params);
+        if diamond_io_security_margins_hold(
+            &cpu_params,
+            &mask_search.simulation,
+            mask_bits,
+            security_bit,
+        ) {
+            info!(crt_depth, mask_bits, "DiamondIO CRT-depth candidate passed");
+            found.push(DiamondIOCrtDepthSearchResult {
+                crt_depth,
+                prf_mask_output_coeff_bits: mask_bits,
+                total_noisy_plaintext_error: mask_search.simulation.noisy_plaintext_error.clone(),
+                input_injection_projection_error: diamond_io_input_injection_projection_error(
+                    &mask_search.simulation.input_injection,
+                ),
+            });
+            high = crt_depth - 1;
+        } else {
+            info!(crt_depth, mask_bits, "DiamondIO CRT-depth candidate failed security margins");
+            low = crt_depth + 1;
+        }
+    }
+    let result = found.into_iter().min_by_key(|candidate| candidate.crt_depth);
+    info!(found = result.is_some(), "finished DiamondIO CRT-depth search");
+    result
+}
+
 impl<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST> DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>
 where
     M: PolyMatrix,
@@ -82,6 +191,86 @@ where
         PE: PltEvaluator<ErrorNorm>,
         ST: SlotTransferEvaluator<ErrorNorm>,
     {
+        self.simulate_error_growth_with_prf_mask_output_coeff_bits(
+            func_type,
+            self.prf_mask_output_coeff_bits,
+            plt_evaluator,
+            slot_transfer_evaluator,
+        )
+    }
+
+    /// Search for the largest PRF mask coefficient bit-width that satisfies the final decode
+    /// margin.
+    ///
+    /// Each candidate bit-width is evaluated with a fresh DiamondIO error simulation, so the
+    /// returned simulation accounts for that candidate's final PRF mask PRG and mask
+    /// decrypt/recomposition error. A candidate is valid exactly when
+    /// `noisy_plaintext_error + 2^candidate < q / 4`.
+    pub fn max_safe_prf_mask_output_coeff_bits<PE, ST>(
+        &self,
+        func_type: DiamondIOFuncType,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+        max_bits: usize,
+    ) -> Option<DiamondIOPrfMaskOutputCoeffBitsSearchResult>
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
+        let cpu_params = cpu_params_from_poly_params(&self.injector.params);
+        let max_candidate = max_bits.min(cpu_params.modulus_bits());
+        let mut low = 1usize;
+        let mut high = max_candidate;
+        let mut best = None;
+        info!(max_bits, max_candidate, "starting DiamondIO PRF mask bit search");
+        while low <= high {
+            let candidate = low + (high - low) / 2;
+            info!(candidate, low, high, "evaluating DiamondIO PRF mask bit candidate");
+            let simulation = self.simulate_error_growth_with_prf_mask_output_coeff_bits(
+                func_type,
+                candidate,
+                plt_evaluator,
+                slot_transfer_evaluator,
+            )?;
+            let q: Arc<BigUint> = cpu_params.modulus().into();
+            let quarter_q = biguint_to_decimal(&(q.as_ref() / 4u32));
+            let mask_value = biguint_to_decimal(&(BigUint::from(1u32) << candidate));
+            let valid = &simulation.noisy_plaintext_error.poly_norm.norm + &mask_value < quarter_q;
+            debug!(
+                candidate,
+                valid,
+                noisy_plaintext_error = %simulation.noisy_plaintext_error.poly_norm.norm,
+                mask_value = %mask_value,
+                quarter_q = %quarter_q,
+                "DiamondIO PRF mask bit candidate evaluated"
+            );
+            if valid {
+                best = Some(DiamondIOPrfMaskOutputCoeffBitsSearchResult {
+                    prf_mask_output_coeff_bits: candidate,
+                    simulation,
+                });
+                low = candidate + 1;
+            } else if candidate == 1 {
+                break;
+            } else {
+                high = candidate - 1;
+            }
+        }
+        info!(found = best.is_some(), "finished DiamondIO PRF mask bit search");
+        best
+    }
+
+    fn simulate_error_growth_with_prf_mask_output_coeff_bits<PE, ST>(
+        &self,
+        func_type: DiamondIOFuncType,
+        prf_mask_output_coeff_bits: usize,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+    ) -> Option<DiamondIOErrorSimulation>
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
         assert_eq!(
             self.input_size,
             self.injector.input_count * self.injector.batch_bits(),
@@ -89,7 +278,7 @@ where
         );
         assert!(self.seed_bits > 0, "DiamondIO error simulation requires seed_bits > 0");
         assert!(
-            self.prf_mask_output_coeff_bits > 0,
+            prf_mask_output_coeff_bits > 0,
             "DiamondIO error simulation requires prf_mask_output_coeff_bits > 0"
         );
 
@@ -103,13 +292,7 @@ where
         );
         let ctx = simulator_context(&cpu_params);
         let input_injection = self.injector.simulate_output_error_bounds();
-        let projection_preimage = input_injection.output_preimage.clone();
-        let projected_state_error = input_injection
-            .state_errors
-            .first()
-            .expect("DiamondIO input injection must produce a base final state error")
-            .clone() *
-            &projection_preimage;
+        let projected_state_error = diamond_io_input_injection_projection_error(&input_injection);
         info!(
             state_count = input_injection.state_errors.len(),
             projected_state_error_bits =
@@ -207,7 +390,7 @@ where
             self.input_size,
             self.output_size
                 .checked_mul(cpu_params.ring_dimension() as usize)
-                .and_then(|count| count.checked_mul(self.prf_mask_output_coeff_bits))
+                .and_then(|count| count.checked_mul(prf_mask_output_coeff_bits))
                 .expect("DiamondIO final mask PRG conceptual output count overflow"),
             0,
             one.clone(),
@@ -217,6 +400,7 @@ where
         );
         let final_mask_error = self.simulate_final_mask_error(
             &cpu_params,
+            prf_mask_output_coeff_bits,
             final_mask_prg_output,
             one.clone(),
             decryption_key.clone(),
@@ -390,6 +574,7 @@ where
     fn simulate_final_mask_error<PE, ST>(
         &self,
         params: &DCRTPolyParams,
+        prf_mask_output_coeff_bits: usize,
         final_mask_prg_output: ErrorNorm,
         one: ErrorNorm,
         decryption_key: ErrorNorm,
@@ -400,9 +585,8 @@ where
         PE: PltEvaluator<ErrorNorm>,
         ST: SlotTransferEvaluator<ErrorNorm>,
     {
-        let circuit = self.build_cpu_prf_mask_circuit(params);
-        let encrypted_bit_count =
-            params.ring_dimension() as usize * self.prf_mask_output_coeff_bits;
+        let circuit = self.build_cpu_prf_mask_circuit(params, prf_mask_output_coeff_bits);
+        let encrypted_bit_count = params.ring_dimension() as usize * prf_mask_output_coeff_bits;
         let wire_count = ring_gsw_wire_count(circuit.num_input() - 1, encrypted_bit_count);
         let mut inputs = Vec::with_capacity(circuit.num_input());
         inputs.push(decryption_key);
@@ -427,7 +611,11 @@ where
         outputs.remove(0)
     }
 
-    fn build_cpu_prf_mask_circuit(&self, params: &DCRTPolyParams) -> PolyCircuit<DCRTPoly> {
+    fn build_cpu_prf_mask_circuit(
+        &self,
+        params: &DCRTPolyParams,
+        prf_mask_output_coeff_bits: usize,
+    ) -> PolyCircuit<DCRTPoly> {
         let mut circuit = PolyCircuit::new();
         let (_, _, crt_depth) = params.to_crt();
         let active_levels =
@@ -436,9 +624,8 @@ where
         let decryption_key = circuit.input(1).at(0).as_single_wire();
         let q: Arc<BigUint> = params.modulus().into();
         let plaintext_moduli =
-            mask_plaintext_moduli_from_full_modulus(q.as_ref(), self.prf_mask_output_coeff_bits);
-        let encrypted_bit_count =
-            params.ring_dimension() as usize * self.prf_mask_output_coeff_bits;
+            mask_plaintext_moduli_from_full_modulus(q.as_ref(), prf_mask_output_coeff_bits);
+        let encrypted_bit_count = params.ring_dimension() as usize * prf_mask_output_coeff_bits;
         let encrypted_bits = (0..encrypted_bit_count)
             .map(|_| {
                 RingGswCiphertext::input(
@@ -574,6 +761,80 @@ fn simulator_context(params: &DCRTPolyParams) -> Arc<SimulatorContext> {
         params.modulus_digits(),
         params.modulus_digits(),
     ))
+}
+
+fn biguint_to_decimal(value: &BigUint) -> BigDecimal {
+    BigDecimal::from(BigInt::from(value.clone()))
+}
+
+fn diamond_io_input_injection_projection_error(
+    input_injection: &DiamondInputErrorSimulation,
+) -> PolyMatrixNorm {
+    input_injection
+        .state_errors
+        .first()
+        .expect("DiamondIO input injection must produce a base final state error")
+        .clone() *
+        &input_injection.output_preimage
+}
+
+fn diamond_io_security_margins_hold(
+    params: &DCRTPolyParams,
+    simulation: &DiamondIOErrorSimulation,
+    prf_mask_output_coeff_bits: usize,
+    security_bit: usize,
+) -> bool {
+    let Some(final_threshold) = diamond_io_final_decode_margin(params, prf_mask_output_coeff_bits)
+    else {
+        return false;
+    };
+    if !validate_error_bound_security_margin(
+        &final_threshold,
+        &simulation.noisy_plaintext_error.poly_norm.norm,
+        security_bit,
+    ) {
+        return false;
+    }
+    simulation.prf_refreshes.iter().all(|refresh| {
+        let Some(threshold) =
+            diamond_io_noise_refresh_pre_round_margin(params, refresh.noise_refresh.v_bits)
+        else {
+            return false;
+        };
+        let worst_error = refresh
+            .noise_refresh
+            .pre_round_outputs
+            .iter()
+            .map(|error| error.poly_norm.norm.clone())
+            .max_by(|lhs, rhs| {
+                lhs.partial_cmp(rhs).expect("noise-refresh pre-rounding norms must be comparable")
+            })
+            .expect("noise-refresh simulation must produce at least one pre-round output");
+        validate_error_bound_security_margin(&threshold, &worst_error, security_bit)
+    })
+}
+
+fn diamond_io_final_decode_margin(
+    params: &DCRTPolyParams,
+    prf_mask_output_coeff_bits: usize,
+) -> Option<BigDecimal> {
+    let q: Arc<BigUint> = params.modulus().into();
+    let threshold = biguint_to_decimal(&(q.as_ref() / 4u32));
+    let mask = biguint_to_decimal(&(BigUint::from(1u32) << prf_mask_output_coeff_bits));
+    (threshold > mask).then_some(threshold - mask)
+}
+
+fn diamond_io_noise_refresh_pre_round_margin(
+    params: &DCRTPolyParams,
+    v_bits: usize,
+) -> Option<BigDecimal> {
+    let (q_moduli, _crt_bits, _crt_depth) = params.to_crt();
+    let q_max = q_moduli.iter().copied().max().expect("CRT modulus list must be nonempty");
+    let full_q: Arc<BigUint> = params.modulus().into();
+    let threshold =
+        biguint_to_decimal(full_q.as_ref()) / (BigDecimal::from(2u32) * BigDecimal::from(q_max));
+    let mask = biguint_to_decimal(&(BigUint::from(1u32) << v_bits));
+    (threshold > mask).then_some(threshold - mask)
 }
 
 fn eval_first_error_output<PE>(

--- a/src/io/diamond_io/simulation.rs
+++ b/src/io/diamond_io/simulation.rs
@@ -1,0 +1,823 @@
+use std::sync::Arc;
+
+use bigdecimal::BigDecimal;
+use digest::Digest;
+use keccak_asm::Keccak256;
+use num_bigint::{BigInt, BigUint};
+use tracing::{debug, info};
+
+use crate::{
+    circuit::{Evaluable, PolyCircuit},
+    gadgets::{
+        arith::NestedRnsPolyContext,
+        fhe::{ring_gsw::RingGswCiphertext, ring_gsw_nested_rns::NestedRnsRingGswContext},
+        fhe_prg::goldreich::evaluate_goldreich_uniform_range,
+    },
+    input_injector::DiamondInputErrorSimulation,
+    lookup::PltEvaluator,
+    matrix::{PolyMatrix, dcrt_poly::DCRTPolyMatrix},
+    noise_refresh::{
+        NoiseRefreshErrorSimulation,
+        circuit_decrypt::{
+            decrypt_bit_decomposed_polynomial, mask_plaintext_moduli_from_full_modulus,
+        },
+        simulate_noise_refresh_error_growth,
+    },
+    poly::{
+        PolyParams,
+        dcrt::{params::DCRTPolyParams, poly::DCRTPoly},
+    },
+    sampler::{PolyHashSampler, PolyTrapdoorSampler, PolyUniformSampler},
+    simulator::{
+        SimulatorContext, error_norm::ErrorNorm, poly_matrix_norm::PolyMatrixNorm,
+        poly_norm::PolyNorm,
+    },
+    slot_transfer::SlotTransferEvaluator,
+    utils::bigdecimal_bits_ceil,
+};
+
+use super::{DIAMOND_SECRET_SIZE, DiamondIO, DiamondIOFuncType};
+
+/// Error-growth summary for the DiamondIO online path.
+///
+/// The simulation exposes the requested durable checkpoints: the Diamond input-injection state
+/// errors, one representative noise-refresh simulation per PRF round, the final projection
+/// residual before decoder addition, and the final noisy-plaintext error after decoder
+/// cancellation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiamondIOErrorSimulation {
+    pub input_injection: DiamondInputErrorSimulation,
+    pub prf_refreshes: Vec<DiamondIOPrfRoundErrorSimulation>,
+    pub projection_residual_error: PolyMatrixNorm,
+    pub noisy_plaintext_error: PolyMatrixNorm,
+}
+
+/// Error-growth summary for one DiamondIO PRF seed-refresh round.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiamondIOPrfRoundErrorSimulation {
+    pub round_idx: usize,
+    pub representative_selected_prg_output: ErrorNorm,
+    pub noise_refresh: NoiseRefreshErrorSimulation,
+}
+
+impl<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST> DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>
+where
+    M: PolyMatrix,
+    US: PolyUniformSampler<M = M> + Send + Sync,
+    HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
+    TS: PolyTrapdoorSampler<M = M> + Send + Sync,
+{
+    /// Simulate DiamondIO error growth for the selected function family.
+    ///
+    /// Goldreich PRG calls are evaluated only for one representative output ciphertext. Those
+    /// representative bounds are simulated with one active q-level and extrapolated to the
+    /// configured full active-level count.
+    pub fn simulate_error_growth<PE, ST>(
+        &self,
+        func_type: DiamondIOFuncType,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+    ) -> Option<DiamondIOErrorSimulation>
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
+        assert_eq!(
+            self.input_size,
+            self.injector.input_count * self.injector.batch_bits(),
+            "DiamondIO input_size must match the injector bit input count"
+        );
+        assert!(self.seed_bits > 0, "DiamondIO error simulation requires seed_bits > 0");
+        assert!(
+            self.prf_mask_output_coeff_bits > 0,
+            "DiamondIO error simulation requires prf_mask_output_coeff_bits > 0"
+        );
+
+        let cpu_params = cpu_params_from_poly_params(&self.injector.params);
+        let (_, _, crt_depth) = cpu_params.to_crt();
+        let full_active_levels =
+            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
+        assert!(
+            full_active_levels > 0 && self.ring_gsw_level_offset + full_active_levels <= crt_depth,
+            "DiamondIO Ring-GSW active levels must fit in the CRT modulus window"
+        );
+        let ctx = simulator_context(&cpu_params);
+        let input_injection = self.injector.simulate_output_error_bounds();
+        let projection_preimage = input_injection.output_preimage.clone();
+        let projected_state_error = input_injection
+            .state_errors
+            .first()
+            .expect("DiamondIO input injection must produce a base final state error")
+            .clone() *
+            &projection_preimage;
+        info!(
+            state_count = input_injection.state_errors.len(),
+            projected_state_error_bits =
+                bigdecimal_bits_ceil(&projected_state_error.poly_norm.norm),
+            "DiamondIO input-injection error simulation finished"
+        );
+        debug!(state_errors = ?input_injection.state_errors, "DiamondIO simulated state errors");
+
+        let one = ErrorNorm::new(PolyNorm::one(ctx.clone()), projected_state_error.clone());
+        let decryption_key = ErrorNorm::new(PolyNorm::one(ctx.clone()), projected_state_error);
+        let decoder_error = ErrorNorm::new(PolyNorm::one(ctx.clone()), one.matrix_norm.clone());
+        // Noise-refresh online decoding material is indexed by `(slot_idx, crt_idx)`.
+        // DiamondIO persists one refresh decoder for every slot and every CRT
+        // level, so the simulator supplies the representative decoder bound in
+        // the same `slot_idx * crt_depth + crt_idx` layout expected by
+        // `simulate_noise_refresh_error_growth`.
+        let decoders =
+            vec![decoder_error.clone(); cpu_params.ring_dimension() as usize * crt_depth];
+        let seed_wire_error = self.initial_seed_wire_error(&cpu_params, &one);
+        let mut seed_errors = vec![seed_wire_error.clone(); self.seed_bits];
+        let mut prf_refreshes = Vec::with_capacity(self.input_size);
+
+        for round_idx in 0..self.input_size {
+            let low = self.simulate_representative_prg_output(
+                &cpu_params,
+                round_idx,
+                2 * self.seed_bits,
+                0,
+                one.clone(),
+                seed_errors.clone(),
+                plt_evaluator,
+                slot_transfer_evaluator,
+            );
+            let high = self.simulate_representative_prg_output(
+                &cpu_params,
+                round_idx,
+                2 * self.seed_bits,
+                self.seed_bits,
+                one.clone(),
+                seed_errors.clone(),
+                plt_evaluator,
+                slot_transfer_evaluator,
+            );
+            let selected = simulate_selected_half_error_norm(one.clone(), low, high, one.clone());
+            let mut refresh_context_circuit = PolyCircuit::<DCRTPoly>::new();
+            let refresh = simulate_noise_refresh_error_growth(
+                self.build_cpu_ring_gsw_context(
+                    &cpu_params,
+                    &mut refresh_context_circuit,
+                    full_active_levels,
+                ),
+                self.seed_bits,
+                self.goldreich_graph_seed,
+                self.noise_refresh_cbd_n,
+                self.ring_gsw_public_key_error_sigma.unwrap_or(0.0),
+                cpu_params.ring_dimension() as usize,
+                one.clone(),
+                selected.clone(),
+                &seed_errors,
+                decryption_key.clone(),
+                &decoders,
+                plt_evaluator,
+                slot_transfer_evaluator,
+            )?;
+            let worst_rounded_error = refresh
+                .rounded_errors
+                .iter()
+                .max_by(|lhs, rhs| {
+                    lhs.poly_norm
+                        .norm
+                        .partial_cmp(&rhs.poly_norm.norm)
+                        .expect("DiamondIO rounded errors must be comparable")
+                })
+                .expect("noise refresh must produce rounded errors")
+                .clone();
+            let refreshed_seed =
+                ErrorNorm::new(worst_rounded_error.poly_norm.clone(), worst_rounded_error);
+            seed_errors = vec![refreshed_seed.clone(); self.seed_bits];
+            info!(
+                round_idx,
+                v_bits = refresh.v_bits,
+                refreshed_seed_error_bits =
+                    bigdecimal_bits_ceil(&refreshed_seed.matrix_norm.poly_norm.norm),
+                "DiamondIO PRF refresh error simulation finished"
+            );
+            prf_refreshes.push(DiamondIOPrfRoundErrorSimulation {
+                round_idx,
+                representative_selected_prg_output: selected,
+                noise_refresh: refresh,
+            });
+        }
+
+        let final_mask_prg_output = self.simulate_representative_prg_output(
+            &cpu_params,
+            self.input_size,
+            self.output_size
+                .checked_mul(cpu_params.ring_dimension() as usize)
+                .and_then(|count| count.checked_mul(self.prf_mask_output_coeff_bits))
+                .expect("DiamondIO final mask PRG conceptual output count overflow"),
+            0,
+            one.clone(),
+            seed_errors,
+            plt_evaluator,
+            slot_transfer_evaluator,
+        );
+        let final_mask_error = self.simulate_final_mask_error(
+            &cpu_params,
+            final_mask_prg_output,
+            one.clone(),
+            decryption_key.clone(),
+            plt_evaluator,
+            slot_transfer_evaluator,
+        );
+        let (function_secret_error, function_public_bottom_error) = self
+            .simulate_representative_function_output(
+                func_type,
+                &cpu_params,
+                one.clone(),
+                decryption_key,
+                seed_wire_error,
+                plt_evaluator,
+                slot_transfer_evaluator,
+            );
+        let evaluated_secret_dependent = function_secret_error + &final_mask_error;
+        let projected_evaluated_error = evaluated_secret_dependent.matrix_norm.clone() *
+            PolyMatrixNorm::gadget_decomposed(ctx.clone(), 1);
+        let public_bottom_decryption_error =
+            self.simulate_public_bottom_decryption_error(&cpu_params, ctx.clone());
+        let projection_residual_error = projected_evaluated_error.clone() +
+            &function_public_bottom_error.matrix_norm +
+            &public_bottom_decryption_error;
+        let noisy_plaintext_error = projection_residual_error.clone() + &decoder_error.matrix_norm;
+        info!(
+            projected_evaluated_bits =
+                bigdecimal_bits_ceil(&projected_evaluated_error.poly_norm.norm),
+            public_bottom_bits =
+                bigdecimal_bits_ceil(&function_public_bottom_error.matrix_norm.poly_norm.norm),
+            public_bottom_decryption_bits =
+                bigdecimal_bits_ceil(&public_bottom_decryption_error.poly_norm.norm),
+            projection_residual_bits =
+                bigdecimal_bits_ceil(&projection_residual_error.poly_norm.norm),
+            noisy_plaintext_bits = bigdecimal_bits_ceil(&noisy_plaintext_error.poly_norm.norm),
+            "DiamondIO final output error simulation finished"
+        );
+
+        Some(DiamondIOErrorSimulation {
+            input_injection,
+            prf_refreshes,
+            projection_residual_error,
+            noisy_plaintext_error,
+        })
+    }
+
+    fn initial_seed_wire_error(&self, _params: &DCRTPolyParams, one: &ErrorNorm) -> ErrorNorm {
+        let max_p_modulus = self
+            .ring_gsw_context
+            .p_moduli
+            .iter()
+            .copied()
+            .max()
+            .expect("nested-RNS Ring-GSW context must have at least one p modulus");
+        let scalar_bound = max_p_modulus - 1;
+        // Ring-GSW native ciphertext inputs are first encoded as nested-RNS
+        // p-residue wires via `ciphertext_inputs_from_native`. Each BGG lift
+        // therefore multiplies by one residue modulo some p_i, not by a full
+        // native q coefficient, so max(p_i) - 1 is the tight scalar bound.
+        let scalar_bound = BigUint::from(scalar_bound);
+        one.large_scalar_mul(&(), &[scalar_bound])
+    }
+
+    fn build_cpu_ring_gsw_context(
+        &self,
+        params: &DCRTPolyParams,
+        circuit: &mut PolyCircuit<DCRTPoly>,
+        active_levels: usize,
+    ) -> Arc<NestedRnsRingGswContext<DCRTPoly>> {
+        let nested_rns_context = Arc::new(NestedRnsPolyContext::setup(
+            circuit,
+            params,
+            self.ring_gsw_context.p_moduli_bits,
+            self.ring_gsw_context.max_unreduced_muls,
+            self.ring_gsw_context.scale,
+            false,
+            Some(active_levels),
+        ));
+        Arc::new(NestedRnsRingGswContext::<DCRTPoly>::from_arith_context(
+            circuit,
+            params,
+            params.ring_dimension() as usize,
+            nested_rns_context,
+            Some(active_levels),
+            Some(self.ring_gsw_level_offset),
+        ))
+    }
+
+    fn simulate_representative_prg_output<PE, ST>(
+        &self,
+        params: &DCRTPolyParams,
+        round_idx: usize,
+        conceptual_output_bits: usize,
+        range_start: usize,
+        one: ErrorNorm,
+        seed_errors: Vec<ErrorNorm>,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+    ) -> ErrorNorm
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
+        let circuit = self.build_cpu_goldreich_prg_range_circuit(
+            params,
+            round_idx,
+            conceptual_output_bits,
+            range_start,
+            1,
+            1,
+        );
+        let wire_count = ring_gsw_wire_count(circuit.num_input(), self.seed_bits);
+        let seed_wire_errors = expand_logical_errors(&seed_errors, wire_count);
+        let mut output = eval_first_error_output(
+            circuit,
+            one,
+            seed_wire_errors,
+            Some(plt_evaluator),
+            Some(slot_transfer_evaluator),
+        );
+        let (_, _, crt_depth) = params.to_crt();
+        let full_active_levels =
+            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
+        output.matrix_norm = output.matrix_norm * BigDecimal::from(full_active_levels as u64);
+        info!(
+            round_idx,
+            conceptual_output_bits,
+            range_start,
+            simulated_active_levels = 1usize,
+            extrapolated_active_levels = full_active_levels,
+            output_error_bits = bigdecimal_bits_ceil(&output.matrix_norm.poly_norm.norm),
+            "DiamondIO representative Goldreich PRG error simulated"
+        );
+        output
+    }
+
+    fn build_cpu_goldreich_prg_range_circuit(
+        &self,
+        params: &DCRTPolyParams,
+        round_idx: usize,
+        conceptual_output_bits: usize,
+        range_start: usize,
+        range_len: usize,
+        active_levels: usize,
+    ) -> PolyCircuit<DCRTPoly> {
+        assert!(self.seed_bits >= 5, "DiamondIO Goldreich PRF seed bit length must be at least 5");
+        let mut circuit = PolyCircuit::new();
+        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, active_levels);
+        let seed_ciphertexts = (0..self.seed_bits)
+            .map(|_| {
+                RingGswCiphertext::input(
+                    ring_gsw_context.clone(),
+                    Some(BigUint::from(1u64)),
+                    &mut circuit,
+                )
+            })
+            .collect::<Vec<_>>();
+        let outputs = evaluate_goldreich_uniform_range(
+            &mut circuit,
+            ring_gsw_context,
+            &seed_ciphertexts,
+            conceptual_output_bits,
+            range_start,
+            range_len,
+            self.derive_diamond_goldreich_graph_seed(round_idx),
+        );
+        circuit.output(outputs.iter().flat_map(|output| output.sub_circuit_wires()));
+        circuit
+    }
+
+    fn simulate_final_mask_error<PE, ST>(
+        &self,
+        params: &DCRTPolyParams,
+        final_mask_prg_output: ErrorNorm,
+        one: ErrorNorm,
+        decryption_key: ErrorNorm,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+    ) -> ErrorNorm
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
+        let circuit = self.build_cpu_prf_mask_circuit(params);
+        let encrypted_bit_count =
+            params.ring_dimension() as usize * self.prf_mask_output_coeff_bits;
+        let wire_count = ring_gsw_wire_count(circuit.num_input() - 1, encrypted_bit_count);
+        let mut inputs = Vec::with_capacity(circuit.num_input());
+        inputs.push(decryption_key);
+        inputs.extend(expand_logical_errors(
+            &vec![final_mask_prg_output; encrypted_bit_count],
+            wire_count,
+        ));
+        assert_eq!(
+            inputs.len(),
+            circuit.num_input(),
+            "DiamondIO final mask error-simulation input count mismatch"
+        );
+        let mut outputs = circuit.eval(
+            &(),
+            one,
+            inputs,
+            Some(plt_evaluator),
+            Some(slot_transfer_evaluator as &dyn SlotTransferEvaluator<ErrorNorm>),
+            None,
+        );
+        assert_eq!(outputs.len(), 1, "DiamondIO final mask circuit must produce one output");
+        outputs.remove(0)
+    }
+
+    fn build_cpu_prf_mask_circuit(&self, params: &DCRTPolyParams) -> PolyCircuit<DCRTPoly> {
+        let mut circuit = PolyCircuit::new();
+        let (_, _, crt_depth) = params.to_crt();
+        let active_levels =
+            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
+        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, active_levels);
+        let decryption_key = circuit.input(1).at(0).as_single_wire();
+        let q: Arc<BigUint> = params.modulus().into();
+        let plaintext_moduli =
+            mask_plaintext_moduli_from_full_modulus(q.as_ref(), self.prf_mask_output_coeff_bits);
+        let encrypted_bit_count =
+            params.ring_dimension() as usize * self.prf_mask_output_coeff_bits;
+        let encrypted_bits = (0..encrypted_bit_count)
+            .map(|_| {
+                RingGswCiphertext::input(
+                    ring_gsw_context.clone(),
+                    Some(BigUint::from(1u64)),
+                    &mut circuit,
+                )
+            })
+            .collect::<Vec<_>>();
+        let decrypted = decrypt_bit_decomposed_polynomial::<
+            DCRTPoly,
+            crate::gadgets::arith::NestedRnsPoly<DCRTPoly>,
+            DCRTPolyMatrix,
+        >(&mut circuit, &encrypted_bits, decryption_key, &plaintext_moduli);
+        circuit.output(vec![decrypted]);
+        circuit
+    }
+
+    fn simulate_representative_function_output<PE, ST>(
+        &self,
+        func_type: DiamondIOFuncType,
+        params: &DCRTPolyParams,
+        one: ErrorNorm,
+        decryption_key: ErrorNorm,
+        seed_wire_error: ErrorNorm,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+    ) -> (ErrorNorm, ErrorNorm)
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
+        let circuit = match func_type {
+            DiamondIOFuncType::DebugDecryption => {
+                self.build_cpu_debug_decryption_circuit(params, 1)
+            }
+        };
+        let seed_wire_count = circuit.num_input() - 1;
+        let mut inputs = Vec::with_capacity(circuit.num_input());
+        inputs.push(decryption_key);
+        inputs.extend(std::iter::repeat_n(seed_wire_error, seed_wire_count));
+        let outputs = circuit.eval(
+            &(),
+            one,
+            inputs,
+            Some(plt_evaluator),
+            Some(slot_transfer_evaluator as &dyn SlotTransferEvaluator<ErrorNorm>),
+            None,
+        );
+        assert_eq!(outputs.len(), 2, "DiamondIO representative function output must be a pair");
+        (outputs[0].clone(), outputs[1].clone())
+    }
+
+    fn build_cpu_debug_decryption_circuit(
+        &self,
+        params: &DCRTPolyParams,
+        representative_seed_bits: usize,
+    ) -> PolyCircuit<DCRTPoly> {
+        let mut circuit = PolyCircuit::new();
+        let (_, _, crt_depth) = params.to_crt();
+        let active_levels =
+            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
+        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, active_levels);
+        let decryption_key = circuit.input(1).at(0).as_single_wire();
+        let mut outputs = Vec::with_capacity(2 * representative_seed_bits);
+        for _ in 0..representative_seed_bits {
+            let ciphertext = RingGswCiphertext::input(
+                ring_gsw_context.clone(),
+                Some(BigUint::from(1u64)),
+                &mut circuit,
+            );
+            let decrypted = ciphertext.decrypt::<DCRTPolyMatrix>(
+                decryption_key,
+                BigUint::from(2u64),
+                &mut circuit,
+            );
+            outputs.push(decrypted.secret_dependent);
+            outputs.push(decrypted.public_bottom);
+        }
+        circuit.output(outputs);
+        circuit
+    }
+
+    fn simulate_public_bottom_decryption_error(
+        &self,
+        params: &DCRTPolyParams,
+        output_ctx: Arc<SimulatorContext>,
+    ) -> PolyMatrixNorm {
+        let mut circuit = PolyCircuit::new();
+        let (_, _, crt_depth) = params.to_crt();
+        let active_levels =
+            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
+        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, active_levels);
+        let ciphertext =
+            RingGswCiphertext::input(ring_gsw_context, Some(BigUint::from(1u64)), &mut circuit);
+        let raw = ciphertext
+            .estimate_decryption_error_norm(self.ring_gsw_public_key_error_sigma.unwrap_or(0.0));
+        PolyMatrixNorm::new(output_ctx, 1, 1, raw.poly_norm.norm, None)
+    }
+
+    fn derive_diamond_goldreich_graph_seed(&self, round_idx: usize) -> [u8; 32] {
+        let mut hasher = Keccak256::new();
+        hasher.update(b"DiamondIOGoldreichPrfGraph/v1");
+        hasher.update(self.goldreich_graph_seed);
+        hasher.update(round_idx.to_le_bytes());
+        hasher.finalize().into()
+    }
+}
+
+fn cpu_params_from_poly_params<P: PolyParams>(params: &P) -> DCRTPolyParams {
+    let (q_moduli, crt_bits, crt_depth) = params.to_crt();
+    let cpu_params =
+        DCRTPolyParams::new(params.ring_dimension(), crt_depth, crt_bits, params.base_bits());
+    let (cpu_q_moduli, cpu_crt_bits, cpu_crt_depth) = cpu_params.to_crt();
+    assert_eq!(cpu_crt_bits, crt_bits, "CPU simulation CRT bit width mismatch");
+    assert_eq!(cpu_crt_depth, crt_depth, "CPU simulation CRT depth mismatch");
+    assert_eq!(
+        cpu_q_moduli, q_moduli,
+        "CPU simulation parameters must reproduce the DiamondIO CRT moduli"
+    );
+    cpu_params
+}
+
+fn simulator_context(params: &DCRTPolyParams) -> Arc<SimulatorContext> {
+    let ring_dim_sqrt = BigDecimal::from(params.ring_dimension() as u64)
+        .sqrt()
+        .expect("sqrt(ring_dimension) failed");
+    let base = BigDecimal::from(BigInt::from(BigUint::from(1u64) << params.base_bits()));
+    Arc::new(SimulatorContext::new(
+        ring_dim_sqrt,
+        base,
+        DIAMOND_SECRET_SIZE,
+        params.modulus_digits(),
+        params.modulus_digits(),
+    ))
+}
+
+fn eval_first_error_output<PE>(
+    mut circuit: PolyCircuit<DCRTPoly>,
+    one: ErrorNorm,
+    inputs: Vec<ErrorNorm>,
+    plt_evaluator: Option<&PE>,
+    slot_transfer_evaluator: Option<&dyn SlotTransferEvaluator<ErrorNorm>>,
+) -> ErrorNorm
+where
+    PE: PltEvaluator<ErrorNorm>,
+{
+    assert_eq!(
+        inputs.len(),
+        circuit.num_input(),
+        "DiamondIO first-output error-simulation input count mismatch"
+    );
+    assert!(circuit.num_output() > 0, "DiamondIO representative circuit has no output");
+    circuit.restrict_outputs_to_indices(&[0]);
+    let mut outputs = circuit.eval(&(), one, inputs, plt_evaluator, slot_transfer_evaluator, None);
+    assert_eq!(outputs.len(), 1, "DiamondIO representative evaluation must return one output");
+    outputs.remove(0)
+}
+
+fn simulate_selected_half_error_norm(
+    one: ErrorNorm,
+    low: ErrorNorm,
+    high: ErrorNorm,
+    selector: ErrorNorm,
+) -> ErrorNorm {
+    let mut circuit = PolyCircuit::<DCRTPoly>::new();
+    let low_wire = circuit.input(1).at(0).as_single_wire();
+    let high_wire = circuit.input(1).at(0).as_single_wire();
+    let selector_wire = circuit.input(1).at(0).as_single_wire();
+    let high_minus_low = circuit.sub_gate(high_wire, low_wire);
+    let selected_delta = circuit.mul_gate(selector_wire, high_minus_low);
+    let selected = circuit.add_gate(low_wire, selected_delta);
+    circuit.output([selected]);
+    let mut outputs = circuit.eval(
+        &(),
+        one,
+        vec![low, high, selector],
+        None::<&crate::simulator::error_norm::NormPltLWEEvaluator>,
+        None,
+        None,
+    );
+    assert_eq!(outputs.len(), 1, "DiamondIO selector circuit must produce one output");
+    outputs.remove(0)
+}
+
+fn expand_logical_errors(logical_errors: &[ErrorNorm], wire_count: usize) -> Vec<ErrorNorm> {
+    assert!(wire_count > 0, "Ring-GSW wire count must be positive");
+    logical_errors.iter().flat_map(|error| std::iter::repeat_n(error.clone(), wire_count)).collect()
+}
+
+fn ring_gsw_wire_count(flat_input_count: usize, logical_bit_count: usize) -> usize {
+    assert!(logical_bit_count > 0, "logical Ring-GSW bit count must be positive");
+    assert_eq!(
+        flat_input_count % logical_bit_count,
+        0,
+        "flattened Ring-GSW input count must be divisible by logical bit count"
+    );
+    flat_input_count / logical_bit_count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        func_enc::aky24::NoCircuitEvaluator,
+        gadgets::arith::ModularArithmeticContext,
+        input_injector::DiamondInjector,
+        matrix::dcrt_poly::DCRTPolyMatrix,
+        sampler::{
+            hash::DCRTPolyHashSampler, trapdoor::DCRTPolyTrapdoorSampler,
+            uniform::DCRTPolyUniformSampler,
+        },
+        simulator::error_norm::{NormNaiveBggEncodingVecSTEvaluator, NormPltLWEEvaluator},
+    };
+    use num_traits::FromPrimitive;
+
+    type TestDiamondIO = DiamondIO<
+        DCRTPolyMatrix,
+        DCRTPolyUniformSampler,
+        DCRTPolyHashSampler<Keccak256>,
+        DCRTPolyTrapdoorSampler,
+        NoCircuitEvaluator,
+        NoCircuitEvaluator,
+        NoCircuitEvaluator,
+        NoCircuitEvaluator,
+    >;
+
+    fn test_scheme(active_levels: usize) -> TestDiamondIO {
+        test_scheme_with_input_count(active_levels, 1)
+    }
+
+    fn test_scheme_with_input_count(active_levels: usize, input_count: usize) -> TestDiamondIO {
+        let params = DCRTPolyParams::new(2, active_levels, 10, 5);
+        let mut setup_circuit = PolyCircuit::<DCRTPoly>::new();
+        let ring_gsw_context = Arc::new(NestedRnsPolyContext::setup(
+            &mut setup_circuit,
+            &params,
+            5,
+            2,
+            1 << 8,
+            false,
+            Some(active_levels),
+        ));
+        let ring_gsw_width = 2 *
+            <NestedRnsPolyContext as ModularArithmeticContext<DCRTPoly>>::gadget_len(
+                ring_gsw_context.as_ref(),
+                Some(active_levels),
+                Some(0),
+            );
+        let injector = DiamondInjector::<
+            DCRTPolyMatrix,
+            DCRTPolyUniformSampler,
+            DCRTPolyHashSampler<Keccak256>,
+            DCRTPolyTrapdoorSampler,
+        >::new(params.clone(), input_count, 2, 4.578, 0.0);
+        TestDiamondIO::new(
+            injector,
+            input_count,
+            5,
+            params.clone(),
+            ring_gsw_context,
+            ring_gsw_width,
+            0,
+            Some(active_levels),
+            Some(0.0),
+            b"diamond_io_error_simulation_test".to_vec(),
+            5,
+            1,
+            1,
+            1,
+            [0x24; 32],
+            [0x42; 32],
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    #[ignore = "full DiamondIO error simulation is heavier than default unit tests"]
+    fn test_simulate_error_growth_reuses_input_injector_state_errors() {
+        let scheme = test_scheme_with_input_count(2, 0);
+        let ctx = simulator_context(&scheme.injector.params);
+        let plt_evaluator =
+            NormPltLWEEvaluator::new(ctx.clone(), &BigDecimal::from_f64(0.0).unwrap());
+        let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
+
+        let expected = scheme.injector.simulate_output_error_bounds().state_errors;
+        let simulation = scheme
+            .simulate_error_growth(
+                DiamondIOFuncType::DebugDecryption,
+                &plt_evaluator,
+                &slot_transfer_evaluator,
+            )
+            .expect("DiamondIO error simulation should find a noise-refresh mask size");
+
+        assert_eq!(simulation.input_injection.state_errors, expected);
+        assert!(simulation.prf_refreshes.is_empty());
+    }
+
+    #[test]
+    #[ignore = "full noise-refresh path is intentionally heavier than default unit tests"]
+    fn test_simulate_error_growth_records_one_refresh_per_input_bit() {
+        let scheme = test_scheme(2);
+        let ctx = simulator_context(&scheme.injector.params);
+        let plt_evaluator =
+            NormPltLWEEvaluator::new(ctx.clone(), &BigDecimal::from_f64(0.0).unwrap());
+        let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
+
+        let simulation = scheme
+            .simulate_error_growth(
+                DiamondIOFuncType::DebugDecryption,
+                &plt_evaluator,
+                &slot_transfer_evaluator,
+            )
+            .expect("DiamondIO error simulation should find a noise-refresh mask size");
+
+        assert_eq!(simulation.prf_refreshes.len(), scheme.input_size);
+    }
+
+    #[test]
+    fn test_goldreich_prg_helper_builds_one_logical_output() {
+        let scheme = test_scheme(1);
+        let params = cpu_params_from_poly_params(&scheme.injector.params);
+        let one_output =
+            scheme.build_cpu_goldreich_prg_range_circuit(&params, 0, 2 * scheme.seed_bits, 0, 1, 1);
+        let two_outputs =
+            scheme.build_cpu_goldreich_prg_range_circuit(&params, 0, 2 * scheme.seed_bits, 0, 2, 1);
+        assert!(one_output.num_output() > 0);
+        assert_eq!(two_outputs.num_output(), 2 * one_output.num_output());
+    }
+
+    #[test]
+    #[ignore = "representative PRG ErrorNorm evaluation is heavier than default unit tests"]
+    fn test_representative_prg_extrapolates_active_levels() {
+        let scheme = test_scheme(2);
+        let params = cpu_params_from_poly_params(&scheme.injector.params);
+        let ctx = simulator_context(&params);
+        let projected = PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_g, BigDecimal::from(1u64), None);
+        let one = ErrorNorm::new(PolyNorm::one(ctx.clone()), projected);
+        let seed_errors = vec![one.clone(); scheme.seed_bits];
+        let plt_evaluator = NormPltLWEEvaluator::new(ctx, &BigDecimal::from_f64(0.0).unwrap());
+        let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
+
+        let mut unscaled = eval_first_error_output(
+            scheme.build_cpu_goldreich_prg_range_circuit(&params, 0, 2 * scheme.seed_bits, 0, 1, 1),
+            one.clone(),
+            expand_logical_errors(
+                &seed_errors,
+                ring_gsw_wire_count(
+                    scheme
+                        .build_cpu_goldreich_prg_range_circuit(
+                            &params,
+                            0,
+                            2 * scheme.seed_bits,
+                            0,
+                            1,
+                            1,
+                        )
+                        .num_input(),
+                    scheme.seed_bits,
+                ),
+            ),
+            Some(&plt_evaluator),
+            Some(&slot_transfer_evaluator),
+        );
+        unscaled.matrix_norm = unscaled.matrix_norm * BigDecimal::from(2u64);
+        let scaled = scheme.simulate_representative_prg_output(
+            &params,
+            0,
+            2 * scheme.seed_bits,
+            0,
+            one,
+            seed_errors,
+            &plt_evaluator,
+            &slot_transfer_evaluator,
+        );
+        assert_eq!(scaled.matrix_norm, unscaled.matrix_norm);
+    }
+}

--- a/src/io/diamond_io/simulation.rs
+++ b/src/io/diamond_io/simulation.rs
@@ -17,11 +17,7 @@ use crate::{
     lookup::PltEvaluator,
     matrix::{PolyMatrix, dcrt_poly::DCRTPolyMatrix},
     noise_refresh::{
-        NoiseRefreshErrorSimulation,
-        circuit_decrypt::{
-            decrypt_bit_decomposed_polynomial, mask_plaintext_moduli_from_full_modulus,
-        },
-        simulate_noise_refresh_error_growth,
+        NoiseRefreshErrorSimulation, simulate_symmetric_noise_refresh_error_growth,
         simulation::validate_error_bound_security_margin,
     },
     poly::{
@@ -84,6 +80,20 @@ pub struct DiamondIOCrtDepthSearchResult {
     /// This is `input_injection.state_errors[0] * input_injection.output_preimage`, matching the
     /// projected state error used as the `one`, decryption-key, and decoder input bound.
     pub input_injection_projection_error: PolyMatrixNorm,
+}
+
+#[derive(Debug, Clone)]
+struct DiamondIOMaskIndependentErrorPrefix {
+    cpu_params: DCRTPolyParams,
+    ctx: Arc<SimulatorContext>,
+    input_injection: DiamondInputErrorSimulation,
+    prf_refreshes: Vec<DiamondIOPrfRoundErrorSimulation>,
+    one: ErrorNorm,
+    decryption_key: ErrorNorm,
+    final_decoder_error: ErrorNorm,
+    final_seed_errors: Vec<ErrorNorm>,
+    function_secret_error: ErrorNorm,
+    public_bottom_decryption_error: PolyMatrixNorm,
 }
 
 /// Finds the smallest CRT depth whose correctness and security checks pass.
@@ -202,10 +212,9 @@ where
     /// Search for the largest PRF mask coefficient bit-width that satisfies the final decode
     /// margin.
     ///
-    /// Each candidate bit-width is evaluated with a fresh DiamondIO error simulation, so the
-    /// returned simulation accounts for that candidate's final PRF mask PRG and mask
-    /// decrypt/recomposition error. A candidate is valid exactly when
-    /// `noisy_plaintext_error + 2^candidate < q / 4`.
+    /// The mask-independent prefix and final-mask representative PRG are cached across candidates.
+    /// The remaining per-candidate work accounts for that bit width's mask decrypt/recomposition
+    /// error. A candidate is valid exactly when `noisy_plaintext_error + 2^candidate < q / 4`.
     pub fn max_safe_prf_mask_output_coeff_bits<PE, ST>(
         &self,
         func_type: DiamondIOFuncType,
@@ -223,16 +232,59 @@ where
         let mut high = max_candidate;
         let mut best = None;
         info!(max_bits, max_candidate, "starting DiamondIO PRF mask bit search");
+        let prefix = self.simulate_mask_independent_error_prefix(
+            func_type,
+            plt_evaluator,
+            slot_transfer_evaluator,
+        )?;
+        info!(
+            prf_rounds = prefix.prf_refreshes.len(),
+            "DiamondIO PRF mask bit search cached mask-independent prefix"
+        );
+        let cached_final_mask_prg_output = self.simulate_representative_prg_output(
+            &prefix.cpu_params,
+            self.input_size,
+            self.output_size
+                .checked_mul(prefix.cpu_params.ring_dimension() as usize)
+                .and_then(|count| count.checked_mul(max_candidate))
+                .expect("DiamondIO final mask PRG conceptual output count overflow"),
+            0,
+            prefix.one.clone(),
+            prefix.final_seed_errors.clone(),
+            plt_evaluator,
+            slot_transfer_evaluator,
+        );
+        info!(
+            max_candidate,
+            final_mask_prg_bits =
+                bigdecimal_bits_ceil(&cached_final_mask_prg_output.matrix_norm.poly_norm.norm),
+            "DiamondIO PRF mask bit search cached final-mask representative PRG"
+        );
+        let cached_final_mask_base_error = self.simulate_final_mask_base_error(
+            &prefix.cpu_params,
+            cached_final_mask_prg_output.clone(),
+            prefix.one.clone(),
+            prefix.decryption_key.clone(),
+            plt_evaluator,
+            slot_transfer_evaluator,
+        );
+        info!(
+            final_mask_base_bits =
+                bigdecimal_bits_ceil(&cached_final_mask_base_error.matrix_norm.poly_norm.norm),
+            "DiamondIO PRF mask bit search cached final-mask representative decrypt"
+        );
         while low <= high {
             let candidate = low + (high - low) / 2;
             info!(candidate, low, high, "evaluating DiamondIO PRF mask bit candidate");
-            let simulation = self.simulate_error_growth_with_prf_mask_output_coeff_bits(
-                func_type,
+            let simulation = self.finish_error_growth_from_mask_independent_prefix(
+                &prefix,
                 candidate,
+                Some(cached_final_mask_prg_output.clone()),
+                Some(cached_final_mask_base_error.clone()),
                 plt_evaluator,
                 slot_transfer_evaluator,
-            )?;
-            let q: Arc<BigUint> = cpu_params.modulus().into();
+            );
+            let q: Arc<BigUint> = prefix.cpu_params.modulus().into();
             let quarter_q = biguint_to_decimal(&(q.as_ref() / 4u32));
             let mask_value = biguint_to_decimal(&(BigUint::from(1u32) << candidate));
             let valid = &simulation.noisy_plaintext_error.poly_norm.norm + &mask_value < quarter_q;
@@ -282,6 +334,38 @@ where
             "DiamondIO error simulation requires prf_mask_output_coeff_bits > 0"
         );
 
+        let prefix = self.simulate_mask_independent_error_prefix(
+            func_type,
+            plt_evaluator,
+            slot_transfer_evaluator,
+        )?;
+        Some(self.finish_error_growth_from_mask_independent_prefix(
+            &prefix,
+            prf_mask_output_coeff_bits,
+            None,
+            None,
+            plt_evaluator,
+            slot_transfer_evaluator,
+        ))
+    }
+
+    fn simulate_mask_independent_error_prefix<PE, ST>(
+        &self,
+        func_type: DiamondIOFuncType,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+    ) -> Option<DiamondIOMaskIndependentErrorPrefix>
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
+        assert_eq!(
+            self.input_size,
+            self.injector.input_count * self.injector.batch_bits(),
+            "DiamondIO input_size must match the injector bit input count"
+        );
+        assert!(self.seed_bits > 0, "DiamondIO error simulation requires seed_bits > 0");
+
         let cpu_params = cpu_params_from_poly_params(&self.injector.params);
         let (_, _, crt_depth) = cpu_params.to_crt();
         let full_active_levels =
@@ -303,20 +387,45 @@ where
 
         let one = ErrorNorm::new(PolyNorm::one(ctx.clone()), projected_state_error.clone());
         let decryption_key = ErrorNorm::new(PolyNorm::one(ctx.clone()), projected_state_error);
-        let decoder_error = ErrorNorm::new(PolyNorm::one(ctx.clone()), one.matrix_norm.clone());
-        // Noise-refresh online decoding material is indexed by `(slot_idx, crt_idx)`.
-        // DiamondIO persists one refresh decoder for every slot and every CRT
-        // level, so the simulator supplies the representative decoder bound in
-        // the same `slot_idx * crt_depth + crt_idx` layout expected by
-        // `simulate_noise_refresh_error_growth`.
-        let decoders =
-            vec![decoder_error.clone(); cpu_params.ring_dimension() as usize * crt_depth];
+        let refresh_decoder_error =
+            ErrorNorm::new(PolyNorm::one(ctx.clone()), one.matrix_norm.clone());
+        let final_decoder_projection_error =
+            diamond_io_input_injection_scalar_projection_error(&input_injection);
+        let final_decoder_error =
+            ErrorNorm::new(PolyNorm::one(ctx.clone()), final_decoder_projection_error);
         let seed_wire_error = self.initial_seed_wire_error(&cpu_params, &one);
         let mut seed_errors = vec![seed_wire_error.clone(); self.seed_bits];
         let mut prf_refreshes = Vec::with_capacity(self.input_size);
+        let mut steady_prf_round_cache: Option<(
+            ErrorNorm,
+            NoiseRefreshErrorSimulation,
+            ErrorNorm,
+        )> = None;
 
         for round_idx in 0..self.input_size {
-            let low = self.simulate_representative_prg_output(
+            if round_idx > 1 {
+                if let Some((selected, refresh, refreshed_seed)) = &steady_prf_round_cache {
+                    seed_errors = vec![refreshed_seed.clone(); self.seed_bits];
+                    info!(
+                        round_idx,
+                        v_bits = refresh.v_bits,
+                        refreshed_seed_error_bits =
+                            bigdecimal_bits_ceil(&refreshed_seed.matrix_norm.poly_norm.norm),
+                        "DiamondIO reusing steady-state PRF refresh error simulation"
+                    );
+                    prf_refreshes.push(DiamondIOPrfRoundErrorSimulation {
+                        round_idx,
+                        representative_selected_prg_output: selected.clone(),
+                        noise_refresh: refresh.clone(),
+                    });
+                    continue;
+                }
+            }
+            // Low and high halves are both one representative Goldreich PRG output evaluated from
+            // the same seed-error profile. The selected output circuit below only needs an
+            // ErrorNorm bound for each encoded branch, so the symmetric high branch can reuse the
+            // low branch bound instead of evaluating the same one-bit PRG circuit twice.
+            let representative_branch = self.simulate_representative_prg_output(
                 &cpu_params,
                 round_idx,
                 2 * self.seed_bits,
@@ -326,19 +435,25 @@ where
                 plt_evaluator,
                 slot_transfer_evaluator,
             );
-            let high = self.simulate_representative_prg_output(
-                &cpu_params,
+            debug!(
                 round_idx,
-                2 * self.seed_bits,
-                self.seed_bits,
-                one.clone(),
-                seed_errors.clone(),
-                plt_evaluator,
-                slot_transfer_evaluator,
+                high_range_start = self.seed_bits,
+                "DiamondIO reusing representative PRG branch error for symmetric high half"
             );
+            let material_branch = representative_branch.clone();
+            let low = representative_branch.clone();
+            let high = representative_branch;
             let selected = simulate_selected_half_error_norm(one.clone(), low, high, one.clone());
+            let material_wire_error = scale_error_norm(
+                // Noise-refresh material is generated from the same encrypted seed profile by a
+                // one-output Goldreich PRG. CBD material combines `2 * cbd_n` uniform branches, so
+                // scaling the active-level-extrapolated representative branch is a conservative
+                // bound for both CBD error and mask material wires.
+                material_branch,
+                &BigDecimal::from((2 * self.noise_refresh_cbd_n) as u64),
+            );
             let mut refresh_context_circuit = PolyCircuit::<DCRTPoly>::new();
-            let refresh = simulate_noise_refresh_error_growth(
+            let refresh = simulate_symmetric_noise_refresh_error_growth(
                 self.build_cpu_ring_gsw_context(
                     &cpu_params,
                     &mut refresh_context_circuit,
@@ -353,7 +468,8 @@ where
                 selected.clone(),
                 &seed_errors,
                 decryption_key.clone(),
-                &decoders,
+                refresh_decoder_error.clone(),
+                Some(material_wire_error),
                 plt_evaluator,
                 slot_transfer_evaluator,
             )?;
@@ -380,71 +496,150 @@ where
             );
             prf_refreshes.push(DiamondIOPrfRoundErrorSimulation {
                 round_idx,
-                representative_selected_prg_output: selected,
-                noise_refresh: refresh,
+                representative_selected_prg_output: selected.clone(),
+                noise_refresh: refresh.clone(),
             });
+            if round_idx >= 1 {
+                // After the first refresh, every subsequent seed wire has the same rounded CBD
+                // error bound. The Goldreich graph seed changes with the round index, but ErrorNorm
+                // sees the same one-output circuit shape and the same symmetric seed-error profile,
+                // so the representative selected PRG output and refresh result can be reused for
+                // later rounds.
+                steady_prf_round_cache = Some((selected, refresh, refreshed_seed));
+            }
         }
 
-        let final_mask_prg_output = self.simulate_representative_prg_output(
-            &cpu_params,
-            self.input_size,
-            self.output_size
-                .checked_mul(cpu_params.ring_dimension() as usize)
-                .and_then(|count| count.checked_mul(prf_mask_output_coeff_bits))
-                .expect("DiamondIO final mask PRG conceptual output count overflow"),
-            0,
-            one.clone(),
-            seed_errors,
-            plt_evaluator,
-            slot_transfer_evaluator,
-        );
-        let final_mask_error = self.simulate_final_mask_error(
-            &cpu_params,
-            prf_mask_output_coeff_bits,
-            final_mask_prg_output,
-            one.clone(),
-            decryption_key.clone(),
-            plt_evaluator,
-            slot_transfer_evaluator,
-        );
         let (function_secret_error, function_public_bottom_error) = self
             .simulate_representative_function_output(
                 func_type,
                 &cpu_params,
                 one.clone(),
-                decryption_key,
-                seed_wire_error,
+                decryption_key.clone(),
+                seed_wire_error.clone(),
                 plt_evaluator,
                 slot_transfer_evaluator,
             );
-        let evaluated_secret_dependent = function_secret_error + &final_mask_error;
-        let projected_evaluated_error = evaluated_secret_dependent.matrix_norm.clone() *
-            PolyMatrixNorm::gadget_decomposed(ctx.clone(), 1);
+        info!(
+            function_secret_bits =
+                bigdecimal_bits_ceil(&function_secret_error.matrix_norm.poly_norm.norm),
+            function_public_bottom_plaintext_bits =
+                bigdecimal_bits_ceil(&function_public_bottom_error.plaintext_norm.norm),
+            function_public_bottom_encoding_bits =
+                bigdecimal_bits_ceil(&function_public_bottom_error.matrix_norm.poly_norm.norm),
+            "DiamondIO representative function output error simulation finished"
+        );
         let public_bottom_decryption_error =
             self.simulate_public_bottom_decryption_error(&cpu_params, ctx.clone());
-        let projection_residual_error = projected_evaluated_error.clone() +
-            &function_public_bottom_error.matrix_norm +
-            &public_bottom_decryption_error;
-        let noisy_plaintext_error = projection_residual_error.clone() + &decoder_error.matrix_norm;
+        info!(
+            prf_rounds = prf_refreshes.len(),
+            "DiamondIO mask-independent error simulation prefix finished"
+        );
+
+        Some(DiamondIOMaskIndependentErrorPrefix {
+            cpu_params,
+            ctx,
+            input_injection,
+            prf_refreshes,
+            one,
+            decryption_key,
+            final_decoder_error,
+            final_seed_errors: seed_errors,
+            function_secret_error,
+            public_bottom_decryption_error,
+        })
+    }
+
+    fn finish_error_growth_from_mask_independent_prefix<PE, ST>(
+        &self,
+        prefix: &DiamondIOMaskIndependentErrorPrefix,
+        prf_mask_output_coeff_bits: usize,
+        cached_final_mask_prg_output: Option<ErrorNorm>,
+        cached_final_mask_base_error: Option<ErrorNorm>,
+        plt_evaluator: &PE,
+        slot_transfer_evaluator: &ST,
+    ) -> DiamondIOErrorSimulation
+    where
+        PE: PltEvaluator<ErrorNorm>,
+        ST: SlotTransferEvaluator<ErrorNorm>,
+    {
+        assert!(
+            prf_mask_output_coeff_bits > 0,
+            "DiamondIO error simulation requires prf_mask_output_coeff_bits > 0"
+        );
+        let final_mask_prg_output = cached_final_mask_prg_output.unwrap_or_else(|| {
+            self.simulate_representative_prg_output(
+                &prefix.cpu_params,
+                self.input_size,
+                self.output_size
+                    .checked_mul(prefix.cpu_params.ring_dimension() as usize)
+                    .and_then(|count| count.checked_mul(prf_mask_output_coeff_bits))
+                    .expect("DiamondIO final mask PRG conceptual output count overflow"),
+                0,
+                prefix.one.clone(),
+                prefix.final_seed_errors.clone(),
+                plt_evaluator,
+                slot_transfer_evaluator,
+            )
+        });
+        info!(
+            prf_mask_output_coeff_bits,
+            final_mask_prg_bits =
+                bigdecimal_bits_ceil(&final_mask_prg_output.matrix_norm.poly_norm.norm),
+            "DiamondIO final mask representative PRG error simulation finished"
+        );
+        let final_mask_base_error = cached_final_mask_base_error.unwrap_or_else(|| {
+            self.simulate_final_mask_base_error(
+                &prefix.cpu_params,
+                final_mask_prg_output,
+                prefix.one.clone(),
+                prefix.decryption_key.clone(),
+                plt_evaluator,
+                slot_transfer_evaluator,
+            )
+        });
+        let final_mask_error = scale_error_norm(
+            final_mask_base_error,
+            &BigDecimal::from(prf_mask_output_coeff_bits as u64),
+        );
+        assert_same_matrix_shape(
+            &final_mask_error.matrix_norm,
+            &prefix.function_secret_error.matrix_norm,
+            "final mask and function secret-dependent representative errors must share the pre-projection BGG encoding shape",
+        );
+        let evaluated_secret_dependent = prefix.function_secret_error.clone() + &final_mask_error;
+        let projected_evaluated_error = evaluated_secret_dependent.matrix_norm.clone() *
+            PolyMatrixNorm::gadget_decomposed(prefix.ctx.clone(), 1);
+        assert_same_matrix_shape(
+            &prefix.public_bottom_decryption_error,
+            &projected_evaluated_error,
+            "public-bottom decryption error must be a representative final scalar residual error",
+        );
+        let projection_residual_error =
+            projected_evaluated_error.clone() + &prefix.public_bottom_decryption_error;
+        assert_same_matrix_shape(
+            &prefix.final_decoder_error.matrix_norm,
+            &projection_residual_error,
+            "decoder projection error must be a representative final scalar residual error",
+        );
+        let noisy_plaintext_error =
+            projection_residual_error.clone() + &prefix.final_decoder_error.matrix_norm;
         info!(
             projected_evaluated_bits =
                 bigdecimal_bits_ceil(&projected_evaluated_error.poly_norm.norm),
-            public_bottom_bits =
-                bigdecimal_bits_ceil(&function_public_bottom_error.matrix_norm.poly_norm.norm),
             public_bottom_decryption_bits =
-                bigdecimal_bits_ceil(&public_bottom_decryption_error.poly_norm.norm),
+                bigdecimal_bits_ceil(&prefix.public_bottom_decryption_error.poly_norm.norm),
             projection_residual_bits =
                 bigdecimal_bits_ceil(&projection_residual_error.poly_norm.norm),
             noisy_plaintext_bits = bigdecimal_bits_ceil(&noisy_plaintext_error.poly_norm.norm),
             "DiamondIO final output error simulation finished"
         );
 
-        Some(DiamondIOErrorSimulation {
-            input_injection,
-            prf_refreshes,
+        DiamondIOErrorSimulation {
+            input_injection: prefix.input_injection.clone(),
+            prf_refreshes: prefix.prf_refreshes.clone(),
             projection_residual_error,
             noisy_plaintext_error,
-        })
+        }
     }
 
     fn initial_seed_wire_error(&self, _params: &DCRTPolyParams, one: &ErrorNorm) -> ErrorNorm {
@@ -482,7 +677,12 @@ where
         Arc::new(NestedRnsRingGswContext::<DCRTPoly>::from_arith_context(
             circuit,
             params,
-            params.ring_dimension() as usize,
+            // Error simulation evaluates one representative Ring-GSW ciphertext at a time.  The
+            // polynomial ring dimension is still carried by `params`; `num_slots = 1` only avoids
+            // constructing the production batch of per-coefficient input wires.  Callers that need
+            // the full coefficient or slot collapse scale it explicitly in the surrounding norm
+            // calculation.
+            1,
             nested_rns_context,
             Some(active_levels),
             Some(self.ring_gsw_level_offset),
@@ -571,10 +771,9 @@ where
         circuit
     }
 
-    fn simulate_final_mask_error<PE, ST>(
+    fn simulate_final_mask_base_error<PE, ST>(
         &self,
         params: &DCRTPolyParams,
-        prf_mask_output_coeff_bits: usize,
         final_mask_prg_output: ErrorNorm,
         one: ErrorNorm,
         decryption_key: ErrorNorm,
@@ -585,15 +784,35 @@ where
         PE: PltEvaluator<ErrorNorm>,
         ST: SlotTransferEvaluator<ErrorNorm>,
     {
-        let circuit = self.build_cpu_prf_mask_circuit(params, prf_mask_output_coeff_bits);
-        let encrypted_bit_count = params.ring_dimension() as usize * prf_mask_output_coeff_bits;
-        let wire_count = ring_gsw_wire_count(circuit.num_input() - 1, encrypted_bit_count);
+        let mut circuit = PolyCircuit::new();
+        let (_, _, crt_depth) = params.to_crt();
+        let full_active_levels =
+            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
+        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, 1);
+        let decryption_key_wire = circuit.input(1).at(0).as_single_wire();
+        let encrypted_bit = RingGswCiphertext::input(
+            ring_gsw_context.clone(),
+            Some(BigUint::from(1u64)),
+            &mut circuit,
+        );
+        // The exact final-mask plaintext modulus changes public constants, but the representative
+        // ErrorNorm growth is the same one-bit decrypt/recompose circuit. The caller applies the
+        // PRF mask coefficient bit-width as an external linear scale.
+        let representative_plaintext_modulus = BigUint::from(2u64);
+        let decrypted = encrypted_bit.decrypt::<DCRTPolyMatrix>(
+            decryption_key_wire,
+            representative_plaintext_modulus,
+            &mut circuit,
+        );
+        let output =
+            circuit.add_gate(decrypted.secret_dependent, decrypted.public_bottom).as_single_wire();
+        circuit.output(vec![output]);
+        let wire_count = circuit.num_input() - 1;
+        let coefficient_scale = BigDecimal::from(params.ring_dimension() as u64);
+        let final_mask_prg_output = scale_error_norm(final_mask_prg_output, &coefficient_scale);
         let mut inputs = Vec::with_capacity(circuit.num_input());
         inputs.push(decryption_key);
-        inputs.extend(expand_logical_errors(
-            &vec![final_mask_prg_output; encrypted_bit_count],
-            wire_count,
-        ));
+        inputs.extend(std::iter::repeat_n(final_mask_prg_output, wire_count));
         assert_eq!(
             inputs.len(),
             circuit.num_input(),
@@ -608,40 +827,7 @@ where
             None,
         );
         assert_eq!(outputs.len(), 1, "DiamondIO final mask circuit must produce one output");
-        outputs.remove(0)
-    }
-
-    fn build_cpu_prf_mask_circuit(
-        &self,
-        params: &DCRTPolyParams,
-        prf_mask_output_coeff_bits: usize,
-    ) -> PolyCircuit<DCRTPoly> {
-        let mut circuit = PolyCircuit::new();
-        let (_, _, crt_depth) = params.to_crt();
-        let active_levels =
-            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
-        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, active_levels);
-        let decryption_key = circuit.input(1).at(0).as_single_wire();
-        let q: Arc<BigUint> = params.modulus().into();
-        let plaintext_moduli =
-            mask_plaintext_moduli_from_full_modulus(q.as_ref(), prf_mask_output_coeff_bits);
-        let encrypted_bit_count = params.ring_dimension() as usize * prf_mask_output_coeff_bits;
-        let encrypted_bits = (0..encrypted_bit_count)
-            .map(|_| {
-                RingGswCiphertext::input(
-                    ring_gsw_context.clone(),
-                    Some(BigUint::from(1u64)),
-                    &mut circuit,
-                )
-            })
-            .collect::<Vec<_>>();
-        let decrypted = decrypt_bit_decomposed_polynomial::<
-            DCRTPoly,
-            crate::gadgets::arith::NestedRnsPoly<DCRTPoly>,
-            DCRTPolyMatrix,
-        >(&mut circuit, &encrypted_bits, decryption_key, &plaintext_moduli);
-        circuit.output(vec![decrypted]);
-        circuit
+        extrapolate_error_norm_matrix_to_active_levels(outputs.remove(0), full_active_levels)
     }
 
     fn simulate_representative_function_output<PE, ST>(
@@ -667,7 +853,7 @@ where
         let mut inputs = Vec::with_capacity(circuit.num_input());
         inputs.push(decryption_key);
         inputs.extend(std::iter::repeat_n(seed_wire_error, seed_wire_count));
-        let outputs = circuit.eval(
+        let mut outputs = circuit.eval(
             &(),
             one,
             inputs,
@@ -676,6 +862,13 @@ where
             None,
         );
         assert_eq!(outputs.len(), 2, "DiamondIO representative function output must be a pair");
+        let (_, _, crt_depth) = params.to_crt();
+        let full_active_levels =
+            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
+        for output in &mut outputs {
+            *output =
+                extrapolate_error_norm_matrix_to_active_levels(output.clone(), full_active_levels);
+        }
         (outputs[0].clone(), outputs[1].clone())
     }
 
@@ -685,10 +878,7 @@ where
         representative_seed_bits: usize,
     ) -> PolyCircuit<DCRTPoly> {
         let mut circuit = PolyCircuit::new();
-        let (_, _, crt_depth) = params.to_crt();
-        let active_levels =
-            self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
-        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, active_levels);
+        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, 1);
         let decryption_key = circuit.input(1).at(0).as_single_wire();
         let mut outputs = Vec::with_capacity(2 * representative_seed_bits);
         for _ in 0..representative_seed_bits {
@@ -716,14 +906,20 @@ where
     ) -> PolyMatrixNorm {
         let mut circuit = PolyCircuit::new();
         let (_, _, crt_depth) = params.to_crt();
-        let active_levels =
+        let full_active_levels =
             self.ring_gsw_enable_levels.unwrap_or_else(|| crt_depth - self.ring_gsw_level_offset);
-        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, active_levels);
+        let ring_gsw_context = self.build_cpu_ring_gsw_context(params, &mut circuit, 1);
         let ciphertext =
             RingGswCiphertext::input(ring_gsw_context, Some(BigUint::from(1u64)), &mut circuit);
         let raw = ciphertext
             .estimate_decryption_error_norm(self.ring_gsw_public_key_error_sigma.unwrap_or(0.0));
-        PolyMatrixNorm::new(output_ctx, 1, 1, raw.poly_norm.norm, None)
+        PolyMatrixNorm::new(
+            output_ctx,
+            1,
+            1,
+            raw.poly_norm.norm * BigDecimal::from(full_active_levels as u64),
+            None,
+        )
     }
 
     fn derive_diamond_goldreich_graph_seed(&self, round_idx: usize) -> [u8; 32] {
@@ -776,6 +972,23 @@ fn diamond_io_input_injection_projection_error(
         .expect("DiamondIO input injection must produce a base final state error")
         .clone() *
         &input_injection.output_preimage
+}
+
+fn diamond_io_input_injection_scalar_projection_error(
+    input_injection: &DiamondInputErrorSimulation,
+) -> PolyMatrixNorm {
+    let state_error = input_injection
+        .state_errors
+        .first()
+        .expect("DiamondIO input injection must produce a base final state error");
+    let scalar_output_preimage = PolyMatrixNorm::new(
+        input_injection.output_preimage.clone_ctx(),
+        input_injection.output_preimage.nrow,
+        1,
+        input_injection.output_preimage.poly_norm.norm.clone(),
+        None,
+    );
+    state_error.clone() * &scalar_output_preimage
 }
 
 fn diamond_io_security_margins_hold(
@@ -888,6 +1101,38 @@ fn simulate_selected_half_error_norm(
 fn expand_logical_errors(logical_errors: &[ErrorNorm], wire_count: usize) -> Vec<ErrorNorm> {
     assert!(wire_count > 0, "Ring-GSW wire count must be positive");
     logical_errors.iter().flat_map(|error| std::iter::repeat_n(error.clone(), wire_count)).collect()
+}
+
+fn scale_error_norm(input: ErrorNorm, scale: &BigDecimal) -> ErrorNorm {
+    ErrorNorm {
+        plaintext_norm: input.plaintext_norm * scale,
+        matrix_norm: input.matrix_norm * scale,
+    }
+}
+
+fn assert_same_matrix_shape(lhs: &PolyMatrixNorm, rhs: &PolyMatrixNorm, message: &str) {
+    assert!(lhs.ctx() == rhs.ctx(), "{message}: simulator contexts must match");
+    assert_eq!(
+        (lhs.nrow, lhs.ncol),
+        (rhs.nrow, rhs.ncol),
+        "{message}: left shape {:?} must match right shape {:?}",
+        (lhs.nrow, lhs.ncol),
+        (rhs.nrow, rhs.ncol)
+    );
+}
+
+fn extrapolate_error_norm_matrix_to_active_levels(
+    mut input: ErrorNorm,
+    active_levels: usize,
+) -> ErrorNorm {
+    assert!(active_levels > 0, "active-level extrapolation scale must be positive");
+    if active_levels > 1 {
+        // Active-level extrapolation models the ciphertext-side Ring-GSW contribution. The
+        // plaintext norm is a bound on the represented value flowing through the circuit, so it is
+        // not scaled by the number of CRT levels.
+        input.matrix_norm = input.matrix_norm * BigDecimal::from(active_levels as u64);
+    }
+    input
 }
 
 fn ring_gsw_wire_count(flat_input_count: usize, logical_bit_count: usize) -> usize {

--- a/src/lookup/lwe/poly_encoding_gpu.rs
+++ b/src/lookup/lwe/poly_encoding_gpu.rs
@@ -377,10 +377,7 @@ where
         .max(k_low_compute_bench.peak_vram)
         .max(stage2_bench.peak_vram);
 
-    let max_parallelism = u128::try_from(
-        output_chunk_count.checked_mul(2).expect("stage-1 task count overflowed usize"),
-    )
-    .expect("stage-1 task count overflowed u128");
+    let max_parallelism = (output_chunk_count as u128) * 2;
     PolyEncodingChunkBenchMeasurement::new(
         latency * max_parallelism as f64,
         latency,

--- a/src/lookup/lwe/pubkey.rs
+++ b/src/lookup/lwe/pubkey.rs
@@ -3,7 +3,9 @@
 mod gpu;
 
 #[cfg(not(feature = "gpu"))]
-use crate::bench_estimator::{PublicLutSampleAuxBenchEstimator, SampleAuxBenchEstimate};
+use crate::bench_estimator::{
+    PublicLutSampleAuxBenchEstimator, SampleAuxBenchEstimate, total_lut_preimage_count,
+};
 use crate::{
     bgg::public_key::BggPublicKey,
     circuit::{evaluable::Evaluable, gate::GateId},
@@ -552,9 +554,7 @@ where
         total_lut_entries: usize,
         total_lut_gates: usize,
     ) -> SampleAuxBenchEstimate {
-        let total_preimages = total_lut_entries
-            .checked_mul(total_lut_gates)
-            .expect("total sampled LWE preimages overflowed usize");
+        let total_preimages = total_lut_preimage_count(total_lut_entries, total_lut_gates);
         if total_preimages == 0 {
             return SampleAuxBenchEstimate::default();
         }

--- a/src/lookup/lwe/pubkey_gpu.rs
+++ b/src/lookup/lwe/pubkey_gpu.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::{
-    bench_estimator::{PublicLutSampleAuxBenchEstimator, SampleAuxBenchEstimate},
+    bench_estimator::{
+        PublicLutSampleAuxBenchEstimator, SampleAuxBenchEstimate, total_lut_preimage_count,
+    },
     bgg::public_key::BggPublicKey,
     element::PolyElem,
     lookup::lwe::{
@@ -533,9 +535,7 @@ where
         total_lut_entries: usize,
         total_lut_gates: usize,
     ) -> SampleAuxBenchEstimate {
-        let total_preimages = total_lut_entries
-            .checked_mul(total_lut_gates)
-            .expect("total sampled LWE preimages overflowed usize");
+        let total_preimages = total_lut_preimage_count(total_lut_entries, total_lut_gates);
         if total_preimages == 0 {
             return SampleAuxBenchEstimate::default();
         }

--- a/src/noise_refresh/mod.rs
+++ b/src/noise_refresh/mod.rs
@@ -13,7 +13,11 @@ pub use naive_vec::{
     NoiseRefresherNaiveVec, debug_sample_prg_encoding_wires, debug_sample_prg_plaintext_wires,
     debug_sample_prg_public_key_wires,
 };
-pub use simulation::{NoiseRefreshErrorSimulation, simulate_noise_refresh_error_growth};
+pub use simulation::{
+    NoiseRefreshErrorSimulation, simulate_noise_refresh_error_growth,
+    simulate_symmetric_noise_refresh_error_growth,
+    simulate_symmetric_noise_refresh_error_growth_for_v_bits,
+};
 
 /// Refreshes the noise of one slotwise encoding wire.
 ///

--- a/src/noise_refresh/naive_vec.rs
+++ b/src/noise_refresh/naive_vec.rs
@@ -1,6 +1,7 @@
 use crate::{
     bench_estimator::{
-        BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary, benchmark_gate_operation,
+        BenchEstimator, CircuitBenchEstimate, CircuitBenchSummary, PublicKeyAuxBenchEstimator,
+        benchmark_gate_operation, estimate_public_key_circuit_bench_with_aux,
     },
     bgg::{
         encoding::BggEncoding,
@@ -177,6 +178,13 @@ where
             NaiveBGGEncodingVec::new(params, encodings)
         })
         .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct NoiseRefreshBenchEstimateParts {
+    pub(crate) material: CircuitBenchSummary,
+    pub(crate) per_refresh: CircuitBenchSummary,
+    pub(crate) total: CircuitBenchSummary,
 }
 
 fn scaled_estimate_summary(unit: CircuitBenchEstimate, task_count: usize) -> CircuitBenchSummary {
@@ -369,6 +377,40 @@ where
     }
 }
 
+fn measured_a_prime_hash_sampling_unit_summary<M, HS>(
+    params: &<M::P as Poly>::Params,
+    hash_key: [u8; 32],
+    secret_size: usize,
+) -> CircuitBenchSummary
+where
+    M: PolyMatrix,
+    HS: PolyHashSampler<[u8; 32], M = M>,
+{
+    let log_base_q = params.modulus_digits();
+    let bench = benchmark_gate_operation(NATIVE_BENCH_ITERATIONS, || {
+        let matrix = HS::new().sample_hash(
+            params,
+            hash_key,
+            b"noise-refresh-bench-a-prime",
+            secret_size,
+            secret_size
+                .checked_mul(log_base_q)
+                .expect("noise-refresh a_prime benchmark column count overflow"),
+            DistType::FinRingDist,
+        );
+        matrix.into_compact_bytes()
+    });
+    let summary = CircuitBenchSummary::new(bench.time, bench.time, 1);
+    #[cfg(feature = "gpu")]
+    {
+        summary.with_peak_vram(bench.peak_vram)
+    }
+    #[cfg(not(feature = "gpu"))]
+    {
+        summary
+    }
+}
+
 /// Naive-vector implementation of one-wire noise refresh.
 ///
 /// The type is intentionally specialized to `NaiveBGGPublicKeyVec` and `NaiveBGGEncodingVec`.
@@ -469,11 +511,28 @@ where
         public_key_estimator: &PKBE,
     ) -> CircuitBenchSummary
     where
-        PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + Sync,
+        PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + PublicKeyAuxBenchEstimator<M::P> + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M>,
+    {
+        self.estimate_preprocess_bench_parts(public_key_estimator).total
+    }
+
+    pub(crate) fn estimate_preprocess_bench_parts<PKBE>(
+        &self,
+        public_key_estimator: &PKBE,
+    ) -> NoiseRefreshBenchEstimateParts
+    where
+        PKBE: BenchEstimator<NaiveBGGPublicKeyVec<M>> + PublicKeyAuxBenchEstimator<M::P> + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M>,
     {
         let num_slots = self.params().ring_dimension() as usize;
         let (_q_moduli, _crt_bits, crt_depth) = self.params().to_crt();
         let log_base_q = self.params().modulus_digits();
+        // The naive-vector refresh paths used by AKY24 and DiamondIO refresh scalar BGG wires:
+        // `one.key(0).matrix.row_size()` and `refreshed_input.key(0).matrix.row_size()` are one in
+        // those call sites. The estimator has no concrete `one` vector, so it measures the same
+        // scalar `A'` hash shape directly.
+        let secret_size = 1usize;
         let combine_task_count =
             num_slots.checked_mul(crt_depth).expect("noise-refresh combine task count overflow");
 
@@ -486,13 +545,23 @@ where
             num_slots,
             self.debug_reuse_single_material,
         );
-        let public_material_summary =
-            public_key_estimator.estimate_circuit_bench(&material_circuit);
+        let public_material_summary = estimate_public_key_circuit_bench_with_aux::<
+            NaiveBGGPublicKeyVec<M>,
+            PKBE,
+        >(
+            public_key_estimator, self.params(), &material_circuit
+        );
 
         let scalar_target = [BigUint::from(1u32)];
         let pk_matrix_mul = public_key_estimator.estimate_large_scalar_mul(&scalar_target);
         let pk_add = public_key_estimator.estimate_add();
         let pk_sub = public_key_estimator.estimate_sub();
+        let a_prime_sampling_unit = measured_a_prime_hash_sampling_unit_summary::<M, HS>(
+            self.params(),
+            self.hash_key,
+            secret_size,
+        );
+        let a_prime_sampling_stage = scaled_summary(a_prime_sampling_unit, num_slots);
         let collapse_add_count = log_base_q
             .checked_mul(num_slots.saturating_sub(1))
             .expect("noise-refresh collapse add count overflow");
@@ -515,7 +584,10 @@ where
             estimate_summary(pk_sub),
         ]);
 
-        let preprocess_combine_stage = scaled_summary(preprocess_combine_unit, combine_task_count);
+        let preprocess_combine_stage = sequential_summaries(&[
+            a_prime_sampling_stage,
+            scaled_summary(preprocess_combine_unit, combine_task_count),
+        ]);
         let preprocess_summary =
             sequential_summaries(&[public_material_summary, preprocess_combine_stage]);
 
@@ -525,6 +597,8 @@ where
             crt_depth,
             log_base_q,
             combine_task_count,
+            ?a_prime_sampling_unit,
+            ?a_prime_sampling_stage,
             ?public_material_summary,
             ?preprocess_combine_unit,
             ?preprocess_combine_stage,
@@ -532,7 +606,11 @@ where
             "estimated naive-vector noise-refresh preprocess benchmark"
         );
 
-        preprocess_summary
+        NoiseRefreshBenchEstimateParts {
+            material: public_material_summary,
+            per_refresh: preprocess_combine_stage,
+            total: preprocess_summary,
+        }
     }
 
     /// Estimates the online-evaluation side of the current naive-vector implementation.
@@ -548,10 +626,25 @@ where
     ) -> CircuitBenchSummary
     where
         EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M>,
+    {
+        self.estimate_online_eval_bench_parts(encoding_estimator).total
+    }
+
+    pub(crate) fn estimate_online_eval_bench_parts<EncBE>(
+        &self,
+        encoding_estimator: &EncBE,
+    ) -> NoiseRefreshBenchEstimateParts
+    where
+        EncBE: BenchEstimator<NaiveBGGEncodingVec<M>> + Sync,
+        HS: PolyHashSampler<[u8; 32], M = M>,
     {
         let num_slots = self.params().ring_dimension() as usize;
         let (_q_moduli, _crt_bits, crt_depth) = self.params().to_crt();
         let log_base_q = self.params().modulus_digits();
+        // See the preprocessing estimator above: online refresh recomputes the same scalar `A'`
+        // matrices from `(refresh_id, slot_idx)` and therefore pays the same hash-sampling unit.
+        let secret_size = 1usize;
         let combine_task_count =
             num_slots.checked_mul(crt_depth).expect("noise-refresh combine task count overflow");
 
@@ -570,6 +663,12 @@ where
         let enc_matrix_mul = encoding_estimator.estimate_large_scalar_mul(&scalar_target);
         let enc_add = encoding_estimator.estimate_add();
         let enc_sub = encoding_estimator.estimate_sub();
+        let a_prime_sampling_unit = measured_a_prime_hash_sampling_unit_summary::<M, HS>(
+            self.params(),
+            self.hash_key,
+            secret_size,
+        );
+        let a_prime_sampling_stage = scaled_summary(a_prime_sampling_unit, num_slots);
         let collapse_add_count = log_base_q
             .checked_mul(num_slots.saturating_sub(1))
             .expect("noise-refresh collapse add count overflow");
@@ -600,13 +699,13 @@ where
         // multiplication, and CRT-level accumulation on raw `M` matrices.
         let online_crt_recompose_unit = measured_crt_recompose_unit_summary::<M>(self.params());
 
-        let online_combine_stage = scaled_summary(online_combine_unit, combine_task_count);
-        let online_crt_stage = scaled_summary(online_crt_recompose_unit, num_slots);
-        let online_summary = sequential_summaries(&[
-            online_material_summary,
-            online_combine_stage,
-            online_crt_stage,
+        let online_combine_stage = sequential_summaries(&[
+            a_prime_sampling_stage,
+            scaled_summary(online_combine_unit, combine_task_count),
         ]);
+        let online_crt_stage = scaled_summary(online_crt_recompose_unit, num_slots);
+        let online_per_refresh = sequential_summaries(&[online_combine_stage, online_crt_stage]);
+        let online_summary = sequential_summaries(&[online_material_summary, online_per_refresh]);
 
         debug!(
             v_bits = self.v_bits,
@@ -615,6 +714,8 @@ where
             log_base_q,
             combine_task_count,
             crt_recompose_task_count = num_slots,
+            ?a_prime_sampling_unit,
+            ?a_prime_sampling_stage,
             ?online_material_summary,
             ?online_combine_unit,
             ?online_combine_stage,
@@ -624,7 +725,11 @@ where
             "estimated naive-vector noise-refresh online benchmark"
         );
 
-        online_summary
+        NoiseRefreshBenchEstimateParts {
+            material: online_material_summary,
+            per_refresh: online_per_refresh,
+            total: online_summary,
+        }
     }
 }
 

--- a/src/noise_refresh/simulation.rs
+++ b/src/noise_refresh/simulation.rs
@@ -6,9 +6,7 @@ use crate::{
     lookup::PltEvaluator,
     matrix::dcrt_poly::DCRTPolyMatrix,
     noise_refresh::{
-        circuit_prg::{
-            evaluate_goldreich_noise_refresh_material, goldreich_noise_refresh_output_sizes,
-        },
+        circuit_prg::evaluate_goldreich_noise_refresh_material_ranges,
         naive_vec::build_noise_refresh_material_circuit,
     },
     poly::{PolyParams, dcrt::poly::DCRTPoly},
@@ -28,24 +26,21 @@ use tracing::{debug, info};
 /// modulo every CRT factor, the conservative sufficient condition is:
 ///
 /// ```text
-/// 2^v_bits + rounding_error + pre_rounding_error < full_q / (2 * q_max)
+/// 2^v_bits + pre_rounding_error < full_q / (2 * q_max)
 /// ```
 ///
-/// where `full_q` is the full DCRT modulus and `q_max` is the largest CRT factor.  The
-/// `rounding_error` term is modeled as `secret_norm * 1`, so this helper uses
-/// `secret_norm.poly_norm.norm` directly.
+/// where `full_q` is the full DCRT modulus and `q_max` is the largest CRT factor. The ideal
+/// `q/q_i`-scaled terms round back exactly, so no separate rounding-error budget is needed.
 pub fn max_safe_noise_refresh_v_bits(
     params: &<DCRTPoly as crate::poly::Poly>::Params,
-    secret_norm: &PolyMatrixNorm,
     pre_rounding_error: &PolyMatrixNorm,
 ) -> Option<usize> {
-    debug_assert_eq!(secret_norm.ctx(), pre_rounding_error.ctx());
     let (q_moduli, _crt_bits, _crt_depth) = params.to_crt();
     let q_max = q_moduli.iter().copied().max().expect("CRT modulus list must be nonempty");
     let full_q: Arc<BigUint> = params.modulus().into();
     let bound =
         biguint_to_decimal(full_q.as_ref()) / (BigDecimal::from(2u32) * BigDecimal::from(q_max));
-    let available = bound - &secret_norm.poly_norm.norm - &pre_rounding_error.poly_norm.norm;
+    let available = bound - &pre_rounding_error.poly_norm.norm;
     max_power_of_two_bits_strictly_below(&available, params.modulus_bits())
 }
 
@@ -87,10 +82,9 @@ fn is_integer_decimal(value: &BigDecimal) -> bool {
 pub fn validate_noise_refresh_v_bits(
     params: &<DCRTPoly as crate::poly::Poly>::Params,
     v_bits: usize,
-    secret_norm: &PolyMatrixNorm,
     pre_rounding_error: &PolyMatrixNorm,
 ) -> bool {
-    max_safe_noise_refresh_v_bits(params, secret_norm, pre_rounding_error)
+    max_safe_noise_refresh_v_bits(params, pre_rounding_error)
         .is_some_and(|max_v_bits| v_bits <= max_v_bits)
 }
 
@@ -146,7 +140,6 @@ pub fn simulate_noise_refresh_error_growth<A, PE, ST>(
     cbd_n: usize,
     ring_gsw_error_sigma: f64,
     num_slots: usize,
-    secret_norm: &PolyMatrixNorm,
     one: ErrorNorm,
     refreshed_input: ErrorNorm,
     enc_seeds: &[ErrorNorm],
@@ -162,9 +155,8 @@ where
 {
     info!(seed_bits, cbd_n, num_slots, "starting noise-refresh error simulation mask-bit search");
     let zero_pre_rounding =
-        PolyMatrixNorm::new(secret_norm.clone_ctx(), 1, 1, BigDecimal::from(0u32), None);
-    let Some(max_candidate) =
-        max_safe_noise_refresh_v_bits(&ring_gsw.params, secret_norm, &zero_pre_rounding)
+        PolyMatrixNorm::new(one.clone_ctx(), 1, 1, BigDecimal::from(0u32), None);
+    let Some(max_candidate) = max_safe_noise_refresh_v_bits(&ring_gsw.params, &zero_pre_rounding)
     else {
         info!("noise-refresh error simulation found no candidate before circuit error");
         return None;
@@ -193,12 +185,7 @@ where
             slot_transfer_evaluator,
         );
         let worst_pre_rounding = worst_pre_rounding_error(&simulation);
-        let valid = validate_noise_refresh_v_bits(
-            &ring_gsw.params,
-            candidate,
-            secret_norm,
-            worst_pre_rounding,
-        );
+        let valid = validate_noise_refresh_v_bits(&ring_gsw.params, candidate, worst_pre_rounding);
         debug!(
             candidate,
             valid,
@@ -256,8 +243,16 @@ where
         "decoder norm count must equal num_slots * crt_depth"
     );
 
+    let active_level_scale = ring_gsw.active_levels;
+    let material_ring_gsw = one_active_level_ring_gsw_context(&ring_gsw);
+    debug!(
+        original_active_levels = active_level_scale,
+        material_active_levels = material_ring_gsw.active_levels,
+        "noise-refresh material error simulation using one-active-level representative PRG"
+    );
+
     let circuit = build_noise_refresh_material_circuit::<DCRTPoly, A, DCRTPolyMatrix>(
-        ring_gsw.clone(),
+        material_ring_gsw.clone(),
         seed_bits,
         v_bits,
         graph_seed,
@@ -284,8 +279,14 @@ where
         num_slots * crt_depth * log_base_q,
         "noise-refresh error simulator output layout mismatch"
     );
-    let material_decryption_errors = material_decryption_error_norms(
-        ring_gsw,
+    let mut material_output_matrix_norms =
+        material_outputs.into_iter().map(|output| output.matrix_norm).collect::<Vec<_>>();
+    extrapolate_matrix_norms_to_active_levels(
+        &mut material_output_matrix_norms,
+        active_level_scale,
+    );
+    let mut material_decryption_error = representative_material_decryption_error_norm(
+        material_ring_gsw,
         seed_bits,
         v_bits,
         graph_seed,
@@ -294,14 +295,13 @@ where
         num_slots,
         one.clone_ctx(),
     );
-    debug!(
-        outputs = material_decryption_errors.len(),
-        "noise-refresh material decryption error norms computed"
+    extrapolate_matrix_norms_to_active_levels(
+        std::slice::from_mut(&mut material_decryption_error),
+        active_level_scale,
     );
-    assert_eq!(
-        material_decryption_errors.len(),
-        material_outputs.len(),
-        "Ring-GSW decryption-error layout must match material output layout"
+    debug!(
+        active_level_scale,
+        "noise-refresh representative material and decryption error norms extrapolated"
     );
 
     let ctx = one.clone_ctx();
@@ -321,11 +321,11 @@ where
             for digit_idx in 0..log_base_q {
                 let material_idx =
                     slot_idx * crt_depth * log_base_q + crt_idx * log_base_q + digit_idx;
-                let decoded_column = material_outputs[material_idx].matrix_norm.clone() *
+                let decoded_column = material_output_matrix_norms[material_idx].clone() *
                     PolyMatrixNorm::gadget_decomposed(ctx.clone(), 1);
                 let collapsed_column =
                     (1..num_slots).fold(decoded_column.clone(), |acc, _| acc + &decoded_column);
-                let collapsed_column = collapsed_column + &material_decryption_errors[material_idx];
+                let collapsed_column = collapsed_column + &material_decryption_error;
                 refresh_nrow = Some(collapsed_column.nrow);
                 refresh_ncol += collapsed_column.ncol;
                 refresh_entry_norm += collapsed_column.poly_norm.norm;
@@ -364,7 +364,38 @@ fn worst_pre_rounding_error(simulation: &NoiseRefreshErrorSimulation) -> &PolyMa
         .expect("simulation must produce at least one pre-round output")
 }
 
-fn material_decryption_error_norms<A>(
+fn one_active_level_ring_gsw_context<A>(
+    ring_gsw: &Arc<RingGswContext<DCRTPoly, A>>,
+) -> Arc<RingGswContext<DCRTPoly, A>>
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+{
+    if ring_gsw.active_levels == 1 {
+        return ring_gsw.clone();
+    }
+    let mut circuit = ring_gsw.fresh_circuit();
+    Arc::new(RingGswContext::from_arith_context(
+        &mut circuit,
+        &ring_gsw.params,
+        ring_gsw.num_slots,
+        ring_gsw.arith_ctx.clone(),
+        Some(1),
+        Some(ring_gsw.level_offset),
+    ))
+}
+
+fn extrapolate_matrix_norms_to_active_levels(norms: &mut [PolyMatrixNorm], active_levels: usize) {
+    assert!(active_levels > 0, "active-level extrapolation scale must be positive");
+    if active_levels == 1 {
+        return;
+    }
+    let scale = BigDecimal::from(active_levels as u64);
+    for norm in norms {
+        *norm = norm.clone() * &scale;
+    }
+}
+
+fn representative_material_decryption_error_norm<A>(
     ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
     seed_bits: usize,
     v_bits: usize,
@@ -373,86 +404,60 @@ fn material_decryption_error_norms<A>(
     ring_gsw_error_sigma: f64,
     num_slots: usize,
     output_ctx: Arc<SimulatorContext>,
-) -> Vec<PolyMatrixNorm>
+) -> PolyMatrixNorm
 where
     A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
 {
-    // This mirrors `build_noise_refresh_material_circuit` only at the Ring-GSW ciphertext metadata
-    // level.  We need the concrete `RingGswCiphertext::randomizer_norm` values produced by the
-    // Goldreich PRG operations, but we do not need to evaluate any native ciphertext plaintexts.
-    //
-    // For each output `(slot_idx, crt_idx, digit_idx)`, the material circuit decrypts `ring_dim`
-    // error ciphertexts and `ring_dim * v_bits` mask ciphertexts into a slotwise polynomial, then
-    // the online path collapses all slots into one polynomial column.  The returned norm is already
-    // collapsed across those coefficient slots so the caller can add it once to the collapsed
-    // decoded-column norm.
     let ring_dim = ring_gsw.params.ring_dimension() as usize;
     assert_eq!(num_slots, ring_dim, "num_slots must match ring_dim");
-    let (_q_moduli, _crt_bits, crt_depth) = ring_gsw.params.to_crt();
-    let log_base_q = ring_gsw.params.modulus_digits();
-    let output_sizes =
-        goldreich_noise_refresh_output_sizes(ring_dim, log_base_q, crt_depth, v_bits);
     let mask_q_chunk_len = ring_dim.checked_mul(v_bits).expect("mask q chunk length overflow");
 
-    let zero = || PolyMatrixNorm::new(output_ctx.clone(), 1, 1, BigDecimal::from(0u32), None);
-    (0..num_slots)
-        .into_par_iter()
-        .flat_map_iter(|slot_idx| {
-            let mut circuit = ring_gsw.fresh_circuit();
-            let encrypted_seeds = (0..seed_bits)
-                .map(|_| RingGswCiphertext::input(ring_gsw.clone(), None, &mut circuit))
-                .collect::<Vec<_>>();
-            let material = evaluate_goldreich_noise_refresh_material(
-                &mut circuit,
-                ring_gsw.clone(),
-                &encrypted_seeds,
-                v_bits,
-                graph_seed,
-                cbd_n,
-                slot_idx as u64,
+    let mut circuit = ring_gsw.fresh_circuit();
+    let encrypted_seeds = (0..seed_bits)
+        .map(|_| RingGswCiphertext::input(ring_gsw.clone(), None, &mut circuit))
+        .collect::<Vec<_>>();
+    let material = evaluate_goldreich_noise_refresh_material_ranges(
+        &mut circuit,
+        ring_gsw,
+        &encrypted_seeds,
+        v_bits,
+        graph_seed,
+        cbd_n,
+        0,
+        0,
+        ring_dim,
+        &[(0, mask_q_chunk_len)],
+    );
+    assert_eq!(material.errors.len(), ring_dim);
+    assert_eq!(material.masks.len(), mask_q_chunk_len);
+
+    let mut collapsed_norm =
+        PolyMatrixNorm::new(output_ctx.clone(), 1, 1, BigDecimal::from(0u32), None);
+    for coeff_idx in 0..ring_dim {
+        let error_norm =
+            material.errors[coeff_idx].estimate_decryption_error_norm(ring_gsw_error_sigma);
+        let mut coeff_norm = PolyMatrixNorm::new(
+            output_ctx.clone(),
+            error_norm.nrow,
+            error_norm.ncol,
+            error_norm.poly_norm.norm,
+            error_norm.zero_rows,
+        );
+
+        let mask_start = coeff_idx * v_bits;
+        for mask_bit in &material.masks[mask_start..mask_start + v_bits] {
+            let mask_norm = mask_bit.estimate_decryption_error_norm(ring_gsw_error_sigma);
+            coeff_norm += PolyMatrixNorm::new(
+                output_ctx.clone(),
+                mask_norm.nrow,
+                mask_norm.ncol,
+                mask_norm.poly_norm.norm,
+                mask_norm.zero_rows,
             );
-            assert_eq!(material.errors.len(), output_sizes.cbd_values);
-            assert_eq!(material.masks.len(), output_sizes.mask_bits);
-
-            (0..crt_depth * log_base_q)
-                .into_par_iter()
-                .map(|flat_idx| {
-                    let crt_idx = flat_idx / log_base_q;
-                    let digit_idx = flat_idx % log_base_q;
-                    let mut collapsed_norm = zero();
-                    for coeff_idx in 0..ring_dim {
-                        let error_idx = digit_idx * ring_dim + coeff_idx;
-                        let error_norm = material.errors[error_idx]
-                            .estimate_decryption_error_norm(ring_gsw_error_sigma);
-                        let mut coeff_norm = PolyMatrixNorm::new(
-                            output_ctx.clone(),
-                            error_norm.nrow,
-                            error_norm.ncol,
-                            error_norm.poly_norm.norm,
-                            error_norm.zero_rows,
-                        );
-
-                        let mask_start = crt_idx * log_base_q * mask_q_chunk_len +
-                            digit_idx * mask_q_chunk_len +
-                            coeff_idx * v_bits;
-                        for mask_bit in &material.masks[mask_start..mask_start + v_bits] {
-                            let mask_norm =
-                                mask_bit.estimate_decryption_error_norm(ring_gsw_error_sigma);
-                            coeff_norm += PolyMatrixNorm::new(
-                                output_ctx.clone(),
-                                mask_norm.nrow,
-                                mask_norm.ncol,
-                                mask_norm.poly_norm.norm,
-                                mask_norm.zero_rows,
-                            );
-                        }
-                        collapsed_norm += coeff_norm;
-                    }
-                    collapsed_norm
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect()
+        }
+        collapsed_norm += coeff_norm;
+    }
+    collapsed_norm
 }
 
 fn biguint_to_decimal(value: &BigUint) -> BigDecimal {

--- a/src/noise_refresh/simulation.rs
+++ b/src/noise_refresh/simulation.rs
@@ -2,11 +2,15 @@ use crate::{
     gadgets::{
         arith::{DecomposeArithmeticGadget, ModularArithmeticPlanner},
         fhe::ring_gsw::{RingGswCiphertext, RingGswContext},
+        fhe_prg::goldreich::GoldreichFheCbdPrg,
     },
     lookup::PltEvaluator,
     matrix::dcrt_poly::DCRTPolyMatrix,
     noise_refresh::{
-        circuit_prg::evaluate_goldreich_noise_refresh_material_ranges,
+        circuit_prg::{
+            derive_noise_refresh_graph_seed, evaluate_goldreich_noise_refresh_material_ranges,
+            goldreich_noise_refresh_output_sizes,
+        },
         naive_vec::build_noise_refresh_material_circuit,
     },
     poly::{PolyParams, dcrt::poly::DCRTPoly},
@@ -205,6 +209,119 @@ where
     best
 }
 
+/// Simulates noise-refresh error growth using the protocol's slot symmetry.
+///
+/// The production refresh material contains one decoded output for every `(slot, crt, digit)`.
+/// DiamondIO only needs the worst representative bound: every refreshed seed wire is symmetric, and
+/// each CRT/digit branch has the same circuit shape up to the plaintext CRT modulus.  This helper
+/// therefore evaluates one Goldreich material ciphertext and one representative decrypt/merge
+/// circuit, then analytically scales the coefficient and slot collapses that are explicit sums in
+/// the production circuit.  It returns representative vectors: `pre_round_outputs` has one entry
+/// per CRT level, and `rounded_errors` has one entry for the symmetric refreshed wire.
+pub fn simulate_symmetric_noise_refresh_error_growth<A, PE, ST>(
+    ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
+    seed_bits: usize,
+    graph_seed: [u8; 32],
+    cbd_n: usize,
+    ring_gsw_error_sigma: f64,
+    num_slots: usize,
+    one: ErrorNorm,
+    refreshed_input: ErrorNorm,
+    enc_seeds: &[ErrorNorm],
+    decryption_key: ErrorNorm,
+    decoder: ErrorNorm,
+    active_level_material_wire_error_override: Option<ErrorNorm>,
+    plt_evaluator: &PE,
+    slot_transfer_evaluator: &ST,
+) -> Option<NoiseRefreshErrorSimulation>
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+{
+    info!(
+        seed_bits,
+        cbd_n, num_slots, "starting symmetric noise-refresh error simulation mask-bit search"
+    );
+    let zero_pre_rounding =
+        PolyMatrixNorm::new(one.clone_ctx(), 1, 1, BigDecimal::from(0u32), None);
+    let Some(max_candidate) = max_safe_noise_refresh_v_bits(&ring_gsw.params, &zero_pre_rounding)
+    else {
+        info!("symmetric noise-refresh error simulation found no candidate before circuit error");
+        return None;
+    };
+    let mut low = 1usize;
+    let mut high = max_candidate;
+    let mut best = None;
+    info!("building symmetric noise-refresh representative material prefix");
+    let prg_prefix = build_symmetric_noise_refresh_prg_error_prefix(
+        &ring_gsw,
+        seed_bits,
+        graph_seed,
+        cbd_n,
+        ring_gsw_error_sigma,
+        one.clone(),
+        enc_seeds,
+        active_level_material_wire_error_override.clone(),
+        plt_evaluator,
+        slot_transfer_evaluator,
+    );
+    info!("finished symmetric noise-refresh representative material prefix");
+    info!("building symmetric noise-refresh representative decrypt prefix");
+    let decrypt_prefix = build_symmetric_noise_refresh_decrypt_prefix(
+        &ring_gsw,
+        &prg_prefix,
+        one.clone(),
+        decryption_key.clone(),
+        plt_evaluator,
+        slot_transfer_evaluator,
+    );
+    info!("finished symmetric noise-refresh representative decrypt prefix");
+    while low <= high {
+        let candidate = low + (high - low) / 2;
+        info!(candidate, low, high, "evaluating symmetric noise-refresh v_bits candidate");
+        let simulation = simulate_symmetric_noise_refresh_error_growth_for_v_bits_with_prefix(
+            ring_gsw.clone(),
+            &prg_prefix,
+            &decrypt_prefix,
+            seed_bits,
+            candidate,
+            graph_seed,
+            cbd_n,
+            ring_gsw_error_sigma,
+            num_slots,
+            one.clone(),
+            refreshed_input.clone(),
+            enc_seeds,
+            decryption_key.clone(),
+            decoder.clone(),
+            plt_evaluator,
+            slot_transfer_evaluator,
+        );
+        let worst_pre_rounding = worst_pre_rounding_error(&simulation);
+        let valid = validate_noise_refresh_v_bits(&ring_gsw.params, candidate, worst_pre_rounding);
+        debug!(
+            candidate,
+            valid,
+            worst_pre_rounding_norm = %worst_pre_rounding.poly_norm.norm,
+            "symmetric noise-refresh candidate evaluated"
+        );
+        if valid {
+            best = Some(simulation);
+            low = candidate + 1;
+        } else if candidate == 1 {
+            break;
+        } else {
+            high = candidate - 1;
+        }
+    }
+    info!(
+        found = best.is_some(),
+        "finished symmetric noise-refresh error simulation mask-bit search"
+    );
+    best
+}
+
 /// Simulates noise growth for a fixed mask bit-size.
 ///
 /// Prefer `simulate_noise_refresh_error_growth` for production estimates.  This fixed-size helper
@@ -351,6 +468,154 @@ where
     NoiseRefreshErrorSimulation { v_bits, pre_round_outputs, rounded_errors }
 }
 
+pub fn simulate_symmetric_noise_refresh_error_growth_for_v_bits<A, PE, ST>(
+    ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
+    seed_bits: usize,
+    v_bits: usize,
+    graph_seed: [u8; 32],
+    cbd_n: usize,
+    ring_gsw_error_sigma: f64,
+    num_slots: usize,
+    one: ErrorNorm,
+    refreshed_input: ErrorNorm,
+    enc_seeds: &[ErrorNorm],
+    decryption_key: ErrorNorm,
+    decoder: ErrorNorm,
+    plt_evaluator: &PE,
+    slot_transfer_evaluator: &ST,
+) -> NoiseRefreshErrorSimulation
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+{
+    let prg_prefix = build_symmetric_noise_refresh_prg_error_prefix(
+        &ring_gsw,
+        seed_bits,
+        graph_seed,
+        cbd_n,
+        ring_gsw_error_sigma,
+        one.clone(),
+        enc_seeds,
+        None,
+        plt_evaluator,
+        slot_transfer_evaluator,
+    );
+    let decrypt_prefix = build_symmetric_noise_refresh_decrypt_prefix(
+        &ring_gsw,
+        &prg_prefix,
+        one.clone(),
+        decryption_key.clone(),
+        plt_evaluator,
+        slot_transfer_evaluator,
+    );
+    simulate_symmetric_noise_refresh_error_growth_for_v_bits_with_prefix(
+        ring_gsw,
+        &prg_prefix,
+        &decrypt_prefix,
+        seed_bits,
+        v_bits,
+        graph_seed,
+        cbd_n,
+        ring_gsw_error_sigma,
+        num_slots,
+        one,
+        refreshed_input,
+        enc_seeds,
+        decryption_key,
+        decoder,
+        plt_evaluator,
+        slot_transfer_evaluator,
+    )
+}
+
+fn simulate_symmetric_noise_refresh_error_growth_for_v_bits_with_prefix<A, PE, ST>(
+    ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
+    prg_prefix: &SymmetricNoiseRefreshPrgErrorPrefix<A>,
+    decrypt_prefix: &SymmetricNoiseRefreshDecryptPrefix,
+    seed_bits: usize,
+    v_bits: usize,
+    _graph_seed: [u8; 32],
+    cbd_n: usize,
+    _ring_gsw_error_sigma: f64,
+    num_slots: usize,
+    one: ErrorNorm,
+    refreshed_input: ErrorNorm,
+    enc_seeds: &[ErrorNorm],
+    _decryption_key: ErrorNorm,
+    decoder: ErrorNorm,
+    _plt_evaluator: &PE,
+    _slot_transfer_evaluator: &ST,
+) -> NoiseRefreshErrorSimulation
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+{
+    info!(
+        seed_bits,
+        v_bits, cbd_n, num_slots, "starting fixed-v_bits symmetric noise-refresh error simulation"
+    );
+    assert_eq!(enc_seeds.len(), seed_bits, "encrypted seed norm count mismatch");
+    let ring_dim = ring_gsw.params.ring_dimension() as usize;
+    assert_eq!(num_slots, ring_dim, "num_slots must match ring_dim");
+    let (_q_moduli, _crt_bits, crt_depth) = ring_gsw.params.to_crt();
+    let log_base_q = ring_gsw.params.modulus_digits();
+    let ctx = one.clone_ctx();
+    assert_eq!(
+        prg_prefix.material_ring_gsw.active_levels, 1,
+        "symmetric noise-refresh PRG prefix must use one active level"
+    );
+
+    let mask_bit_scale = BigDecimal::from(v_bits as u64);
+
+    let material_decryption_error = representative_symmetric_material_decryption_error_norm(
+        prg_prefix,
+        ring_dim,
+        v_bits,
+        ctx.clone(),
+    );
+
+    let one_term =
+        one.matrix_norm.clone() * PolyMatrixNorm::gadget_decomposed(ctx.clone(), log_base_q);
+    let input_term = refreshed_input.matrix_norm.clone() *
+        PolyMatrixNorm::gadget_decomposed(ctx.clone(), log_base_q);
+    let slot_collapse_scale = BigDecimal::from(num_slots as u64);
+
+    let per_digit_decoded = (decrypt_prefix.error_decoded.matrix_norm.clone() +
+        &(decrypt_prefix.mask_decoded.matrix_norm.clone() * &mask_bit_scale)) *
+        PolyMatrixNorm::gadget_decomposed(ctx.clone(), 1);
+    let collapsed_column = per_digit_decoded * &slot_collapse_scale + &material_decryption_error;
+    let mut refresh_nrow = None;
+    let mut refresh_ncol = 0usize;
+    let mut refresh_norm = BigDecimal::from(0u32);
+    for _ in 0..log_base_q {
+        refresh_nrow = Some(collapsed_column.nrow);
+        refresh_ncol += collapsed_column.ncol;
+        refresh_norm += collapsed_column.poly_norm.norm.clone();
+    }
+    let refresh_term = PolyMatrixNorm::new(
+        ctx.clone(),
+        refresh_nrow.expect("log_base_q must be positive"),
+        refresh_ncol,
+        refresh_norm,
+        None,
+    );
+    let representative_pre_round_output =
+        input_term + &refresh_term + &one_term + &decoder.matrix_norm;
+    let pre_round_outputs = vec![representative_pre_round_output; crt_depth];
+    assert_eq!(
+        pre_round_outputs.len(),
+        crt_depth,
+        "symmetric noise-refresh output must contain one representative entry per CRT level"
+    );
+
+    let rounded_errors =
+        vec![PolyMatrixNorm::new(ctx, 1, log_base_q, BigDecimal::from(cbd_n as u64), None)];
+    info!(v_bits, "finished fixed-v_bits symmetric noise-refresh error simulation");
+    NoiseRefreshErrorSimulation { v_bits, pre_round_outputs, rounded_errors }
+}
+
 fn worst_pre_rounding_error(simulation: &NoiseRefreshErrorSimulation) -> &PolyMatrixNorm {
     simulation
         .pre_round_outputs
@@ -393,6 +658,373 @@ fn extrapolate_matrix_norms_to_active_levels(norms: &mut [PolyMatrixNorm], activ
     for norm in norms {
         *norm = norm.clone() * &scale;
     }
+}
+
+fn scale_error_norm(input: ErrorNorm, scale: &BigDecimal) -> ErrorNorm {
+    ErrorNorm {
+        plaintext_norm: input.plaintext_norm * scale,
+        matrix_norm: input.matrix_norm * scale,
+    }
+}
+
+struct SymmetricNoiseRefreshPrgErrorPrefix<A>
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+{
+    material_ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
+    material_wire_error: ErrorNorm,
+    material_error_decryption_error: PolyMatrixNorm,
+    material_mask_decryption_error: PolyMatrixNorm,
+}
+
+struct SymmetricNoiseRefreshDecryptPrefix {
+    error_decoded: ErrorNorm,
+    mask_decoded: ErrorNorm,
+}
+
+fn build_symmetric_noise_refresh_decrypt_prefix<A, PE, ST>(
+    ring_gsw: &Arc<RingGswContext<DCRTPoly, A>>,
+    prg_prefix: &SymmetricNoiseRefreshPrgErrorPrefix<A>,
+    one: ErrorNorm,
+    decryption_key: ErrorNorm,
+    plt_evaluator: &PE,
+    slot_transfer_evaluator: &ST,
+) -> SymmetricNoiseRefreshDecryptPrefix
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+{
+    let ring_dim = ring_gsw.params.ring_dimension() as usize;
+    // One decrypt_batch in the real circuit packs `ring_dim` ciphertexts into one polynomial.
+    // Scaling the representative ciphertext before decrypting models that linear slot reduction
+    // without constructing every coefficient ciphertext.
+    let coefficient_scale = BigDecimal::from(ring_dim as u64);
+    let material_wire_error =
+        scale_error_norm(prg_prefix.material_wire_error.clone(), &coefficient_scale);
+    let representative_plaintext_modulus = BigUint::from(2u64);
+    // The production decrypt path uses `active_q / plaintext_modulus` constants. The exact
+    // plaintext modulus changes the literal residues, but the symmetric ErrorNorm model only needs
+    // one non-zero representative decrypt circuit: CRT levels and mask bits share the same
+    // nested-RNS tower-width shape, while coefficient, slot, bit-count, and explicit Ring-GSW
+    // decryption-error growth are scaled outside this circuit evaluation. Using the one-active
+    // material context keeps this representative decrypt consistent with the one-active PRG
+    // simulation rule. The resulting ErrorNorm is independent of v_bits, so it is cached across
+    // the v_bits binary search.
+    let (error_decoded, mask_decoded) = representative_material_decrypt_outputs(
+        prg_prefix.material_ring_gsw.clone(),
+        representative_plaintext_modulus.clone(),
+        representative_plaintext_modulus,
+        one,
+        material_wire_error,
+        decryption_key,
+        plt_evaluator,
+        slot_transfer_evaluator,
+    );
+    SymmetricNoiseRefreshDecryptPrefix { error_decoded, mask_decoded }
+}
+
+fn build_symmetric_noise_refresh_prg_error_prefix<A, PE, ST>(
+    ring_gsw: &Arc<RingGswContext<DCRTPoly, A>>,
+    seed_bits: usize,
+    graph_seed: [u8; 32],
+    cbd_n: usize,
+    ring_gsw_error_sigma: f64,
+    one: ErrorNorm,
+    enc_seeds: &[ErrorNorm],
+    active_level_material_wire_error_override: Option<ErrorNorm>,
+    plt_evaluator: &PE,
+    slot_transfer_evaluator: &ST,
+) -> SymmetricNoiseRefreshPrgErrorPrefix<A>
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+{
+    let active_level_scale = ring_gsw.active_levels;
+    let material_ring_gsw = one_active_level_ring_gsw_context(ring_gsw);
+    let material_wire_error =
+        if let Some(material_wire_error) = active_level_material_wire_error_override {
+            // DiamondIO has already evaluated a representative uniform Goldreich PRG output for the
+            // same seed-error profile and active-level window. Passing its CBD-scaled bound here
+            // avoids a second equivalent one-output PRG ErrorNorm evaluation inside the v_bits
+            // search. The override is expected to have already been extrapolated to
+            // `ring_gsw.active_levels`.
+            info!("using caller-provided symmetric noise-refresh material wire error");
+            material_wire_error
+        } else {
+            info!("evaluating symmetric noise-refresh representative material wire error");
+            let mut material_wire_error = representative_material_ciphertext_wire_error(
+                material_ring_gsw.clone(),
+                seed_bits,
+                1,
+                graph_seed,
+                cbd_n,
+                one,
+                enc_seeds,
+                plt_evaluator,
+                slot_transfer_evaluator,
+            );
+            material_wire_error.matrix_norm =
+                material_wire_error.matrix_norm * BigDecimal::from(active_level_scale as u64);
+            info!("finished symmetric noise-refresh representative material wire error");
+            material_wire_error
+        };
+
+    info!("estimating symmetric noise-refresh material decryption error");
+    let (mut material_error_decryption_error, mut material_mask_decryption_error) =
+        representative_symmetric_material_decryption_error_base_norms(
+            material_ring_gsw.clone(),
+            seed_bits,
+            graph_seed,
+            cbd_n,
+            ring_gsw_error_sigma,
+        );
+    extrapolate_matrix_norms_to_active_levels(
+        std::slice::from_mut(&mut material_error_decryption_error),
+        active_level_scale,
+    );
+    extrapolate_matrix_norms_to_active_levels(
+        std::slice::from_mut(&mut material_mask_decryption_error),
+        active_level_scale,
+    );
+    info!("finished symmetric noise-refresh material decryption-error estimate");
+
+    SymmetricNoiseRefreshPrgErrorPrefix {
+        material_ring_gsw,
+        material_wire_error,
+        material_error_decryption_error,
+        material_mask_decryption_error,
+    }
+}
+
+fn representative_material_ciphertext_wire_error<A, PE, ST>(
+    ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
+    seed_bits: usize,
+    v_bits: usize,
+    graph_seed: [u8; 32],
+    cbd_n: usize,
+    one: ErrorNorm,
+    enc_seeds: &[ErrorNorm],
+    plt_evaluator: &PE,
+    slot_transfer_evaluator: &ST,
+) -> ErrorNorm
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+{
+    let mut circuit = ring_gsw.fresh_circuit();
+    let encrypted_seeds = (0..seed_bits)
+        .map(|_| RingGswCiphertext::input(ring_gsw.clone(), None, &mut circuit))
+        .collect::<Vec<_>>();
+    let output_sizes = goldreich_noise_refresh_output_sizes(
+        ring_gsw.params.ring_dimension() as usize,
+        ring_gsw.params.modulus_digits(),
+        ring_gsw.params.to_crt().2,
+        v_bits,
+    );
+    let cbd_seed = derive_noise_refresh_graph_seed(graph_seed, b"NoiseRefreshCBD/v1", 0);
+    let cbd_prf = GoldreichFheCbdPrg::setup_range(
+        &mut circuit,
+        ring_gsw.clone(),
+        seed_bits,
+        output_sizes.cbd_values,
+        0,
+        1,
+        cbd_seed,
+        cbd_n,
+    );
+    let errors = cbd_prf.evaluate_cbd_prf(&encrypted_seeds, &mut circuit);
+    // The symmetric simulator uses the CBD material output as the representative bound for both
+    // CBD error ciphertexts and uniform mask ciphertexts. A CBD output combines `2 * cbd_n`
+    // Goldreich uniform branches, so it is a conservative representative for a single mask bit
+    // while avoiding a second equivalent one-output PRG evaluation.
+    circuit.output(errors.iter().flat_map(|output| output.sub_circuit_wires()));
+    let wire_count = representative_ring_gsw_wire_count(ring_gsw);
+    let inputs = enc_seeds
+        .iter()
+        .flat_map(|seed| std::iter::repeat_n(seed.clone(), wire_count))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        inputs.len(),
+        circuit.num_input(),
+        "noise-refresh representative material input count mismatch"
+    );
+    circuit
+        .eval(
+            &(),
+            one,
+            inputs,
+            Some(plt_evaluator),
+            Some(slot_transfer_evaluator as &dyn SlotTransferEvaluator<ErrorNorm>),
+            None,
+        )
+        .into_iter()
+        .max_by(|lhs, rhs| {
+            lhs.matrix_norm
+                .poly_norm
+                .norm
+                .partial_cmp(&rhs.matrix_norm.poly_norm.norm)
+                .expect("representative material norms must be comparable")
+        })
+        .expect("representative material circuit must produce output wires")
+}
+
+fn representative_ring_gsw_wire_count<A>(ring_gsw: Arc<RingGswContext<DCRTPoly, A>>) -> usize
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+{
+    let mut circuit = ring_gsw.fresh_circuit();
+    RingGswCiphertext::input(ring_gsw, None, &mut circuit)
+        .sub_circuit_wires()
+        .iter()
+        .map(|wire| wire.len())
+        .sum()
+}
+
+fn representative_material_decrypt_outputs<A, PE, ST>(
+    ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
+    error_plaintext_modulus: BigUint,
+    mask_plaintext_modulus: BigUint,
+    one: ErrorNorm,
+    material_wire_error: ErrorNorm,
+    decryption_key: ErrorNorm,
+    plt_evaluator: &PE,
+    slot_transfer_evaluator: &ST,
+) -> (ErrorNorm, ErrorNorm)
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+    PE: PltEvaluator<ErrorNorm>,
+    ST: SlotTransferEvaluator<ErrorNorm>,
+{
+    let mut circuit = ring_gsw.fresh_circuit();
+    let decryption_key_wire = circuit.input(1).at(0).as_single_wire();
+    let error_ciphertext = RingGswCiphertext::input(ring_gsw.clone(), None, &mut circuit);
+    let mask_ciphertext = RingGswCiphertext::input(ring_gsw, None, &mut circuit);
+    let error_parts = error_ciphertext.decrypt::<DCRTPolyMatrix>(
+        decryption_key_wire,
+        error_plaintext_modulus,
+        &mut circuit,
+    );
+    let mask_parts = mask_ciphertext.decrypt::<DCRTPolyMatrix>(
+        decryption_key_wire,
+        mask_plaintext_modulus,
+        &mut circuit,
+    );
+    let error_output =
+        circuit.add_gate(error_parts.secret_dependent, error_parts.public_bottom).as_single_wire();
+    let mask_output =
+        circuit.add_gate(mask_parts.secret_dependent, mask_parts.public_bottom).as_single_wire();
+    circuit.output(vec![error_output, mask_output]);
+
+    let wire_count = (circuit.num_input() - 1) / 2;
+    let mut inputs = Vec::with_capacity(circuit.num_input());
+    inputs.push(decryption_key);
+    inputs.extend(std::iter::repeat_n(material_wire_error.clone(), wire_count));
+    inputs.extend(std::iter::repeat_n(material_wire_error, wire_count));
+    assert_eq!(
+        inputs.len(),
+        circuit.num_input(),
+        "noise-refresh representative decrypt input count mismatch"
+    );
+    let outputs = circuit.eval(
+        &(),
+        one,
+        inputs,
+        Some(plt_evaluator),
+        Some(slot_transfer_evaluator as &dyn SlotTransferEvaluator<ErrorNorm>),
+        None,
+    );
+    assert_eq!(outputs.len(), 2, "representative decrypt circuit must produce two outputs");
+    (outputs[0].clone(), outputs[1].clone())
+}
+
+fn representative_symmetric_material_decryption_error_base_norms<A>(
+    ring_gsw: Arc<RingGswContext<DCRTPoly, A>>,
+    seed_bits: usize,
+    graph_seed: [u8; 32],
+    cbd_n: usize,
+    ring_gsw_error_sigma: f64,
+) -> (PolyMatrixNorm, PolyMatrixNorm)
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+{
+    let mut circuit = ring_gsw.fresh_circuit();
+    let output_ctx = ring_gsw.randomizer_norm_ctx.clone();
+    let encrypted_seeds = (0..seed_bits)
+        .map(|_| RingGswCiphertext::input(ring_gsw.clone(), None, &mut circuit))
+        .collect::<Vec<_>>();
+    let output_sizes = goldreich_noise_refresh_output_sizes(
+        ring_gsw.params.ring_dimension() as usize,
+        ring_gsw.params.modulus_digits(),
+        ring_gsw.params.to_crt().2,
+        1,
+    );
+    let cbd_seed = derive_noise_refresh_graph_seed(graph_seed, b"NoiseRefreshCBD/v1", 0);
+    let cbd_prf = GoldreichFheCbdPrg::setup_range(
+        &mut circuit,
+        ring_gsw.clone(),
+        seed_bits,
+        output_sizes.cbd_values,
+        0,
+        1,
+        cbd_seed,
+        cbd_n,
+    );
+    let errors = cbd_prf.evaluate_cbd_prf(&encrypted_seeds, &mut circuit);
+    let error_norm = errors[0].estimate_decryption_error_norm(ring_gsw_error_sigma);
+    // Reuse the CBD randomizer bound for mask ciphertexts as well. This is intentionally
+    // conservative and keeps the representative noise-refresh PRG simulation to one CBD output.
+    let mask_norm = error_norm.clone();
+    (
+        PolyMatrixNorm::new(
+            output_ctx.clone(),
+            error_norm.nrow,
+            error_norm.ncol,
+            error_norm.poly_norm.norm,
+            error_norm.zero_rows,
+        ),
+        PolyMatrixNorm::new(
+            output_ctx,
+            mask_norm.nrow,
+            mask_norm.ncol,
+            mask_norm.poly_norm.norm,
+            mask_norm.zero_rows,
+        ),
+    )
+}
+
+fn representative_symmetric_material_decryption_error_norm<A>(
+    prg_prefix: &SymmetricNoiseRefreshPrgErrorPrefix<A>,
+    ring_dim: usize,
+    v_bits: usize,
+    output_ctx: Arc<SimulatorContext>,
+) -> PolyMatrixNorm
+where
+    A: DecomposeArithmeticGadget<DCRTPoly> + ModularArithmeticPlanner<DCRTPoly>,
+{
+    let coefficient_scale = BigDecimal::from(ring_dim as u64);
+    let mask_scale = BigDecimal::from(
+        ring_dim
+            .checked_mul(v_bits)
+            .expect("noise-refresh representative mask decryption-error scale overflow")
+            as u64,
+    );
+    PolyMatrixNorm::new(
+        output_ctx,
+        prg_prefix
+            .material_error_decryption_error
+            .nrow
+            .max(prg_prefix.material_mask_decryption_error.nrow),
+        prg_prefix
+            .material_error_decryption_error
+            .ncol
+            .max(prg_prefix.material_mask_decryption_error.ncol),
+        prg_prefix.material_error_decryption_error.poly_norm.norm.clone() * coefficient_scale +
+            prg_prefix.material_mask_decryption_error.poly_norm.norm.clone() * mask_scale,
+        None,
+    )
 }
 
 fn representative_material_decryption_error_norm<A>(

--- a/src/simulator/eval_error/evaluators.rs
+++ b/src/simulator/eval_error/evaluators.rs
@@ -22,7 +22,7 @@ impl NormBggPolyEncodingSTEvaluator {
 
         let b0_preimage_norm =
             compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, Some(1), None);
-        info!(
+        debug!(
             "{}",
             format!(
                 "BGG poly-encoding slot-transfer preimage norm bits {}",
@@ -119,12 +119,12 @@ impl NormBggPolyEncodingSTEvaluator {
         let input_vector_multiplier = PolyMatrixNorm::gadget_decomposed(ctx.clone(), ctx.m_g);
         log_matrix_norm_bits("input_vector_multiplier", &input_vector_multiplier);
 
-        info!("BGG poly-encoding slot-transfer const term bits {}", matrix_norm_bits(&const_term));
-        info!(
+        debug!("BGG poly-encoding slot-transfer const term bits {}", matrix_norm_bits(&const_term));
+        debug!(
             "BGG poly-encoding slot-transfer plaintext multiplier bits {}",
             matrix_norm_bits(&transfer_plaintext_multiplier)
         );
-        info!(
+        debug!(
             "BGG poly-encoding slot-transfer input multiplier bits {}",
             matrix_norm_bits(&input_vector_multiplier)
         );
@@ -240,19 +240,19 @@ impl NormPltLWEEvaluator {
             compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, None);
         let k_high_norm_bits = bigdecimal_bits_ceil(&k_high_norm);
         let k_low = PolyMatrixNorm::gadget_decomposed(ctx.clone(), ctx.m_g);
-        info!("{}", format!("preimage norm bits {}", k_high_norm_bits));
-        info!(
+        debug!("{}", format!("preimage norm bits {}", k_high_norm_bits));
+        debug!(
             "LWE PLT k_low decomposition norm bits {}",
             bigdecimal_bits_ceil(&k_low.poly_norm.norm)
         );
         let e_b_init = PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_b, e_b_sigma * 6, None);
         let e_b_times_k_high =
             &e_b_init * &PolyMatrixNorm::new(ctx.clone(), ctx.m_b, ctx.m_g, k_high_norm, None);
-        info!(
+        debug!(
             "LWE PLT const term norm bits {}",
             bigdecimal_bits_ceil(&e_b_times_k_high.poly_norm.norm)
         );
-        info!(
+        debug!(
             "LWE PLT e_input multiplier norm bits {}",
             bigdecimal_bits_ceil(&k_low.poly_norm.norm)
         );
@@ -319,7 +319,7 @@ impl NormPltGGH15Evaluator {
 
         let preimage_norm =
             compute_preimage_norm(&ctx.ring_dim_sqrt, ctx.m_g as u64, &ctx.base, None, None);
-        info!("{}", format!("preimage norm bits {}", bigdecimal_bits_ceil(&preimage_norm)));
+        debug!("{}", format!("preimage norm bits {}", bigdecimal_bits_ceil(&preimage_norm)));
         let e_b_init =
             PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_b, e_b_sigma * &gaussian_bound, None);
         let s_vec = PolyMatrixNorm::new(
@@ -443,14 +443,14 @@ impl NormPltGGH15Evaluator {
         let mut const_term = const_term_gate2_identity_total.clone();
         const_term += const_term_gate2_t_total.clone();
         const_term += const_term_lut_subtraction_total.clone();
-        info!(
+        debug!(
             "{}",
             format!(
                 "GGH15 PLT const term norm bits {}",
                 bigdecimal_bits_ceil(&const_term.poly_norm.norm)
             )
         );
-        info!(
+        debug!(
             "{}",
             format!(
                 "GGH15 PLT input-plaintext multiplier norm bits {}",
@@ -459,7 +459,7 @@ impl NormPltGGH15Evaluator {
         );
 
         if dump_const_term_breakdown {
-            info!(
+            debug!(
                 "GGH15 const term breakdown bits: gate1_total={} gate1_from_eb={} gate1_from_s={} gate2_identity_total={} gate2_identity_from_eb={} gate2_identity_from_s={} gate2_gy_total={} gate2_gy_from_eb={} gate2_gy_from_s={} gate2_v_total={} gate2_v_from_eb={} gate2_v_from_s={} gate2_vx_total={} gate2_vx_from_eb={} gate2_vx_from_s={} term_gate2_identity={} term_gate2_gy={} term_gate2_v={} term_gate2_t={} term_gate2_vx_input_plaintext_multiplier={} term_lut_subtraction={} const_total={}",
                 gate1_total_bits,
                 gate1_from_eb_bits,
@@ -488,7 +488,7 @@ impl NormPltGGH15Evaluator {
 
         // Corresponds to `input.vector * u_g_decomposed * v_idx` in `public_lookup`.
         let e_input_multiplier = PolyMatrixNorm::gadget_decomposed(ctx.clone(), ctx.m_g) * &v_idx;
-        info!(
+        debug!(
             "{}",
             format!(
                 "GGH15 PLT e_input multiplier norm bits {}",
@@ -624,7 +624,7 @@ impl NormPltCommitEvaluator {
         let preimage =
             PolyMatrixNorm::new(ctx.clone(), ctx.m_b, verifier_norm.nrow, preimage_norm, None);
         let lut_term = &init_error * preimage * verifier_norm + init_error * opening_norm;
-        info!("lut_term norm bits {}", bigdecimal_bits_ceil(&lut_term.poly_norm.norm));
+        debug!("lut_term norm bits {}", bigdecimal_bits_ceil(&lut_term.poly_norm.norm));
         Self { lut_term }
     }
 }

--- a/tests/test_gpu_diamond_io.rs
+++ b/tests/test_gpu_diamond_io.rs
@@ -10,6 +10,7 @@ use mxx::{
     bgg::{public_key::BggPublicKey, sampler::BGGPublicKeySampler},
     circuit::{PolyCircuit, gate::GateId},
     element::PolyElem,
+    func_enc::aky24::NoCircuitEvaluator,
     gadgets::arith::{ModularArithmeticContext, NestedRnsPolyContext},
     input_injector::DiamondInjector,
     io::diamond_io::{
@@ -23,7 +24,7 @@ use mxx::{
             NaiveLWEBGGEncodingVecPltEvaluator, NaiveLWEBGGPublicKeyVecPltEvaluator,
         },
     },
-    matrix::gpu_dcrt_poly::GpuDCRTPolyMatrix,
+    matrix::{dcrt_poly::DCRTPolyMatrix, gpu_dcrt_poly::GpuDCRTPolyMatrix},
     poly::{
         Poly, PolyParams,
         dcrt::{
@@ -35,7 +36,9 @@ use mxx::{
     sampler::{
         PolyTrapdoorSampler,
         gpu::{GpuDCRTPolyHashSampler, GpuDCRTPolyUniformSampler},
-        trapdoor::GpuDCRTPolyTrapdoorSampler,
+        hash::DCRTPolyHashSampler,
+        trapdoor::{DCRTPolyTrapdoorSampler, GpuDCRTPolyTrapdoorSampler},
+        uniform::DCRTPolyUniformSampler,
     },
     simulator::error_norm::{ErrorNorm, NormNaiveBggEncodingVecSTEvaluator, NormPltLWEEvaluator},
     slot_transfer::{NaiveBGGVecSlotTransferEvaluator, bgg_pubkey::BggPublicKeySTEvaluator},
@@ -50,10 +53,11 @@ use std::{
 };
 use tempfile::tempdir;
 use tracing::info;
+use tracing_subscriber::prelude::*;
 
 const DEFAULT_RING_DIM: u32 = 1 << 16;
 const DEFAULT_INPUT_SIZE: usize = 5;
-const DEFAULT_SEED_BITS: usize = 1;
+const DEFAULT_SEED_BITS: usize = 5;
 const DEFAULT_CRT_BITS: usize = 28;
 const DEFAULT_BASE_BITS: u32 = 14;
 const DEFAULT_P_MODULI_BITS: usize = 7;
@@ -72,6 +76,20 @@ const DEFAULT_HASH_KEY: [u8; 32] = [0x42; 32];
 
 type GpuMatrix = GpuDCRTPolyMatrix;
 type GpuHashSampler = GpuDCRTPolyHashSampler<Keccak256>;
+type CpuMatrix = DCRTPolyMatrix;
+type CpuHashSampler = DCRTPolyHashSampler<Keccak256>;
+type CpuInjector =
+    DiamondInjector<CpuMatrix, DCRTPolyUniformSampler, CpuHashSampler, DCRTPolyTrapdoorSampler>;
+type CpuDiamondIO = DiamondIO<
+    CpuMatrix,
+    DCRTPolyUniformSampler,
+    CpuHashSampler,
+    DCRTPolyTrapdoorSampler,
+    NoCircuitEvaluator,
+    NoCircuitEvaluator,
+    NoCircuitEvaluator,
+    NoCircuitEvaluator,
+>;
 type GpuInjector = DiamondInjector<
     GpuMatrix,
     GpuDCRTPolyUniformSampler,
@@ -282,7 +300,7 @@ fn gpu_params_for_crt_depth(
         moduli,
         cpu_params.base_bits(),
         vec![gpu_id],
-        Some(crt_depth as u32),
+        Some(1),
     );
     assert_eq!(gpu_params.modulus(), cpu_params.modulus());
     (cpu_params, gpu_params)
@@ -294,6 +312,23 @@ fn build_ring_gsw_context(
     active_levels: usize,
 ) -> Arc<NestedRnsPolyContext> {
     let mut setup_circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    Arc::new(NestedRnsPolyContext::setup(
+        &mut setup_circuit,
+        params,
+        cfg.p_moduli_bits,
+        cfg.max_unreduced_muls,
+        cfg.scale,
+        false,
+        Some(active_levels),
+    ))
+}
+
+fn build_cpu_ring_gsw_context(
+    params: &DCRTPolyParams,
+    cfg: &DiamondIOGpuBenchConfig,
+    active_levels: usize,
+) -> Arc<NestedRnsPolyContext> {
+    let mut setup_circuit = PolyCircuit::<DCRTPoly>::new();
     Arc::new(NestedRnsPolyContext::setup(
         &mut setup_circuit,
         params,
@@ -408,6 +443,55 @@ fn build_diamond_io(
             )
         })),
         Some(NaiveBGGVecSlotTransferEvaluator::new()),
+    )
+}
+
+fn build_cpu_diamond_io_for_search(
+    cfg: &DiamondIOGpuBenchConfig,
+    crt_depth: usize,
+    prf_mask_output_coeff_bits: usize,
+) -> CpuDiamondIO {
+    let params = DCRTPolyParams::new(cfg.ring_dim, crt_depth, cfg.crt_bits, cfg.base_bits);
+    let (_, _, actual_crt_depth) = params.to_crt();
+    assert_eq!(actual_crt_depth, crt_depth, "DCRTPolyParams returned an unexpected CRT depth");
+    let ring_gsw_context = build_cpu_ring_gsw_context(&params, cfg, crt_depth);
+    let ring_gsw_level_offset = 0usize;
+    let ring_gsw_enable_levels = Some(crt_depth);
+    let ring_gsw_width = 2 *
+        <NestedRnsPolyContext as ModularArithmeticContext<DCRTPoly>>::gadget_len(
+            ring_gsw_context.as_ref(),
+            ring_gsw_enable_levels,
+            Some(ring_gsw_level_offset),
+        );
+    let injector = CpuInjector::new(
+        params.clone(),
+        cfg.input_size,
+        cfg.input_base(),
+        cfg.trapdoor_sigma,
+        cfg.error_sigma,
+    );
+    DiamondIO::new(
+        injector,
+        cfg.input_size,
+        cfg.output_size(),
+        params,
+        ring_gsw_context,
+        ring_gsw_width,
+        ring_gsw_level_offset,
+        ring_gsw_enable_levels,
+        Some(cfg.error_sigma),
+        b"test_gpu_diamond_io_cpu_search".to_vec(),
+        cfg.seed_bits,
+        prf_mask_output_coeff_bits,
+        cfg.noise_refresh_v_bits,
+        cfg.noise_refresh_cbd_n,
+        [0x24; 32],
+        [0x25; 32],
+        None,
+        None,
+        None,
+        None,
+        None,
     )
 }
 
@@ -549,7 +633,16 @@ fn build_public_key_bench_estimator(
 #[tokio::test]
 #[sequential_test::sequential]
 async fn test_gpu_diamond_io_error_search_and_bench_estimate() {
-    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+    let log_filter = tracing_subscriber::filter::Targets::new()
+        .with_target("test_gpu_diamond_io", tracing_subscriber::filter::LevelFilter::INFO)
+        .with_target("mxx::io::diamond_io", tracing_subscriber::filter::LevelFilter::INFO)
+        .with_target("mxx::noise_refresh", tracing_subscriber::filter::LevelFilter::INFO)
+        .with_target("mxx::storage::write", tracing_subscriber::filter::LevelFilter::INFO)
+        .with_default(tracing_subscriber::filter::LevelFilter::WARN);
+    let _ = tracing_subscriber::registry()
+        .with(log_filter)
+        .with(tracing_subscriber::fmt::layer())
+        .try_init();
     gpu_device_sync();
 
     let cfg = DiamondIOGpuBenchConfig::from_env();
@@ -568,12 +661,10 @@ async fn test_gpu_diamond_io_error_search_and_bench_estimate() {
         cfg.security_bits,
         DiamondIOFuncType::DebugDecryption,
         |crt_depth| {
-            build_diamond_io(
+            build_cpu_diamond_io_for_search(
                 &cfg,
                 crt_depth,
                 cfg.prf_mask_output_coeff_bits_search_bound(),
-                gpu_id,
-                temp_dir.path().to_path_buf(),
             )
         },
         &plt_evaluator,

--- a/tests/test_gpu_diamond_io.rs
+++ b/tests/test_gpu_diamond_io.rs
@@ -1,0 +1,638 @@
+#![cfg(feature = "gpu")]
+
+use bigdecimal::{BigDecimal, FromPrimitive};
+use keccak_asm::Keccak256;
+use mxx::{
+    bench_estimator::{
+        BggEncodingBenchEstimator, BggPublicKeyBenchEstimator, BggPublicKeyBenchSamples,
+        NaiveBGGVecBenchEstimator,
+    },
+    bgg::{public_key::BggPublicKey, sampler::BGGPublicKeySampler},
+    circuit::{PolyCircuit, gate::GateId},
+    element::PolyElem,
+    gadgets::arith::{ModularArithmeticContext, NestedRnsPolyContext},
+    input_injector::DiamondInjector,
+    io::diamond_io::{
+        DiamondIO, DiamondIOBenchEstimator, DiamondIOFuncType,
+        GpuDCRTPolyMatrixNativeBenchEstimator, diamond_io_find_crt_depth,
+    },
+    lookup::{
+        PltEvaluator, PublicLut,
+        lwe::{
+            LWEBGGEncodingPltEvaluator, LWEBGGPubKeyPltEvaluator,
+            NaiveLWEBGGEncodingVecPltEvaluator, NaiveLWEBGGPublicKeyVecPltEvaluator,
+        },
+    },
+    matrix::gpu_dcrt_poly::GpuDCRTPolyMatrix,
+    poly::{
+        Poly, PolyParams,
+        dcrt::{
+            gpu::{GpuDCRTPoly, GpuDCRTPolyParams, detected_gpu_device_ids, gpu_device_sync},
+            params::DCRTPolyParams,
+            poly::DCRTPoly,
+        },
+    },
+    sampler::{
+        PolyTrapdoorSampler,
+        gpu::{GpuDCRTPolyHashSampler, GpuDCRTPolyUniformSampler},
+        trapdoor::GpuDCRTPolyTrapdoorSampler,
+    },
+    simulator::error_norm::{ErrorNorm, NormNaiveBggEncodingVecSTEvaluator, NormPltLWEEvaluator},
+    slot_transfer::{NaiveBGGVecSlotTransferEvaluator, bgg_pubkey::BggPublicKeySTEvaluator},
+    storage::write::init_storage_system,
+    utils::bigdecimal_bits_ceil,
+};
+use num_bigint::BigUint;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tempfile::tempdir;
+use tracing::info;
+
+const DEFAULT_RING_DIM: u32 = 1 << 16;
+const DEFAULT_INPUT_SIZE: usize = 5;
+const DEFAULT_SEED_BITS: usize = 1;
+const DEFAULT_CRT_BITS: usize = 28;
+const DEFAULT_BASE_BITS: u32 = 14;
+const DEFAULT_P_MODULI_BITS: usize = 7;
+const DEFAULT_MAX_UNREDUCED_MULS: usize = 4;
+const DEFAULT_SCALE: u64 = 1 << 8;
+const DEFAULT_MIN_CRT_DEPTH: usize = 1;
+const DEFAULT_MAX_CRT_DEPTH: usize = 64;
+const DEFAULT_SECURITY_BITS: usize = 0;
+const DEFAULT_NOISE_REFRESH_V_BITS: usize = 200;
+const DEFAULT_NOISE_REFRESH_CBD_N: usize = 1;
+const DEFAULT_BENCH_ITERATIONS: usize = 1;
+const DEFAULT_ERROR_SIGMA: f64 = 4.0;
+const DEFAULT_TRAPDOOR_SIGMA: f64 = 4.578;
+const DEFAULT_D_SECRET: usize = 1;
+const DEFAULT_HASH_KEY: [u8; 32] = [0x42; 32];
+
+type GpuMatrix = GpuDCRTPolyMatrix;
+type GpuHashSampler = GpuDCRTPolyHashSampler<Keccak256>;
+type GpuInjector = DiamondInjector<
+    GpuMatrix,
+    GpuDCRTPolyUniformSampler,
+    GpuHashSampler,
+    GpuDCRTPolyTrapdoorSampler,
+>;
+type GpuPubKeyPltEvaluator =
+    NaiveLWEBGGPublicKeyVecPltEvaluator<GpuMatrix, GpuHashSampler, GpuDCRTPolyTrapdoorSampler>;
+type GpuScalarPubKeyPltEvaluator =
+    LWEBGGPubKeyPltEvaluator<GpuMatrix, GpuHashSampler, GpuDCRTPolyTrapdoorSampler>;
+type GpuPubKeySlotEvaluator = BggPublicKeySTEvaluator<
+    GpuMatrix,
+    GpuDCRTPolyUniformSampler,
+    GpuHashSampler,
+    GpuDCRTPolyTrapdoorSampler,
+>;
+type GpuEncodingPltEvaluator = NaiveLWEBGGEncodingVecPltEvaluator<GpuMatrix, GpuHashSampler>;
+type GpuDiamondIO = DiamondIO<
+    GpuMatrix,
+    GpuDCRTPolyUniformSampler,
+    GpuHashSampler,
+    GpuDCRTPolyTrapdoorSampler,
+    GpuPubKeyPltEvaluator,
+    NaiveBGGVecSlotTransferEvaluator,
+    GpuEncodingPltEvaluator,
+    NaiveBGGVecSlotTransferEvaluator,
+>;
+
+#[derive(Debug, Clone)]
+struct DiamondIOGpuBenchConfig {
+    ring_dim: u32,
+    input_size: usize,
+    seed_bits: usize,
+    crt_bits: usize,
+    base_bits: u32,
+    p_moduli_bits: usize,
+    max_unreduced_muls: usize,
+    scale: u64,
+    min_crt_depth: usize,
+    max_crt_depth: usize,
+    security_bits: usize,
+    noise_refresh_v_bits: usize,
+    noise_refresh_cbd_n: usize,
+    bench_iterations: usize,
+    error_sigma: f64,
+    trapdoor_sigma: f64,
+    d_secret: usize,
+}
+
+impl DiamondIOGpuBenchConfig {
+    fn from_env() -> Self {
+        let cfg = Self {
+            ring_dim: env_or_parse_u32("DIAMOND_IO_GPU_BENCH_RING_DIM", DEFAULT_RING_DIM),
+            input_size: env_or_parse_usize("DIAMOND_IO_GPU_BENCH_INPUT_SIZE", DEFAULT_INPUT_SIZE),
+            seed_bits: env_or_parse_usize("DIAMOND_IO_GPU_BENCH_SEED_BITS", DEFAULT_SEED_BITS),
+            crt_bits: env_or_parse_usize("DIAMOND_IO_GPU_BENCH_CRT_BITS", DEFAULT_CRT_BITS),
+            base_bits: env_or_parse_u32("DIAMOND_IO_GPU_BENCH_BASE_BITS", DEFAULT_BASE_BITS),
+            p_moduli_bits: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_P_MODULI_BITS",
+                DEFAULT_P_MODULI_BITS,
+            ),
+            max_unreduced_muls: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_MAX_UNREDUCED_MULS",
+                DEFAULT_MAX_UNREDUCED_MULS,
+            ),
+            scale: env_or_parse_u64("DIAMOND_IO_GPU_BENCH_SCALE", DEFAULT_SCALE),
+            min_crt_depth: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_MIN_CRT_DEPTH",
+                DEFAULT_MIN_CRT_DEPTH,
+            ),
+            max_crt_depth: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_MAX_CRT_DEPTH",
+                DEFAULT_MAX_CRT_DEPTH,
+            ),
+            security_bits: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_SECURITY_BITS",
+                DEFAULT_SECURITY_BITS,
+            ),
+            noise_refresh_v_bits: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_NOISE_REFRESH_V_BITS",
+                DEFAULT_NOISE_REFRESH_V_BITS,
+            ),
+            noise_refresh_cbd_n: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_NOISE_REFRESH_CBD_N",
+                DEFAULT_NOISE_REFRESH_CBD_N,
+            ),
+            bench_iterations: env_or_parse_usize(
+                "DIAMOND_IO_GPU_BENCH_ITERATIONS",
+                DEFAULT_BENCH_ITERATIONS,
+            ),
+            error_sigma: env_or_parse_f64("DIAMOND_IO_GPU_BENCH_ERROR_SIGMA", DEFAULT_ERROR_SIGMA),
+            trapdoor_sigma: env_or_parse_f64(
+                "DIAMOND_IO_GPU_BENCH_TRAPDOOR_SIGMA",
+                DEFAULT_TRAPDOOR_SIGMA,
+            ),
+            d_secret: env_or_parse_usize("DIAMOND_IO_GPU_BENCH_D_SECRET", DEFAULT_D_SECRET),
+        };
+        assert!(cfg.ring_dim > 0, "DIAMOND_IO_GPU_BENCH_RING_DIM must be positive");
+        assert!(cfg.input_size > 0, "DIAMOND_IO_GPU_BENCH_INPUT_SIZE must be positive");
+        assert!(cfg.seed_bits > 0, "DIAMOND_IO_GPU_BENCH_SEED_BITS must be positive");
+        assert!(cfg.crt_bits > 0, "DIAMOND_IO_GPU_BENCH_CRT_BITS must be positive");
+        assert!(cfg.base_bits > 0, "DIAMOND_IO_GPU_BENCH_BASE_BITS must be positive");
+        assert!(
+            cfg.min_crt_depth <= cfg.max_crt_depth,
+            "DIAMOND_IO_GPU_BENCH_MIN_CRT_DEPTH must be <= DIAMOND_IO_GPU_BENCH_MAX_CRT_DEPTH"
+        );
+        assert!(
+            cfg.noise_refresh_v_bits > 0,
+            "DIAMOND_IO_GPU_BENCH_NOISE_REFRESH_V_BITS must be positive"
+        );
+        assert!(
+            cfg.noise_refresh_cbd_n > 0,
+            "DIAMOND_IO_GPU_BENCH_NOISE_REFRESH_CBD_N must be positive"
+        );
+        assert!(cfg.bench_iterations > 0, "DIAMOND_IO_GPU_BENCH_ITERATIONS must be positive");
+        assert!(cfg.error_sigma >= 0.0, "DIAMOND_IO_GPU_BENCH_ERROR_SIGMA must be nonnegative");
+        assert!(cfg.trapdoor_sigma > 0.0, "DIAMOND_IO_GPU_BENCH_TRAPDOOR_SIGMA must be positive");
+        assert!(cfg.d_secret > 0, "DIAMOND_IO_GPU_BENCH_D_SECRET must be positive");
+        cfg
+    }
+
+    fn output_size(&self) -> usize {
+        self.seed_bits
+    }
+
+    fn input_base(&self) -> usize {
+        2
+    }
+
+    fn prf_mask_output_coeff_bits_search_bound(&self) -> usize {
+        self.max_crt_depth
+            .checked_mul(self.crt_bits)
+            .expect("DiamondIO PRF-mask search bound overflow")
+            .max(1)
+    }
+}
+
+struct DynamicNormPltLWEEvaluator {
+    error_sigma: BigDecimal,
+}
+
+impl DynamicNormPltLWEEvaluator {
+    fn new(error_sigma: f64) -> Self {
+        Self { error_sigma: BigDecimal::from_f64(error_sigma).expect("finite error sigma") }
+    }
+}
+
+impl PltEvaluator<ErrorNorm> for DynamicNormPltLWEEvaluator {
+    fn public_lookup(
+        &self,
+        params: &(),
+        plt: &PublicLut<DCRTPoly>,
+        one: &ErrorNorm,
+        input: &ErrorNorm,
+        gate_id: GateId,
+        lut_id: usize,
+    ) -> ErrorNorm {
+        let evaluator = NormPltLWEEvaluator::new(input.clone_ctx(), &self.error_sigma);
+        evaluator.public_lookup(params, plt, one, input, gate_id, lut_id)
+    }
+}
+
+fn env_or_parse_u32(key: &str, default: u32) -> u32 {
+    env::var(key)
+        .ok()
+        .map(|raw| raw.parse::<u32>().unwrap_or_else(|err| panic!("{key} must be u32: {err}")))
+        .unwrap_or(default)
+}
+
+fn env_or_parse_u64(key: &str, default: u64) -> u64 {
+    env::var(key)
+        .ok()
+        .map(|raw| raw.parse::<u64>().unwrap_or_else(|err| panic!("{key} must be u64: {err}")))
+        .unwrap_or(default)
+}
+
+fn env_or_parse_usize(key: &str, default: usize) -> usize {
+    env::var(key)
+        .ok()
+        .map(|raw| raw.parse::<usize>().unwrap_or_else(|err| panic!("{key} must be usize: {err}")))
+        .unwrap_or(default)
+}
+
+fn env_or_parse_f64(key: &str, default: f64) -> f64 {
+    env::var(key)
+        .ok()
+        .map(|raw| raw.parse::<f64>().unwrap_or_else(|err| panic!("{key} must be f64: {err}")))
+        .unwrap_or(default)
+}
+
+fn ensure_clean_dir(dir: &Path) {
+    if dir.exists() {
+        fs::remove_dir_all(dir).expect("failed to remove existing DiamondIO GPU bench directory");
+    }
+    fs::create_dir_all(dir).expect("failed to create DiamondIO GPU bench directory");
+}
+
+fn gpu_params_for_crt_depth(
+    cfg: &DiamondIOGpuBenchConfig,
+    crt_depth: usize,
+    gpu_id: i32,
+) -> (DCRTPolyParams, GpuDCRTPolyParams) {
+    let cpu_params = DCRTPolyParams::new(cfg.ring_dim, crt_depth, cfg.crt_bits, cfg.base_bits);
+    let (moduli, _, actual_depth) = cpu_params.to_crt();
+    assert_eq!(actual_depth, crt_depth, "DCRTPolyParams returned an unexpected CRT depth");
+    let gpu_params = GpuDCRTPolyParams::new_with_gpu(
+        cpu_params.ring_dimension(),
+        moduli,
+        cpu_params.base_bits(),
+        vec![gpu_id],
+        Some(crt_depth as u32),
+    );
+    assert_eq!(gpu_params.modulus(), cpu_params.modulus());
+    (cpu_params, gpu_params)
+}
+
+fn build_ring_gsw_context(
+    params: &GpuDCRTPolyParams,
+    cfg: &DiamondIOGpuBenchConfig,
+    active_levels: usize,
+) -> Arc<NestedRnsPolyContext> {
+    let mut setup_circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    Arc::new(NestedRnsPolyContext::setup(
+        &mut setup_circuit,
+        params,
+        cfg.p_moduli_bits,
+        cfg.max_unreduced_muls,
+        cfg.scale,
+        false,
+        Some(active_levels),
+    ))
+}
+
+fn build_lwe_pubkey_vec_plt_evaluator(
+    params: &GpuDCRTPolyParams,
+    hash_key: [u8; 32],
+    d_secret: usize,
+    dir_path: PathBuf,
+) -> (GpuPubKeyPltEvaluator, GpuMatrix) {
+    let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(params, DEFAULT_TRAPDOOR_SIGMA);
+    let (trapdoor, pub_matrix) = trapdoor_sampler.trapdoor(params, d_secret);
+    let evaluator = GpuPubKeyPltEvaluator::new(LWEBGGPubKeyPltEvaluator::<
+        GpuMatrix,
+        GpuHashSampler,
+        GpuDCRTPolyTrapdoorSampler,
+    >::new(
+        hash_key,
+        trapdoor_sampler,
+        Arc::new(pub_matrix.clone()),
+        Arc::new(trapdoor),
+        dir_path,
+    ));
+    (evaluator, pub_matrix)
+}
+
+fn build_lwe_scalar_pubkey_plt_evaluator(
+    params: &GpuDCRTPolyParams,
+    hash_key: [u8; 32],
+    d_secret: usize,
+    dir_path: PathBuf,
+) -> GpuScalarPubKeyPltEvaluator {
+    let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(params, DEFAULT_TRAPDOOR_SIGMA);
+    let (trapdoor, pub_matrix) = trapdoor_sampler.trapdoor(params, d_secret);
+    GpuScalarPubKeyPltEvaluator::new(
+        hash_key,
+        trapdoor_sampler,
+        Arc::new(pub_matrix),
+        Arc::new(trapdoor),
+        dir_path,
+    )
+}
+
+fn build_diamond_io(
+    cfg: &DiamondIOGpuBenchConfig,
+    crt_depth: usize,
+    prf_mask_output_coeff_bits: usize,
+    gpu_id: i32,
+    dir_path: PathBuf,
+) -> GpuDiamondIO {
+    let (cpu_params, gpu_params) = gpu_params_for_crt_depth(cfg, crt_depth, gpu_id);
+    let ring_gsw_context = build_ring_gsw_context(&gpu_params, cfg, crt_depth);
+    let ring_gsw_level_offset = 0usize;
+    let ring_gsw_enable_levels = Some(crt_depth);
+    let ring_gsw_width = 2 *
+        <NestedRnsPolyContext as ModularArithmeticContext<GpuDCRTPoly>>::gadget_len(
+            ring_gsw_context.as_ref(),
+            ring_gsw_enable_levels,
+            Some(ring_gsw_level_offset),
+        );
+    let injector = GpuInjector::new(
+        gpu_params.clone(),
+        cfg.input_size,
+        cfg.input_base(),
+        cfg.trapdoor_sigma,
+        cfg.error_sigma,
+    )
+    .with_gpu_device_ids(vec![gpu_id]);
+    let lookup_dir = dir_path.join(format!("lookup_crt{crt_depth}"));
+    fs::create_dir_all(&lookup_dir).expect("failed to create DiamondIO lookup directory");
+    let (pk_lookup_evaluator, lookup_base_matrix) = build_lwe_pubkey_vec_plt_evaluator(
+        &gpu_params,
+        DEFAULT_HASH_KEY,
+        cfg.d_secret,
+        lookup_dir.clone(),
+    );
+    let enc_lookup_dir = lookup_dir.clone();
+    DiamondIO::new(
+        injector,
+        cfg.input_size,
+        cfg.output_size(),
+        cpu_params,
+        ring_gsw_context,
+        ring_gsw_width,
+        ring_gsw_level_offset,
+        ring_gsw_enable_levels,
+        Some(cfg.error_sigma),
+        b"test_gpu_diamond_io".to_vec(),
+        cfg.seed_bits,
+        prf_mask_output_coeff_bits,
+        cfg.noise_refresh_v_bits,
+        cfg.noise_refresh_cbd_n,
+        [0x24; 32],
+        [0x25; 32],
+        Some(pk_lookup_evaluator),
+        Some(NaiveBGGVecSlotTransferEvaluator::new()),
+        Some(lookup_base_matrix),
+        Some(Arc::new(move |c_b0| {
+            GpuEncodingPltEvaluator::new(
+                LWEBGGEncodingPltEvaluator::<GpuMatrix, GpuHashSampler>::new(
+                    DEFAULT_HASH_KEY,
+                    enc_lookup_dir.clone(),
+                    c_b0,
+                ),
+            )
+        })),
+        Some(NaiveBGGVecSlotTransferEvaluator::new()),
+    )
+}
+
+fn build_benchmark_public_lut(params: &GpuDCRTPolyParams) -> PublicLut<GpuDCRTPoly> {
+    PublicLut::<GpuDCRTPoly>::new(
+        params,
+        16,
+        move |params, x| {
+            if x >= 16 {
+                return None;
+            }
+            let y_elem = <<GpuDCRTPoly as Poly>::Elem as PolyElem>::constant(
+                &params.modulus(),
+                (x + 1) % 16,
+            );
+            Some((x, y_elem))
+        },
+        None,
+    )
+}
+
+fn build_benchmark_public_lookup_gate(
+    params: &GpuDCRTPolyParams,
+) -> (PublicLut<GpuDCRTPoly>, usize, GateId) {
+    let lut = build_benchmark_public_lut(params);
+    let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    let input = circuit.input(1);
+    let lut_id = circuit.register_public_lookup(lut.clone());
+    let gate_id = circuit.public_lookup_gate(input, lut_id).as_single_wire();
+    (lut, lut_id, gate_id)
+}
+
+fn build_benchmark_slot_transfer_gate(src_slots: &[(u32, Option<u32>)]) -> GateId {
+    let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    let input = circuit.input(1);
+    circuit.slot_transfer_gate(input, src_slots).as_single_wire()
+}
+
+fn identity_slot_transfer_plan(num_slots: usize) -> Vec<(u32, Option<u32>)> {
+    (0..num_slots).map(|slot| (slot as u32, None)).collect()
+}
+
+fn sample_benchmark_pubkeys(
+    params: &GpuDCRTPolyParams,
+    seed: [u8; 32],
+    d_secret: usize,
+    non_constant_key_count: usize,
+    tag: &[u8],
+) -> Vec<BggPublicKey<GpuMatrix>> {
+    let sampler = BGGPublicKeySampler::<_, GpuHashSampler>::new(seed, d_secret);
+    let reveal_plaintexts = vec![true; non_constant_key_count];
+    sampler.sample(params, tag, &reveal_plaintexts)
+}
+
+fn constant_and_shared_benchmark_pubkeys(
+    pubkeys: &[BggPublicKey<GpuMatrix>],
+) -> (&BggPublicKey<GpuMatrix>, &BggPublicKey<GpuMatrix>) {
+    assert!(
+        pubkeys.len() >= 2,
+        "benchmark pubkeys must contain the constant-one key and one reusable input key"
+    );
+    (&pubkeys[0], &pubkeys[1])
+}
+
+fn build_public_key_bench_estimator(
+    params: &GpuDCRTPolyParams,
+    cfg: &DiamondIOGpuBenchConfig,
+    bench_dir: PathBuf,
+) -> NaiveBGGVecBenchEstimator<
+    BggPublicKeyBenchEstimator<GpuMatrix, GpuPubKeyPltEvaluator, GpuPubKeySlotEvaluator>,
+> {
+    let (public_lut, public_lut_id, public_lut_gate_id) =
+        build_benchmark_public_lookup_gate(params);
+    let slot_transfer_src_slots = identity_slot_transfer_plan(params.ring_dimension() as usize);
+    let slot_transfer_gate_id = build_benchmark_slot_transfer_gate(&slot_transfer_src_slots);
+    let public_keys = sample_benchmark_pubkeys(
+        params,
+        DEFAULT_HASH_KEY,
+        cfg.d_secret,
+        1,
+        b"test_gpu_diamond_io_pubkey_bench",
+    );
+    let (public_lut_one, shared_input) = constant_and_shared_benchmark_pubkeys(&public_keys);
+    let scalar_plt_evaluator = build_lwe_scalar_pubkey_plt_evaluator(
+        params,
+        DEFAULT_HASH_KEY,
+        cfg.d_secret,
+        bench_dir.clone(),
+    );
+    let scalar_slot_evaluator = GpuPubKeySlotEvaluator::new(
+        DEFAULT_HASH_KEY,
+        cfg.d_secret,
+        params.ring_dimension() as usize,
+        cfg.trapdoor_sigma,
+        cfg.error_sigma,
+        bench_dir.clone(),
+    );
+    let (public_lut_estimator, _) =
+        build_lwe_pubkey_vec_plt_evaluator(params, DEFAULT_HASH_KEY, cfg.d_secret, bench_dir);
+    let slot_transfer_estimator = GpuPubKeySlotEvaluator::new(
+        DEFAULT_HASH_KEY,
+        cfg.d_secret,
+        params.ring_dimension() as usize,
+        cfg.trapdoor_sigma,
+        cfg.error_sigma,
+        PathBuf::from("test_data/test_gpu_diamond_io_slot_transfer_estimator"),
+    );
+    let scalar_estimator = BggPublicKeyBenchEstimator::benchmark(
+        &BggPublicKeyBenchSamples {
+            params,
+            add_lhs: shared_input,
+            add_rhs: shared_input,
+            sub_lhs: shared_input,
+            sub_rhs: shared_input,
+            mul_lhs: shared_input,
+            mul_rhs: shared_input,
+            small_scalar_input: shared_input,
+            small_scalar: &[3u32, 5u32],
+            large_scalar_input: shared_input,
+            large_scalar: &[BigUint::from(7u32)],
+            public_lut_one,
+            public_lut_input: shared_input,
+            public_lut: &public_lut,
+            public_lut_id,
+            public_lut_gate_id,
+            slot_transfer_input: shared_input,
+            slot_transfer_src_slots: &slot_transfer_src_slots,
+            slot_transfer_gate_id,
+        },
+        &scalar_plt_evaluator,
+        &scalar_slot_evaluator,
+        public_lut_estimator,
+        slot_transfer_estimator,
+        cfg.bench_iterations,
+    );
+    NaiveBGGVecBenchEstimator::new(scalar_estimator, params.ring_dimension() as usize)
+}
+
+#[tokio::test]
+#[sequential_test::sequential]
+async fn test_gpu_diamond_io_error_search_and_bench_estimate() {
+    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::INFO).try_init();
+    gpu_device_sync();
+
+    let cfg = DiamondIOGpuBenchConfig::from_env();
+    info!("DiamondIO GPU bench config: {:?}", cfg);
+    let gpu_id =
+        *detected_gpu_device_ids().first().expect("test_gpu_diamond_io requires at least one GPU");
+    let temp_dir = tempdir().expect("DiamondIO GPU bench test must create a tempdir");
+    init_storage_system(temp_dir.path().to_path_buf());
+
+    let plt_evaluator = DynamicNormPltLWEEvaluator::new(cfg.error_sigma);
+    let slot_transfer_evaluator = NormNaiveBggEncodingVecSTEvaluator::new();
+    let search = diamond_io_find_crt_depth(
+        cfg.min_crt_depth,
+        cfg.max_crt_depth,
+        cfg.prf_mask_output_coeff_bits_search_bound(),
+        cfg.security_bits,
+        DiamondIOFuncType::DebugDecryption,
+        |crt_depth| {
+            build_diamond_io(
+                &cfg,
+                crt_depth,
+                cfg.prf_mask_output_coeff_bits_search_bound(),
+                gpu_id,
+                temp_dir.path().to_path_buf(),
+            )
+        },
+        &plt_evaluator,
+        &slot_transfer_evaluator,
+    )
+    .expect("DiamondIO CRT-depth search must find a valid benchmark candidate");
+    info!(
+        crt_depth = search.crt_depth,
+        prf_mask_output_coeff_bits = search.prf_mask_output_coeff_bits,
+        noisy_plaintext_error_bits =
+            bigdecimal_bits_ceil(&search.total_noisy_plaintext_error.poly_norm.norm),
+        input_injection_error_bits =
+            bigdecimal_bits_ceil(&search.input_injection_projection_error.poly_norm.norm),
+        "DiamondIO CRT-depth search selected parameters"
+    );
+
+    let (_, gpu_params) = gpu_params_for_crt_depth(&cfg, search.crt_depth, gpu_id);
+    let final_dir = temp_dir.path().join("final_estimate");
+    ensure_clean_dir(&final_dir);
+    init_storage_system(final_dir.clone());
+    let diamond = build_diamond_io(
+        &cfg,
+        search.crt_depth,
+        search.prf_mask_output_coeff_bits,
+        gpu_id,
+        final_dir.clone(),
+    );
+    let public_key_estimator =
+        build_public_key_bench_estimator(&gpu_params, &cfg, final_dir.join("pubkey_bench"));
+    let encoding_scalar_estimator =
+        BggEncodingBenchEstimator::<GpuMatrix>::benchmark(&gpu_params, cfg.bench_iterations);
+    let encoding_estimator = NaiveBGGVecBenchEstimator::new(
+        encoding_scalar_estimator,
+        gpu_params.ring_dimension() as usize,
+    );
+    let native_estimator =
+        GpuDCRTPolyMatrixNativeBenchEstimator::new(gpu_params.clone(), cfg.bench_iterations);
+    let diamond_bench_estimator = DiamondIOBenchEstimator::new(
+        &public_key_estimator,
+        &encoding_estimator,
+        &native_estimator,
+        &diamond,
+        cfg.bench_iterations,
+    );
+    let estimate = diamond_bench_estimator.estimate(&diamond, DiamondIOFuncType::DebugDecryption);
+
+    info!(
+        obfuscate_latency = estimate.obfuscate.latency,
+        obfuscate_total_time = estimate.obfuscate.total_time,
+        obfuscate_max_parallelism = estimate.obfuscate.max_parallelism,
+        eval_latency = estimate.eval.latency,
+        eval_total_time = estimate.eval.total_time,
+        eval_max_parallelism = estimate.eval.max_parallelism,
+        obfuscated_circuit_bytes = %estimate.obfuscated_circuit_bytes,
+        input_injection_bytes = %estimate.input_injection_bytes,
+        "DiamondIO GPU benchmark estimate"
+    );
+    assert!(estimate.obfuscate.total_time >= 0.0);
+    assert!(estimate.eval.total_time >= 0.0);
+    assert!(estimate.obfuscated_circuit_bytes > BigUint::from(0u32));
+    assert!(estimate.input_injection_bytes > BigUint::from(0u32));
+}

--- a/tests/test_gpu_lwe_montgomery_modq_arith.rs
+++ b/tests/test_gpu_lwe_montgomery_modq_arith.rs
@@ -3,13 +3,22 @@
 use bigdecimal::{BigDecimal, FromPrimitive};
 use keccak_asm::Keccak256;
 use mxx::{
-    bgg::sampler::{BGGEncodingSampler, BGGPublicKeySampler},
-    circuit::PolyCircuit,
+    bench_estimator::{
+        BenchEstimator, BggEncodingBenchEstimator, BggPublicKeyBenchEstimator,
+        BggPublicKeyBenchSamples, PublicLutSampleAuxBenchEstimator,
+    },
+    bgg::{
+        public_key::BggPublicKey,
+        sampler::{BGGEncodingSampler, BGGPublicKeySampler},
+    },
+    circuit::{PolyCircuit, PolyGateKind, gate::GateId},
     element::PolyElem,
     gadgets::arith::{
-        ModularArithmeticContext, MontgomeryPoly, MontgomeryPolyContext, encode_montgomery_poly,
+        ModularArithmeticGadget, MontgomeryPoly, MontgomeryPolyContext,
+        encode_montgomery_poly_with_window,
     },
     lookup::{
+        PublicLut,
         lwe::{LWEBGGEncodingPltEvaluator, LWEBGGPubKeyPltEvaluator},
         poly::PolyPltEvaluator,
     },
@@ -28,13 +37,18 @@ use mxx::{
         trapdoor::GpuDCRTPolyTrapdoorSampler,
     },
     simulator::{SimulatorContext, error_norm::NormPltLWEEvaluator},
+    slot_transfer::bgg_pubkey::BggPublicKeySTEvaluator,
     storage::write::{init_storage_system, wait_for_all_writes},
-    utils::{bigdecimal_bits_ceil, gen_biguint_for_modulus},
+    utils::bigdecimal_bits_ceil,
 };
 use num_bigint::BigUint;
-use rayon::prelude::*;
-use std::{env, fs, path::Path, sync::Arc, time::Instant};
-use tracing::info;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
+use tracing::{debug, info};
 
 const DEFAULT_RING_DIM: u32 = 1 << 16;
 const DEFAULT_CRT_BITS: usize = 32;
@@ -44,6 +58,26 @@ const DEFAULT_ERROR_SIGMA: f64 = 4.0;
 const DEFAULT_D_SECRET: usize = 1;
 const DEFAULT_HEIGHT: usize = 1;
 const DEFAULT_LIMB_BIT_SIZE: usize = 6;
+const DEFAULT_BENCH_ITERATIONS: usize = 1;
+const DEFAULT_BENCH_SEED: [u8; 32] = [0u8; 32];
+const TRAPDOOR_SIGMA: f64 = 4.578;
+const ERROR_SIM_ACTIVE_LEVELS: usize = 1;
+const ACTUAL_HASH_KEY_CHECKPOINT_FILE: &str = "actual_lwe_hash_key.bin";
+const ACTUAL_TRAPDOOR_CHECKPOINT_FILE: &str = "actual_lwe_trapdoor.bin";
+const ACTUAL_PUB_MATRIX_CHECKPOINT_FILE: &str = "actual_lwe_pub_matrix.bin";
+
+type GpuMatrix = GpuDCRTPolyMatrix;
+type GpuHashSampler = GpuDCRTPolyHashSampler<Keccak256>;
+type GpuScalarPubKeyPltEvaluator =
+    LWEBGGPubKeyPltEvaluator<GpuMatrix, GpuHashSampler, GpuDCRTPolyTrapdoorSampler>;
+type GpuScalarEncodingPltEvaluator = LWEBGGEncodingPltEvaluator<GpuMatrix, GpuHashSampler>;
+type GpuPubKeySlotEvaluator = BggPublicKeySTEvaluator<
+    GpuMatrix,
+    GpuDCRTPolyUniformSampler,
+    GpuHashSampler,
+    GpuDCRTPolyTrapdoorSampler,
+>;
+type GpuTrapdoor = <GpuDCRTPolyTrapdoorSampler as PolyTrapdoorSampler>::Trapdoor;
 
 #[derive(Debug, Clone)]
 struct MontgomeryModqArithConfig {
@@ -51,10 +85,12 @@ struct MontgomeryModqArithConfig {
     crt_bits: usize,
     base_bits: u32,
     max_crt_depth: usize,
+    active_levels: Option<usize>,
     error_sigma: f64,
     d_secret: usize,
     height: usize,
     limb_bit_size: usize,
+    bench_iterations: usize,
     dir_name_override: Option<String>,
 }
 
@@ -81,6 +117,53 @@ fn env_or_parse_f64(key: &str, default: f64) -> f64 {
     }
 }
 
+fn load_or_create_actual_lwe_checkpoint(
+    params: &GpuDCRTPolyParams,
+    d_secret: usize,
+    dir: &Path,
+) -> ([u8; 32], GpuDCRTPolyTrapdoorSampler, GpuTrapdoor, GpuMatrix) {
+    fs::create_dir_all(dir).expect("failed to create actual LWE checkpoint dir");
+
+    let hash_key_path = dir.join(ACTUAL_HASH_KEY_CHECKPOINT_FILE);
+    let hash_key = match fs::read(&hash_key_path) {
+        Ok(bytes) => {
+            let hash_key: [u8; 32] = bytes
+                .try_into()
+                .expect("actual LWE hash key checkpoint must contain exactly 32 bytes");
+            info!("loaded actual LWE hash key checkpoint from {}", hash_key_path.display());
+            hash_key
+        }
+        Err(_) => {
+            fs::write(&hash_key_path, DEFAULT_BENCH_SEED)
+                .expect("failed to write actual LWE hash key checkpoint");
+            info!("wrote actual LWE hash key checkpoint to {}", hash_key_path.display());
+            DEFAULT_BENCH_SEED
+        }
+    };
+
+    let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(params, TRAPDOOR_SIGMA);
+    let trapdoor_path = dir.join(ACTUAL_TRAPDOOR_CHECKPOINT_FILE);
+    let pub_matrix_path = dir.join(ACTUAL_PUB_MATRIX_CHECKPOINT_FILE);
+    match (fs::read(&trapdoor_path), fs::read(&pub_matrix_path)) {
+        (Ok(trapdoor_bytes), Ok(pub_matrix_bytes)) => {
+            let trapdoor = GpuDCRTPolyTrapdoorSampler::trapdoor_from_bytes(params, &trapdoor_bytes)
+                .expect("failed to decode actual LWE trapdoor checkpoint");
+            let pub_matrix = GpuMatrix::from_compact_bytes(params, &pub_matrix_bytes);
+            info!("loaded actual LWE trapdoor/pub_matrix checkpoints from {}", dir.display());
+            (hash_key, trapdoor_sampler, trapdoor, pub_matrix)
+        }
+        _ => {
+            let (trapdoor, pub_matrix) = trapdoor_sampler.trapdoor(params, d_secret);
+            fs::write(&trapdoor_path, GpuDCRTPolyTrapdoorSampler::trapdoor_to_bytes(&trapdoor))
+                .expect("failed to write actual LWE trapdoor checkpoint");
+            fs::write(&pub_matrix_path, pub_matrix.to_compact_bytes())
+                .expect("failed to write actual LWE pub_matrix checkpoint");
+            info!("wrote actual LWE trapdoor/pub_matrix checkpoints to {}", dir.display());
+            (hash_key, trapdoor_sampler, trapdoor, pub_matrix)
+        }
+    }
+}
+
 impl MontgomeryModqArithConfig {
     fn from_env() -> Self {
         let ring_dim = env_or_parse_u32("LWE_MONTGOMERY_MODQ_ARITH_RING_DIM", DEFAULT_RING_DIM);
@@ -88,12 +171,26 @@ impl MontgomeryModqArithConfig {
         let base_bits = env_or_parse_u32("LWE_MONTGOMERY_MODQ_ARITH_BASE_BITS", DEFAULT_BASE_BITS);
         let max_crt_depth =
             env_or_parse_usize("LWE_MONTGOMERY_MODQ_ARITH_MAX_CRT_DEPTH", DEFAULT_MAX_CRT_DEPTH);
+        let active_levels = env::var("LWE_MONTGOMERY_MODQ_ARITH_Q_LEVEL").ok().map(|raw| {
+            let level = raw
+                .parse::<usize>()
+                .expect("LWE_MONTGOMERY_MODQ_ARITH_Q_LEVEL must be a positive integer");
+            assert!(
+                level > 0,
+                "LWE_MONTGOMERY_MODQ_ARITH_Q_LEVEL must be greater than or equal to 1"
+            );
+            level
+        });
         let error_sigma =
             env_or_parse_f64("LWE_MONTGOMERY_MODQ_ARITH_ERROR_SIGMA", DEFAULT_ERROR_SIGMA);
         let d_secret = env_or_parse_usize("LWE_MONTGOMERY_MODQ_ARITH_D_SECRET", DEFAULT_D_SECRET);
         let height = env_or_parse_usize("LWE_MONTGOMERY_MODQ_ARITH_HEIGHT", DEFAULT_HEIGHT);
         let limb_bit_size =
             env_or_parse_usize("LWE_MONTGOMERY_MODQ_ARITH_LIMB_BIT_SIZE", DEFAULT_LIMB_BIT_SIZE);
+        let bench_iterations = env_or_parse_usize(
+            "LWE_MONTGOMERY_MODQ_ARITH_BENCH_ITERATIONS",
+            DEFAULT_BENCH_ITERATIONS,
+        );
         let dir_name_override = env::var("LWE_MONTGOMERY_MODQ_ARITH_DIR_NAME")
             .ok()
             .map(|v| v.trim().to_string())
@@ -110,25 +207,64 @@ impl MontgomeryModqArithConfig {
             limb_bit_size > 0 && limb_bit_size < 32,
             "LWE_MONTGOMERY_MODQ_ARITH_LIMB_BIT_SIZE must be in 1..32"
         );
+        assert!(bench_iterations > 0, "LWE_MONTGOMERY_MODQ_ARITH_BENCH_ITERATIONS must be > 0");
 
         Self {
             ring_dim,
             crt_bits,
             base_bits,
             max_crt_depth,
+            active_levels,
             error_sigma,
             d_secret,
             height,
             limb_bit_size,
+            bench_iterations,
             dir_name_override,
         }
     }
 
-    fn dir_name(&self) -> String {
-        self.dir_name_override
-            .clone()
-            .unwrap_or_else(|| "test_data/test_gpu_lwe_montgomery_modq_arith".to_string())
+    fn num_slots(&self) -> usize {
+        self.ring_dim as usize
     }
+
+    fn active_levels_for_crt_depth(&self, crt_depth: usize, q_level: Option<usize>) -> usize {
+        let active_levels = q_level.unwrap_or(crt_depth);
+        assert!(
+            active_levels <= crt_depth,
+            "LWE_MONTGOMERY_MODQ_ARITH_Q_LEVEL exceeds crt_depth: q_level={}, crt_depth={}",
+            active_levels,
+            crt_depth
+        );
+        active_levels
+    }
+
+    fn dir_name(&self, crt_depth: usize) -> String {
+        self.dir_name_override.clone().unwrap_or_else(|| {
+            format!(
+                "test_data/test_gpu_lwe_montgomery_modq_arith_ring{}_active{}_crt{}_depth{}",
+                self.ring_dim, crt_depth, self.crt_bits, crt_depth
+            )
+        })
+    }
+}
+
+fn active_q_moduli_and_modulus<T: PolyParams>(
+    params: &T,
+    q_level: Option<usize>,
+) -> (Vec<u64>, BigUint, usize) {
+    let (q_moduli, _, max_q_level) = params.to_crt();
+    let active_q_level = q_level.unwrap_or(max_q_level);
+    assert!(
+        active_q_level <= max_q_level,
+        "q_level exceeds CRT depth: q_level={}, crt_depth={}",
+        active_q_level,
+        max_q_level
+    );
+    let active_q_moduli = q_moduli.into_iter().take(active_q_level).collect::<Vec<_>>();
+    let active_q =
+        active_q_moduli.iter().fold(BigUint::from(1u64), |acc, &q_i| acc * BigUint::from(q_i));
+    (active_q_moduli, active_q, active_q_level)
 }
 
 fn round_div_biguint(value: &BigUint, divisor: &BigUint) -> BigUint {
@@ -140,11 +276,20 @@ fn build_montgomery_multiplication_tree<P: Poly + 'static>(
     ctx: Arc<MontgomeryPolyContext<P>>,
     circuit: &mut PolyCircuit<P>,
     height: usize,
+    q_level: Option<usize>,
 ) {
     let num_inputs =
         1usize.checked_shl(height as u32).expect("height is too large to represent 2^h inputs");
-    let mut current_layer: Vec<MontgomeryPoly<P>> =
-        (0..num_inputs).map(|_| MontgomeryPoly::input(ctx.clone(), circuit)).collect();
+    let mut current_layer: Vec<MontgomeryPoly<P>> = (0..num_inputs)
+        .map(|_| {
+            <MontgomeryPoly<P> as ModularArithmeticGadget<P>>::input(
+                ctx.clone(),
+                q_level,
+                None,
+                circuit,
+            )
+        })
+        .collect();
 
     while current_layer.len() > 1 {
         debug_assert!(current_layer.len().is_multiple_of(2), "layer size must stay even");
@@ -164,94 +309,278 @@ fn build_montgomery_multiplication_tree<P: Poly + 'static>(
 fn build_modq_arith_circuit_cpu(
     params: &DCRTPolyParams,
     cfg: &MontgomeryModqArithConfig,
+    q_level: Option<usize>,
 ) -> (PolyCircuit<DCRTPoly>, Arc<MontgomeryPolyContext<DCRTPoly>>) {
     let mut circuit = PolyCircuit::<DCRTPoly>::new();
     let ctx =
         Arc::new(MontgomeryPolyContext::setup(&mut circuit, params, cfg.limb_bit_size, false));
-    build_montgomery_multiplication_tree(ctx.clone(), &mut circuit, cfg.height);
+    build_montgomery_multiplication_tree(ctx.clone(), &mut circuit, cfg.height, q_level);
     (circuit, ctx)
 }
 
 fn build_modq_arith_circuit_gpu(
     params: &GpuDCRTPolyParams,
     cfg: &MontgomeryModqArithConfig,
+    q_level: Option<usize>,
 ) -> (PolyCircuit<GpuDCRTPoly>, Arc<MontgomeryPolyContext<GpuDCRTPoly>>) {
     let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
     let ctx =
         Arc::new(MontgomeryPolyContext::setup(&mut circuit, params, cfg.limb_bit_size, false));
-    build_montgomery_multiplication_tree(ctx.clone(), &mut circuit, cfg.height);
+    build_montgomery_multiplication_tree(ctx.clone(), &mut circuit, cfg.height, q_level);
     (circuit, ctx)
 }
 
 fn build_modq_arith_value_circuit_gpu(
     params: &GpuDCRTPolyParams,
     cfg: &MontgomeryModqArithConfig,
+    q_level: Option<usize>,
 ) -> PolyCircuit<GpuDCRTPoly> {
     let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
     let ctx =
         Arc::new(MontgomeryPolyContext::setup(&mut circuit, params, cfg.limb_bit_size, false));
-    build_montgomery_multiplication_tree(ctx, &mut circuit, cfg.height);
+    build_montgomery_multiplication_tree(ctx, &mut circuit, cfg.height, q_level);
     circuit
 }
 
-fn find_crt_depth_for_modq_arith(cfg: &MontgomeryModqArithConfig) -> (usize, DCRTPolyParams) {
+#[derive(Debug)]
+struct CrtDepthProbe {
+    params: DCRTPolyParams,
+    eval_ok: bool,
+}
+
+impl CrtDepthProbe {
+    fn search_ok(&self) -> bool {
+        self.eval_ok
+    }
+}
+
+fn corrected_max_eval_error_for_active_levels(
+    simulated_error: &BigDecimal,
+    requested_active_levels: usize,
+) -> BigDecimal {
+    simulated_error * BigDecimal::from_biguint(BigUint::from(requested_active_levels), 0)
+}
+
+fn probe_crt_depth_for_modq_arith(
+    cfg: &MontgomeryModqArithConfig,
+    q_level: Option<usize>,
+    crt_depth: usize,
+    ring_dim_sqrt: &BigDecimal,
+    base: &BigDecimal,
+    error_sigma: &BigDecimal,
+    input_bound: &BigDecimal,
+    e_init_norm: &BigDecimal,
+) -> CrtDepthProbe {
+    let params = DCRTPolyParams::new(cfg.ring_dim, crt_depth, cfg.crt_bits, cfg.base_bits);
+    let (_, _, actual_crt_depth) = params.to_crt();
+    let active_levels = cfg.active_levels_for_crt_depth(actual_crt_depth, q_level);
+    assert!(
+        ERROR_SIM_ACTIVE_LEVELS <= actual_crt_depth,
+        "error simulation requires crt_depth >= ERROR_SIM_ACTIVE_LEVELS: crt_depth={}, ERROR_SIM_ACTIVE_LEVELS={}",
+        actual_crt_depth,
+        ERROR_SIM_ACTIVE_LEVELS
+    );
+    let (active_q_moduli, active_q, _) = active_q_moduli_and_modulus(&params, Some(active_levels));
+    let full_q = params.modulus();
+    let q_max = *active_q_moduli.iter().max().expect("active_q_moduli must not be empty");
+    let (circuit, _ctx) = build_modq_arith_circuit_cpu(&params, cfg, Some(ERROR_SIM_ACTIVE_LEVELS));
+
+    let log_base_q = params.modulus_digits();
+    let log_base_q_small = log_base_q / actual_crt_depth;
+    let ctx = Arc::new(SimulatorContext::new(
+        ring_dim_sqrt.clone(),
+        base.clone(),
+        cfg.d_secret,
+        log_base_q,
+        log_base_q_small,
+    ));
+    let plt_evaluator = NormPltLWEEvaluator::new(ctx.clone(), error_sigma);
+
+    let out_errors = circuit.simulate_max_error_norm(
+        ctx,
+        input_bound.clone(),
+        circuit.num_input(),
+        e_init_norm,
+        Some(&plt_evaluator),
+        None,
+    );
+
+    debug!(
+        "montgomery modq_arith simulate_max_error_norm finished output_errors={}",
+        out_errors.len()
+    );
+    assert_eq!(out_errors.len(), 1);
+
+    let threshold = full_q.as_ref() / BigUint::from(2u64 * q_max);
+    let threshold_bd = BigDecimal::from_biguint(threshold.clone(), 0);
+    let max_eval_error = out_errors[0].matrix_norm.poly_norm.norm.clone();
+    let corrected_max_eval_error =
+        corrected_max_eval_error_for_active_levels(&max_eval_error, active_levels);
+    let eval_ok = corrected_max_eval_error < threshold_bd;
+
+    info!(
+        "montgomery modq_arith crt_depth={} active_levels={} error_sim_active_levels={} active_q_bits={} full_q_bits={} num_inputs={} output_polys={} sim_max_eval_error_bits={} max_eval_error_bits={} eval_threshold_bits={} eval_ok={}",
+        crt_depth,
+        active_levels,
+        ERROR_SIM_ACTIVE_LEVELS,
+        active_q.bits(),
+        full_q.bits(),
+        circuit.num_input(),
+        out_errors.len(),
+        bigdecimal_bits_ceil(&max_eval_error),
+        bigdecimal_bits_ceil(&corrected_max_eval_error),
+        bigdecimal_bits_ceil(&BigDecimal::from_biguint(threshold, 0)),
+        eval_ok
+    );
+
+    CrtDepthProbe { params, eval_ok }
+}
+
+fn find_crt_depth_for_modq_arith(
+    cfg: &MontgomeryModqArithConfig,
+    q_level: Option<usize>,
+) -> (usize, DCRTPolyParams) {
     let ring_dim_sqrt = BigDecimal::from_u32(cfg.ring_dim).unwrap().sqrt().unwrap();
     let base = BigDecimal::from_biguint(BigUint::from(1u32) << cfg.base_bits, 0);
     let error_sigma = BigDecimal::from_f64(cfg.error_sigma).expect("valid error sigma");
     let input_bound = BigDecimal::from((1u64 << cfg.limb_bit_size) - 1);
     let e_init_norm = &error_sigma * BigDecimal::from_f32(6.5).unwrap();
 
-    for crt_depth in 1..=cfg.max_crt_depth {
-        let params = DCRTPolyParams::new(cfg.ring_dim, crt_depth, cfg.crt_bits, cfg.base_bits);
-        let full_q = params.modulus();
-        let (q_moduli, _, crt_depth) = params.to_crt();
-        let q_max = *q_moduli.iter().max().expect("q_moduli must not be empty");
-        let (circuit, _ctx) = build_modq_arith_circuit_cpu(&params, cfg);
+    if let Some(raw_crt_depth) = env::var("CRT_DEPTH").ok().filter(|value| !value.trim().is_empty())
+    {
+        let requested_crt_depth = raw_crt_depth
+            .parse::<usize>()
+            .unwrap_or_else(|e| panic!("CRT_DEPTH must be a valid usize: {e}"));
+        assert!(requested_crt_depth > 0, "CRT_DEPTH must be > 0");
+        let params =
+            DCRTPolyParams::new(cfg.ring_dim, requested_crt_depth, cfg.crt_bits, cfg.base_bits);
+        return (requested_crt_depth, params);
+    }
 
-        let log_base_q = params.modulus_digits();
-        let log_base_q_small = log_base_q / crt_depth;
-        let ctx = Arc::new(SimulatorContext::new(
-            ring_dim_sqrt.clone(),
-            base.clone(),
-            cfg.d_secret,
-            log_base_q,
-            log_base_q_small,
-        ));
-        let plt_evaluator = NormPltLWEEvaluator::new(ctx.clone(), &error_sigma);
+    let min_crt_depth = q_level.unwrap_or(1);
+    assert!(
+        min_crt_depth <= cfg.max_crt_depth,
+        "minimum crt_depth must be <= LWE_MONTGOMERY_MODQ_ARITH_MAX_CRT_DEPTH"
+    );
 
-        let out_errors = circuit.simulate_max_error_norm(
-            ctx,
-            input_bound.clone(),
-            circuit.num_input(),
+    let mut low = min_crt_depth;
+    let mut high = cfg.max_crt_depth;
+    while low < high {
+        let mid = low + (high - low) / 2;
+        let probe = probe_crt_depth_for_modq_arith(
+            cfg,
+            q_level,
+            mid,
+            &ring_dim_sqrt,
+            &base,
+            &error_sigma,
+            &input_bound,
             &e_init_norm,
-            Some(&plt_evaluator),
-            None,
         );
-
-        assert_eq!(out_errors.len(), 1);
-
-        let threshold = full_q.as_ref() / BigUint::from(2u64 * q_max);
-        let error = &out_errors[0].matrix_norm.poly_norm.norm;
-        let max_error_bits = bigdecimal_bits_ceil(error);
-        let all_ok = *error < BigDecimal::from_biguint(threshold.clone(), 0);
-
-        info!(
-            "crt_depth={} q_bits={} max_error_bits={} threshold_bits={}",
-            crt_depth,
-            params.modulus_bits(),
-            max_error_bits,
-            threshold.bits()
-        );
-
-        if all_ok {
-            return (crt_depth, params);
+        if probe.search_ok() {
+            high = mid;
+        } else {
+            low = mid + 1;
         }
     }
 
+    let probe = probe_crt_depth_for_modq_arith(
+        cfg,
+        q_level,
+        low,
+        &ring_dim_sqrt,
+        &base,
+        &error_sigma,
+        &input_bound,
+        &e_init_norm,
+    );
+    if probe.search_ok() {
+        info!("selected crt_depth={} for Montgomery modq arithmetic search", low);
+        return (low, probe.params);
+    }
+
     panic!(
-        "crt_depth satisfying error < q/(2*q_i) for all CRT moduli not found up to MAX_CRT_DEPTH ({})",
+        "crt_depth satisfying error < q/(2*q_i) for all CRT moduli not found up to LWE_MONTGOMERY_MODQ_ARITH_MAX_CRT_DEPTH ({})",
         cfg.max_crt_depth
     );
+}
+
+fn build_lwe_scalar_pubkey_plt_evaluator(
+    params: &GpuDCRTPolyParams,
+    hash_key: [u8; 32],
+    d_secret: usize,
+    dir_path: PathBuf,
+) -> GpuScalarPubKeyPltEvaluator {
+    let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(params, TRAPDOOR_SIGMA);
+    let (trapdoor, pub_matrix) = trapdoor_sampler.trapdoor(params, d_secret);
+    GpuScalarPubKeyPltEvaluator::new(
+        hash_key,
+        trapdoor_sampler,
+        Arc::new(pub_matrix),
+        Arc::new(trapdoor),
+        dir_path,
+    )
+}
+
+fn build_benchmark_public_lut(params: &GpuDCRTPolyParams) -> PublicLut<GpuDCRTPoly> {
+    PublicLut::<GpuDCRTPoly>::new(
+        params,
+        16,
+        move |params, x| {
+            if x >= 16 {
+                return None;
+            }
+            let y_elem = <<GpuDCRTPoly as Poly>::Elem as PolyElem>::constant(
+                &params.modulus(),
+                (x + 1) % 16,
+            );
+            Some((x, y_elem))
+        },
+        None,
+    )
+}
+
+fn build_benchmark_public_lookup_gate(
+    params: &GpuDCRTPolyParams,
+) -> (PublicLut<GpuDCRTPoly>, usize, GateId) {
+    let lut = build_benchmark_public_lut(params);
+    let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    let input = circuit.input(1);
+    let lut_id = circuit.register_public_lookup(lut.clone());
+    let gate_id = circuit.public_lookup_gate(input, lut_id).as_single_wire();
+    (lut, lut_id, gate_id)
+}
+
+fn build_benchmark_slot_transfer_gate(src_slots: &[(u32, Option<u32>)]) -> GateId {
+    let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    let input = circuit.input(1);
+    circuit.slot_transfer_gate(input, src_slots).as_single_wire()
+}
+
+fn identity_slot_transfer_plan(num_slots: usize) -> Vec<(u32, Option<u32>)> {
+    (0..num_slots).map(|slot| (slot as u32, None)).collect()
+}
+
+fn sample_benchmark_pubkeys(
+    params: &GpuDCRTPolyParams,
+    seed: [u8; 32],
+    d_secret: usize,
+    non_constant_key_count: usize,
+    tag: &[u8],
+) -> Vec<BggPublicKey<GpuMatrix>> {
+    let sampler = BGGPublicKeySampler::<_, GpuHashSampler>::new(seed, d_secret);
+    let reveal_plaintexts = vec![true; non_constant_key_count];
+    sampler.sample(params, tag, &reveal_plaintexts)
+}
+
+fn constant_and_shared_benchmark_pubkeys(
+    pubkeys: &[BggPublicKey<GpuMatrix>],
+) -> (&BggPublicKey<GpuMatrix>, &BggPublicKey<GpuMatrix>) {
+    assert!(
+        pubkeys.len() >= 2,
+        "benchmark pubkeys must contain the constant-one key and at least one reusable input key"
+    );
+    (&pubkeys[0], &pubkeys[1])
 }
 
 #[tokio::test]
@@ -261,11 +590,12 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
     let cfg = MontgomeryModqArithConfig::from_env();
     info!("montgomery modq arith test config: {:?}", cfg);
 
+    let q_level = cfg.active_levels;
     let num_inputs = 1usize
         .checked_shl(cfg.height as u32)
         .expect("LWE_MONTGOMERY_MODQ_ARITH_HEIGHT is too large");
     let depth_search_start = Instant::now();
-    let (crt_depth, cpu_params) = find_crt_depth_for_modq_arith(&cfg);
+    let (crt_depth, cpu_params) = find_crt_depth_for_modq_arith(&cfg, q_level);
     info!("crt depth search elapsed_ms={:.3}", depth_search_start.elapsed().as_secs_f64() * 1000.0);
 
     let (moduli, _, _) = cpu_params.to_crt();
@@ -282,53 +612,183 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
         vec![single_gpu_id],
         Some(1),
     );
-    let full_q = params.modulus();
-    let (all_q_moduli, _, _) = params.to_crt();
-    let q_max = *all_q_moduli.iter().max().expect("q_moduli must not be empty");
-    let (circuit, ctx) = build_modq_arith_circuit_gpu(&params, &cfg);
+    let (all_q_moduli, _, actual_crt_depth) = params.to_crt();
+    let active_levels = cfg.active_levels_for_crt_depth(actual_crt_depth, q_level);
+    let (active_q_moduli, active_q, active_q_level) =
+        active_q_moduli_and_modulus(&params, Some(active_levels));
+    let (circuit, ctx) = build_modq_arith_circuit_gpu(&params, &cfg, Some(active_levels));
     let gate_counts = circuit.count_gates_by_type_vec();
     let total_gates = circuit.num_gates();
+    let total_lut_entries = circuit.total_registered_public_lut_entries();
+    let total_public_lut_gates = gate_counts.get(&PolyGateKind::PubLut).copied().unwrap_or(0);
+    let total_slot_transfer_gates =
+        gate_counts.get(&PolyGateKind::SlotTransfer).copied().unwrap_or(0);
 
     info!("forcing single GPU for this test: gpu_id={}", single_gpu_id);
     info!("found crt_depth={}", crt_depth);
     info!(
-        "selected crt_depth={} ring_dim={} crt_bits={} base_bits={} limb_bit_size={} q_moduli={:?}",
+        "selected crt_depth={} actual_crt_depth={} cfg_active_levels={:?} ring_dim={} crt_bits={} base_bits={} q_level={:?} active_levels={} limb_bit_size={} q_moduli={:?}",
         crt_depth,
+        actual_crt_depth,
+        cfg.active_levels,
         params.ring_dimension(),
         cfg.crt_bits,
         cfg.base_bits,
+        q_level,
+        active_levels,
         cfg.limb_bit_size,
         all_q_moduli
+    );
+    info!(
+        "active_q_level={} active_q_bits={} active_q_moduli_len={}",
+        active_q_level,
+        active_q.bits(),
+        active_q_moduli.len()
     );
     info!("multiplication tree config: height={} num_inputs={}", cfg.height, num_inputs);
     let non_free_depth_contributions = circuit.non_free_depth_contributions();
     info!(
-        "circuit total_gates={} non_free_depth_contributions={:?} gate_counts={:?}",
-        total_gates, non_free_depth_contributions, gate_counts
+        "circuit total_gates={} non_free_depth_contributions={:?} gate_counts={:?} total_lut_entries={} total_public_lut_gates={} total_slot_transfer_gates={}",
+        total_gates,
+        non_free_depth_contributions,
+        gate_counts,
+        total_lut_entries,
+        total_public_lut_gates,
+        total_slot_transfer_gates
     );
 
     assert_eq!(params.modulus(), cpu_params.modulus());
     assert_eq!(circuit.num_output(), 1, "multiplication tree should emit one output gate");
     assert_eq!(
         circuit.num_input(),
-        num_inputs * ctx.num_limbs * ctx.q_moduli_depth(),
+        num_inputs * ctx.num_limbs * active_q_level,
         "Montgomery inputs should contribute one limb polynomial per input limb at each active q-level"
     );
     assert!(total_gates > 0, "circuit must contain gates");
 
-    let mut rng = rand::rng();
-    let input_values: Vec<BigUint> =
-        (0..num_inputs).map(|_| gen_biguint_for_modulus(&mut rng, &full_q)).collect();
-    let expected = input_values
-        .par_iter()
-        .cloned()
-        .reduce(|| BigUint::from(1u64), |acc, value| (acc * value) % full_q.as_ref());
-    let plaintext_inputs: Vec<GpuDCRTPoly> = input_values
-        .par_iter()
-        .flat_map(|value| encode_montgomery_poly(cfg.limb_bit_size, &params, value))
-        .collect();
+    let dir_name = cfg.dir_name(crt_depth);
+    let dir = Path::new(&dir_name);
+    fs::create_dir_all(dir).expect("failed to create modq arithmetic test directory");
+    init_storage_system(dir.to_path_buf());
 
-    let dry_circuit = build_modq_arith_value_circuit_gpu(&params, &cfg);
+    let (pubkey_bench_lut, pubkey_bench_public_lut_id, pubkey_bench_public_lut_gate_id) =
+        build_benchmark_public_lookup_gate(&params);
+    let pubkey_bench_slot_transfer_src_slots = identity_slot_transfer_plan(cfg.num_slots());
+    let pubkey_bench_slot_transfer_gate_id =
+        build_benchmark_slot_transfer_gate(&pubkey_bench_slot_transfer_src_slots);
+    let pubkey_bench_public_keys = sample_benchmark_pubkeys(
+        &params,
+        DEFAULT_BENCH_SEED,
+        cfg.d_secret,
+        1,
+        b"LWE_MONTGOMERY_MODQ_ARITH_PUBKEY_BENCH",
+    );
+    let (pubkey_bench_public_lut_one, pubkey_bench_shared_input) =
+        constant_and_shared_benchmark_pubkeys(&pubkey_bench_public_keys);
+    let pubkey_scalar_bench_plt_evaluator = build_lwe_scalar_pubkey_plt_evaluator(
+        &params,
+        DEFAULT_BENCH_SEED,
+        cfg.d_secret,
+        dir.to_path_buf(),
+    );
+    let pubkey_public_lut_aux_estimate = pubkey_scalar_bench_plt_evaluator
+        .estimate_public_lut_sample_aux_matrices(
+            &params,
+            total_lut_entries,
+            total_public_lut_gates,
+        );
+    gpu_device_sync();
+    info!(
+        "montgomery modq_arith scalar pubkey sample_aux estimates: public_lut={:?} total_lut_entries={} public_lut_gates={}",
+        pubkey_public_lut_aux_estimate, total_lut_entries, total_public_lut_gates
+    );
+    let pubkey_scalar_bench_slot_evaluator = GpuPubKeySlotEvaluator::new(
+        DEFAULT_BENCH_SEED,
+        cfg.d_secret,
+        cfg.num_slots(),
+        TRAPDOOR_SIGMA,
+        cfg.error_sigma,
+        dir.to_path_buf(),
+    );
+    let pubkey_scalar_bench = BggPublicKeyBenchEstimator::benchmark(
+        &BggPublicKeyBenchSamples {
+            params: &params,
+            add_lhs: pubkey_bench_shared_input,
+            add_rhs: pubkey_bench_shared_input,
+            sub_lhs: pubkey_bench_shared_input,
+            sub_rhs: pubkey_bench_shared_input,
+            mul_lhs: pubkey_bench_shared_input,
+            mul_rhs: pubkey_bench_shared_input,
+            small_scalar_input: pubkey_bench_shared_input,
+            small_scalar: &[3u32, 5u32],
+            large_scalar_input: pubkey_bench_shared_input,
+            large_scalar: &[BigUint::from(7u32)],
+            public_lut_one: pubkey_bench_public_lut_one,
+            public_lut_input: pubkey_bench_shared_input,
+            public_lut: &pubkey_bench_lut,
+            public_lut_id: pubkey_bench_public_lut_id,
+            public_lut_gate_id: pubkey_bench_public_lut_gate_id,
+            slot_transfer_input: pubkey_bench_shared_input,
+            slot_transfer_src_slots: &pubkey_bench_slot_transfer_src_slots,
+            slot_transfer_gate_id: pubkey_bench_slot_transfer_gate_id,
+        },
+        &pubkey_scalar_bench_plt_evaluator,
+        &pubkey_scalar_bench_slot_evaluator,
+        build_lwe_scalar_pubkey_plt_evaluator(
+            &params,
+            DEFAULT_BENCH_SEED,
+            cfg.d_secret,
+            dir.to_path_buf(),
+        ),
+        GpuPubKeySlotEvaluator::new(
+            DEFAULT_BENCH_SEED,
+            cfg.d_secret,
+            cfg.num_slots(),
+            TRAPDOOR_SIGMA,
+            cfg.error_sigma,
+            dir.to_path_buf(),
+        ),
+        cfg.bench_iterations,
+    );
+    let pubkey_circuit_bench = pubkey_scalar_bench.estimate_circuit_bench(&circuit);
+    info!(
+        "montgomery modq_arith scalar bgg pubkey circuit bench estimate: total_time={:.6} latency={:.6} max_parallelism={} peak_vram={}",
+        pubkey_circuit_bench.total_time,
+        pubkey_circuit_bench.latency,
+        pubkey_circuit_bench.max_parallelism,
+        pubkey_circuit_bench.peak_vram
+    );
+
+    let encoding_scalar_bench =
+        BggEncodingBenchEstimator::<GpuMatrix>::benchmark(&params, cfg.bench_iterations);
+    let encoding_circuit_bench = encoding_scalar_bench.estimate_circuit_bench(&circuit);
+    info!(
+        "montgomery modq_arith scalar bgg encoding circuit bench estimate: total_time={:.6} latency={:.6} max_parallelism={} peak_vram={}",
+        encoding_circuit_bench.total_time,
+        encoding_circuit_bench.latency,
+        encoding_circuit_bench.max_parallelism,
+        encoding_circuit_bench.peak_vram
+    );
+
+    let input_value = BigUint::from(1u64);
+    let expected = BigUint::from(1u64);
+    let expected_poly = GpuDCRTPoly::from_biguint_to_constant(&params, expected.clone());
+    let encoded_input = encode_montgomery_poly_with_window(
+        cfg.limb_bit_size,
+        &params,
+        &input_value,
+        Some(active_q_level),
+        0,
+    );
+    let plaintext_inputs: Vec<GpuDCRTPoly> =
+        (0..num_inputs).flat_map(|_| encoded_input.clone()).collect();
+    assert_eq!(
+        plaintext_inputs.len(),
+        circuit.num_input(),
+        "encoded Montgomery input count must match the multiplication tree circuit input count"
+    );
+
+    let dry_circuit = build_modq_arith_value_circuit_gpu(&params, &cfg, Some(active_q_level));
     let dry_plt_evaluator = PolyPltEvaluator::new();
     let dry_eval_start = Instant::now();
     let dry_one = GpuDCRTPoly::const_one(&params);
@@ -338,28 +798,12 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
         dry_circuit.eval(&params, dry_one, dry_inputs, Some(&dry_plt_evaluator), None, None);
     info!("dry eval elapsed_ms={:.3}", dry_eval_start.elapsed().as_secs_f64() * 1000.0);
     assert_eq!(dry_out.len(), 1, "dry-run should output one value polynomial");
-    let dry_const_term = dry_out[0]
-        .coeffs()
-        .into_iter()
-        .next()
-        .expect("dry-run output polynomial must have at least one coefficient")
-        .value()
-        .clone();
+    let dry_const_term = dry_out[0].coeffs_biguints()[0].clone();
     assert_eq!(dry_const_term, expected, "dry-run output must match the expected product mod q");
     info!("dry-run succeeded with expected constant term");
     drop(dry_out);
     drop(dry_circuit);
     drop(dry_plt_evaluator);
-
-    let seed: [u8; 32] = [0u8; 32];
-    let trapdoor_sigma = 4.578;
-
-    let dir_name = cfg.dir_name();
-    let dir = Path::new(&dir_name);
-    if !dir.exists() {
-        fs::create_dir_all(dir).expect("failed to create test directory");
-    }
-    init_storage_system(dir.to_path_buf());
 
     let uniform_sampler = GpuDCRTPolyUniformSampler::new();
     let secrets =
@@ -367,8 +811,13 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
     let s_vec = GpuDCRTPolyMatrix::from_poly_vec_row(&params, secrets.clone());
     info!("sampled secret vector with {} polynomials", secrets.len());
 
-    let pk_sampler =
-        BGGPublicKeySampler::<_, GpuDCRTPolyHashSampler<Keccak256>>::new(seed, cfg.d_secret);
+    let actual_eval_dir = dir.join("actual_scalar_bgg");
+    let (actual_hash_key, trapdoor_sampler, trapdoor, pub_matrix) =
+        load_or_create_actual_lwe_checkpoint(&params, cfg.d_secret, &actual_eval_dir);
+    let trapdoor = Arc::new(trapdoor);
+    let pub_matrix = Arc::new(pub_matrix);
+
+    let pk_sampler = BGGPublicKeySampler::<_, GpuHashSampler>::new(actual_hash_key, cfg.d_secret);
     let reveal_plaintexts = vec![true; circuit.num_input()];
     info!("sampling public keys");
     let mut pubkeys = pk_sampler.sample(&params, b"BGG_PUBKEY", &reveal_plaintexts);
@@ -402,16 +851,15 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
     );
 
     let pk_evaluator_setup_start = Instant::now();
-    let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(&params, trapdoor_sigma);
-    let (trapdoor, pub_matrix) = trapdoor_sampler.trapdoor(&params, cfg.d_secret);
-    let trapdoor = Arc::new(trapdoor);
-    let pub_matrix = Arc::new(pub_matrix);
-    let pk_evaluator =
-        LWEBGGPubKeyPltEvaluator::<
-            GpuDCRTPolyMatrix,
-            GpuDCRTPolyHashSampler<Keccak256>,
-            GpuDCRTPolyTrapdoorSampler,
-        >::new(seed, trapdoor_sampler, pub_matrix.clone(), trapdoor, dir.to_path_buf());
+    init_storage_system(actual_eval_dir.clone());
+
+    let pk_evaluator = GpuScalarPubKeyPltEvaluator::new(
+        actual_hash_key,
+        trapdoor_sampler,
+        pub_matrix.clone(),
+        trapdoor,
+        actual_eval_dir.clone(),
+    );
     info!(
         "pk evaluator setup elapsed_ms={:.3}",
         pk_evaluator_setup_start.elapsed().as_secs_f64() * 1000.0
@@ -433,7 +881,9 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
     );
 
     let wait_writes_start = Instant::now();
-    wait_for_all_writes(dir.to_path_buf()).await.expect("storage writes should complete");
+    wait_for_all_writes(actual_eval_dir.clone())
+        .await
+        .expect("actual scalar BGG pubkey auxiliary writes should complete");
     info!(
         "wait_for_all_writes elapsed_ms={:.3}",
         wait_writes_start.elapsed().as_secs_f64() * 1000.0
@@ -451,10 +901,7 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
     }
     drop(pk_evaluator);
 
-    let enc_evaluator = LWEBGGEncodingPltEvaluator::<
-        GpuDCRTPolyMatrix,
-        GpuDCRTPolyHashSampler<Keccak256>,
-    >::new(seed, dir.to_path_buf(), c_b);
+    let enc_evaluator = GpuScalarEncodingPltEvaluator::new(actual_hash_key, actual_eval_dir, c_b);
 
     let encodings_restore_start = Instant::now();
     let mut encodings: Vec<_> = encodings_compact
@@ -484,6 +931,10 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
     assert_eq!(encoding_out.len(), 1);
 
     assert_eq!(encoding_out[0].pubkey, pubkey_out[0]);
+    assert_eq!(
+        encoding_out[0].plaintext.as_ref().expect("output encoding plaintext should be revealed"),
+        &expected_poly
+    );
     let expected_poly = GpuDCRTPoly::from_biguint_to_constant(&params, expected.clone());
     let expected_times_gadget = s_vec.clone() *
         (GpuDCRTPolyMatrix::gadget_matrix(&params, cfg.d_secret) * expected_poly.clone());
@@ -498,8 +949,9 @@ async fn test_gpu_lwe_montgomery_modq_arith() {
         .value()
         .clone();
 
+    let q_max = *active_q_moduli.iter().max().expect("active_q_moduli must not be empty");
+    let q_over_qmax = params.modulus().as_ref() / BigUint::from(q_max);
     let random_int: u64 = rand::random::<u64>() % q_max;
-    let q_over_qmax = full_q.as_ref() / BigUint::from(q_max);
     let randomized_coeff = coeff + q_over_qmax.clone() * BigUint::from(random_int);
     let rounded = round_div_biguint(&randomized_coeff, &q_over_qmax);
     let decoded_random: u64 = (&rounded % BigUint::from(q_max))

--- a/tests/test_gpu_lwe_nested_rns_modq_arith.rs
+++ b/tests/test_gpu_lwe_nested_rns_modq_arith.rs
@@ -1,23 +1,56 @@
 #![cfg(feature = "gpu")]
 
 use bigdecimal::{BigDecimal, FromPrimitive};
+use keccak_asm::Keccak256;
 use mxx::{
-    circuit::PolyCircuit,
-    gadgets::arith::{DEFAULT_MAX_UNREDUCED_MULS, NestedRnsPoly, NestedRnsPolyContext},
+    bench_estimator::{
+        BenchEstimator, BggEncodingBenchEstimator, BggPublicKeyBenchEstimator,
+        BggPublicKeyBenchSamples, PublicLutSampleAuxBenchEstimator,
+    },
+    bgg::{
+        public_key::BggPublicKey,
+        sampler::{BGGEncodingSampler, BGGPublicKeySampler},
+    },
+    circuit::{PolyCircuit, PolyGateKind, gate::GateId},
+    element::PolyElem,
+    gadgets::arith::{
+        DEFAULT_MAX_UNREDUCED_MULS, NestedRnsPoly, NestedRnsPolyContext, encode_nested_rns_poly,
+    },
+    lookup::{
+        PublicLut,
+        lwe::{LWEBGGEncodingPltEvaluator, LWEBGGPubKeyPltEvaluator},
+        poly::PolyPltEvaluator,
+    },
+    matrix::{PolyMatrix, gpu_dcrt_poly::GpuDCRTPolyMatrix},
     poly::{
-        PolyParams,
+        Poly, PolyParams,
         dcrt::{
-            gpu::{GpuDCRTPoly, GpuDCRTPolyParams, gpu_device_sync},
+            gpu::{
+                GpuDCRTPoly, GpuDCRTPolyParams, detected_gpu_device_count, detected_gpu_device_ids,
+                gpu_device_sync,
+            },
             params::DCRTPolyParams,
             poly::DCRTPoly,
         },
     },
+    sampler::{
+        DistType, PolyTrapdoorSampler, PolyUniformSampler,
+        gpu::{GpuDCRTPolyHashSampler, GpuDCRTPolyUniformSampler},
+        trapdoor::GpuDCRTPolyTrapdoorSampler,
+    },
     simulator::{SimulatorContext, error_norm::NormPltLWEEvaluator},
+    slot_transfer::bgg_pubkey::BggPublicKeySTEvaluator,
+    storage::write::{init_storage_system, wait_for_all_writes},
     utils::bigdecimal_bits_ceil,
 };
 use num_bigint::BigUint;
-use std::{env, sync::Arc};
-use tracing::info;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
+use tracing::{debug, info};
 
 const DEFAULT_RING_DIM: u32 = 1 << 14;
 const DEFAULT_CRT_BITS: usize = 24;
@@ -29,6 +62,25 @@ const DEFAULT_MAX_CRT_DEPTH: usize = 32;
 const DEFAULT_ERROR_SIGMA: f64 = 4.0;
 const DEFAULT_D_SECRET: usize = 1;
 const DEFAULT_HEIGHT: usize = 1;
+const DEFAULT_BENCH_ITERATIONS: usize = 1;
+const DEFAULT_BENCH_SEED: [u8; 32] = [0u8; 32];
+const TRAPDOOR_SIGMA: f64 = 4.578;
+const ERROR_SIM_ACTIVE_LEVELS: usize = 1;
+const ACTUAL_HASH_KEY_CHECKPOINT_FILE: &str = "actual_lwe_hash_key.bin";
+const ACTUAL_TRAPDOOR_CHECKPOINT_FILE: &str = "actual_lwe_trapdoor.bin";
+const ACTUAL_PUB_MATRIX_CHECKPOINT_FILE: &str = "actual_lwe_pub_matrix.bin";
+
+type GpuMatrix = GpuDCRTPolyMatrix;
+type GpuHashSampler = GpuDCRTPolyHashSampler<Keccak256>;
+type GpuScalarPubKeyPltEvaluator =
+    LWEBGGPubKeyPltEvaluator<GpuMatrix, GpuHashSampler, GpuDCRTPolyTrapdoorSampler>;
+type GpuPubKeySlotEvaluator = BggPublicKeySTEvaluator<
+    GpuMatrix,
+    GpuDCRTPolyUniformSampler,
+    GpuHashSampler,
+    GpuDCRTPolyTrapdoorSampler,
+>;
+type GpuTrapdoor = <GpuDCRTPolyTrapdoorSampler as PolyTrapdoorSampler>::Trapdoor;
 
 #[derive(Debug, Clone)]
 struct ModqArithConfig {
@@ -38,9 +90,12 @@ struct ModqArithConfig {
     scale: u64,
     base_bits: u32,
     max_crt_depth: usize,
+    active_levels: Option<usize>,
     error_sigma: f64,
     d_secret: usize,
     height: usize,
+    bench_iterations: usize,
+    dir_name_override: Option<String>,
 }
 
 fn env_or_parse_u32(key: &str, default: u32) -> u32 {
@@ -73,6 +128,53 @@ fn env_or_parse_f64(key: &str, default: f64) -> f64 {
     }
 }
 
+fn load_or_create_actual_lwe_checkpoint(
+    params: &GpuDCRTPolyParams,
+    d_secret: usize,
+    dir: &Path,
+) -> ([u8; 32], GpuDCRTPolyTrapdoorSampler, GpuTrapdoor, GpuMatrix) {
+    fs::create_dir_all(dir).expect("failed to create actual LWE checkpoint dir");
+
+    let hash_key_path = dir.join(ACTUAL_HASH_KEY_CHECKPOINT_FILE);
+    let hash_key = match fs::read(&hash_key_path) {
+        Ok(bytes) => {
+            let hash_key: [u8; 32] = bytes
+                .try_into()
+                .expect("actual LWE hash key checkpoint must contain exactly 32 bytes");
+            info!("loaded actual LWE hash key checkpoint from {}", hash_key_path.display());
+            hash_key
+        }
+        Err(_) => {
+            fs::write(&hash_key_path, DEFAULT_BENCH_SEED)
+                .expect("failed to write actual LWE hash key checkpoint");
+            info!("wrote actual LWE hash key checkpoint to {}", hash_key_path.display());
+            DEFAULT_BENCH_SEED
+        }
+    };
+
+    let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(params, TRAPDOOR_SIGMA);
+    let trapdoor_path = dir.join(ACTUAL_TRAPDOOR_CHECKPOINT_FILE);
+    let pub_matrix_path = dir.join(ACTUAL_PUB_MATRIX_CHECKPOINT_FILE);
+    match (fs::read(&trapdoor_path), fs::read(&pub_matrix_path)) {
+        (Ok(trapdoor_bytes), Ok(pub_matrix_bytes)) => {
+            let trapdoor = GpuDCRTPolyTrapdoorSampler::trapdoor_from_bytes(params, &trapdoor_bytes)
+                .expect("failed to decode actual LWE trapdoor checkpoint");
+            let pub_matrix = GpuMatrix::from_compact_bytes(params, &pub_matrix_bytes);
+            info!("loaded actual LWE trapdoor/pub_matrix checkpoints from {}", dir.display());
+            (hash_key, trapdoor_sampler, trapdoor, pub_matrix)
+        }
+        _ => {
+            let (trapdoor, pub_matrix) = trapdoor_sampler.trapdoor(params, d_secret);
+            fs::write(&trapdoor_path, GpuDCRTPolyTrapdoorSampler::trapdoor_to_bytes(&trapdoor))
+                .expect("failed to write actual LWE trapdoor checkpoint");
+            fs::write(&pub_matrix_path, pub_matrix.to_compact_bytes())
+                .expect("failed to write actual LWE pub_matrix checkpoint");
+            info!("wrote actual LWE trapdoor/pub_matrix checkpoints to {}", dir.display());
+            (hash_key, trapdoor_sampler, trapdoor, pub_matrix)
+        }
+    }
+}
+
 impl ModqArithConfig {
     fn from_env() -> Self {
         let ring_dim = env_or_parse_u32("LWE_NESTED_RNS_MODQ_ARITH_RING_DIM", DEFAULT_RING_DIM);
@@ -83,10 +185,28 @@ impl ModqArithConfig {
         let base_bits = env_or_parse_u32("LWE_NESTED_RNS_MODQ_ARITH_BASE_BITS", DEFAULT_BASE_BITS);
         let max_crt_depth =
             env_or_parse_usize("LWE_NESTED_RNS_MODQ_ARITH_MAX_CRT_DEPTH", DEFAULT_MAX_CRT_DEPTH);
+        let active_levels = std::env::var("LWE_NESTED_RNS_MODQ_ARITH_Q_LEVEL").ok().map(|raw| {
+            let level = raw
+                .parse::<usize>()
+                .expect("LWE_NESTED_RNS_MODQ_ARITH_Q_LEVEL must be a positive integer");
+            assert!(
+                level > 0,
+                "LWE_NESTED_RNS_MODQ_ARITH_Q_LEVEL must be greater than or equal to 1"
+            );
+            level
+        });
         let error_sigma =
             env_or_parse_f64("LWE_NESTED_RNS_MODQ_ARITH_ERROR_SIGMA", DEFAULT_ERROR_SIGMA);
         let d_secret = env_or_parse_usize("LWE_NESTED_RNS_MODQ_ARITH_D_SECRET", DEFAULT_D_SECRET);
         let height = env_or_parse_usize("LWE_NESTED_RNS_MODQ_ARITH_HEIGHT", DEFAULT_HEIGHT);
+        let bench_iterations = env_or_parse_usize(
+            "LWE_NESTED_RNS_MODQ_ARITH_BENCH_ITERATIONS",
+            DEFAULT_BENCH_ITERATIONS,
+        );
+        let dir_name_override = env::var("LWE_NESTED_RNS_MODQ_ARITH_DIR_NAME")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
 
         assert!(ring_dim > 0, "LWE_NESTED_RNS_MODQ_ARITH_RING_DIM must be > 0");
         assert!(crt_bits > 0, "LWE_NESTED_RNS_MODQ_ARITH_CRT_BITS must be > 0");
@@ -96,6 +216,7 @@ impl ModqArithConfig {
         assert!(max_crt_depth > 0, "LWE_NESTED_RNS_MODQ_ARITH_MAX_CRT_DEPTH must be > 0");
         assert!(error_sigma > 0.0, "LWE_NESTED_RNS_MODQ_ARITH_ERROR_SIGMA must be > 0");
         assert!(d_secret > 0, "LWE_NESTED_RNS_MODQ_ARITH_D_SECRET must be > 0");
+        assert!(bench_iterations > 0, "LWE_NESTED_RNS_MODQ_ARITH_BENCH_ITERATIONS must be > 0");
 
         Self {
             ring_dim,
@@ -104,21 +225,38 @@ impl ModqArithConfig {
             scale,
             base_bits,
             max_crt_depth,
+            active_levels,
             error_sigma,
             d_secret,
             height,
+            bench_iterations,
+            dir_name_override,
         }
     }
-}
 
-fn q_level_from_env() -> Option<usize> {
-    std::env::var("LWE_NESTED_RNS_MODQ_ARITH_Q_LEVEL").ok().map(|raw| {
-        let level = raw
-            .parse::<usize>()
-            .expect("LWE_NESTED_RNS_MODQ_ARITH_Q_LEVEL must be a positive integer");
-        assert!(level > 0, "LWE_NESTED_RNS_MODQ_ARITH_Q_LEVEL must be greater than or equal to 1");
-        level
-    })
+    fn num_slots(&self) -> usize {
+        self.ring_dim as usize
+    }
+
+    fn active_levels_for_crt_depth(&self, crt_depth: usize, q_level: Option<usize>) -> usize {
+        let active_levels = q_level.unwrap_or(crt_depth);
+        assert!(
+            active_levels <= crt_depth,
+            "LWE_NESTED_RNS_MODQ_ARITH_Q_LEVEL exceeds crt_depth: q_level={}, crt_depth={}",
+            active_levels,
+            crt_depth
+        );
+        active_levels
+    }
+
+    fn dir_name(&self, crt_depth: usize) -> String {
+        self.dir_name_override.clone().unwrap_or_else(|| {
+            format!(
+                "test_data/test_gpu_lwe_nested_rns_modq_arith_ring{}_active{}_crt{}_depth{}",
+                self.ring_dim, crt_depth, self.crt_bits, crt_depth
+            )
+        })
+    }
 }
 
 fn active_q_moduli_and_modulus<T: PolyParams>(
@@ -183,6 +321,103 @@ fn build_modq_arith_circuit_gpu(
     (circuit, ctx)
 }
 
+#[derive(Debug)]
+struct CrtDepthProbe {
+    params: DCRTPolyParams,
+    eval_ok: bool,
+}
+
+impl CrtDepthProbe {
+    fn search_ok(&self) -> bool {
+        self.eval_ok
+    }
+}
+
+fn corrected_max_eval_error_for_active_levels(
+    simulated_error: &BigDecimal,
+    requested_active_levels: usize,
+) -> BigDecimal {
+    simulated_error * BigDecimal::from_biguint(BigUint::from(requested_active_levels), 0)
+}
+
+fn probe_crt_depth_for_modq_arith(
+    cfg: &ModqArithConfig,
+    q_level: Option<usize>,
+    crt_depth: usize,
+    ring_dim_sqrt: &BigDecimal,
+    base: &BigDecimal,
+    error_sigma: &BigDecimal,
+    input_bound: &BigDecimal,
+    e_init_norm: &BigDecimal,
+) -> CrtDepthProbe {
+    let params = DCRTPolyParams::new(cfg.ring_dim, crt_depth, cfg.crt_bits, cfg.base_bits);
+    let (_, _, actual_crt_depth) = params.to_crt();
+    let active_levels = cfg.active_levels_for_crt_depth(actual_crt_depth, q_level);
+    assert!(
+        ERROR_SIM_ACTIVE_LEVELS <= actual_crt_depth,
+        "error simulation requires crt_depth >= ERROR_SIM_ACTIVE_LEVELS: crt_depth={}, ERROR_SIM_ACTIVE_LEVELS={}",
+        actual_crt_depth,
+        ERROR_SIM_ACTIVE_LEVELS
+    );
+    let (active_q_moduli, active_q, _) = active_q_moduli_and_modulus(&params, Some(active_levels));
+    let full_q = params.modulus();
+    let q_max = *active_q_moduli.iter().max().expect("active_q_moduli must not be empty");
+    let (circuit, _ctx) = build_modq_arith_circuit_cpu(
+        &params,
+        Some(ERROR_SIM_ACTIVE_LEVELS),
+        cfg.p_moduli_bits,
+        cfg.scale,
+        cfg.height,
+    );
+
+    let log_base_q = params.modulus_digits();
+    let log_base_q_small = log_base_q / actual_crt_depth;
+    let sim_ctx = Arc::new(SimulatorContext::new(
+        ring_dim_sqrt.clone(),
+        base.clone(),
+        cfg.d_secret,
+        log_base_q,
+        log_base_q_small,
+    ));
+    let plt_evaluator = NormPltLWEEvaluator::new(sim_ctx.clone(), error_sigma);
+
+    let out_errors = circuit.simulate_max_error_norm(
+        sim_ctx,
+        input_bound.clone(),
+        circuit.num_input(),
+        e_init_norm,
+        Some(&plt_evaluator),
+        None,
+    );
+
+    debug!("modq_arith simulate_max_error_norm finished output_errors={}", out_errors.len());
+    assert_eq!(out_errors.len(), 1);
+
+    let threshold = full_q.as_ref() / BigUint::from(2u64 * q_max);
+    let threshold_bd = BigDecimal::from_biguint(threshold.clone(), 0);
+    let max_eval_error = out_errors[0].matrix_norm.poly_norm.norm.clone();
+    let corrected_max_eval_error =
+        corrected_max_eval_error_for_active_levels(&max_eval_error, active_levels);
+    let eval_ok = corrected_max_eval_error < threshold_bd;
+
+    info!(
+        "modq_arith crt_depth={} active_levels={} error_sim_active_levels={} active_q_bits={} full_q_bits={} num_inputs={} output_polys={} sim_max_eval_error_bits={} max_eval_error_bits={} eval_threshold_bits={} eval_ok={}",
+        crt_depth,
+        active_levels,
+        ERROR_SIM_ACTIVE_LEVELS,
+        active_q.bits(),
+        full_q.bits(),
+        circuit.num_input(),
+        out_errors.len(),
+        bigdecimal_bits_ceil(&max_eval_error),
+        bigdecimal_bits_ceil(&corrected_max_eval_error),
+        bigdecimal_bits_ceil(&BigDecimal::from_biguint(threshold, 0)),
+        eval_ok
+    );
+
+    CrtDepthProbe { params, eval_ok }
+}
+
 fn find_crt_depth_for_modq_arith(
     cfg: &ModqArithConfig,
     q_level: Option<usize>,
@@ -193,82 +428,169 @@ fn find_crt_depth_for_modq_arith(
     let input_bound = BigDecimal::from((1u64 << cfg.p_moduli_bits) - 1);
     let e_init_norm = &error_sigma * BigDecimal::from_f32(6.5).unwrap();
 
-    for crt_depth in 1..=cfg.max_crt_depth {
-        let params = DCRTPolyParams::new(cfg.ring_dim, crt_depth, cfg.crt_bits, cfg.base_bits);
-        let (active_q_moduli, _, _) = active_q_moduli_and_modulus(&params, q_level);
-        let full_q = params.modulus();
-        let q_max = *active_q_moduli.iter().max().expect("active_q_moduli must not be empty");
-        let (_, _, crt_depth) = params.to_crt();
-        let (circuit, _ctx) = build_modq_arith_circuit_cpu(
-            &params,
+    if let Some(raw_crt_depth) = env::var("CRT_DEPTH").ok().filter(|value| !value.trim().is_empty())
+    {
+        let requested_crt_depth = raw_crt_depth
+            .parse::<usize>()
+            .unwrap_or_else(|e| panic!("CRT_DEPTH must be a valid usize: {e}"));
+        assert!(requested_crt_depth > 0, "CRT_DEPTH must be > 0");
+        let params =
+            DCRTPolyParams::new(cfg.ring_dim, requested_crt_depth, cfg.crt_bits, cfg.base_bits);
+        return (requested_crt_depth, params);
+    }
+
+    let min_crt_depth = q_level.unwrap_or(1);
+    assert!(
+        min_crt_depth <= cfg.max_crt_depth,
+        "minimum crt_depth must be <= LWE_NESTED_RNS_MODQ_ARITH_MAX_CRT_DEPTH"
+    );
+
+    let mut low = min_crt_depth;
+    let mut high = cfg.max_crt_depth;
+    while low < high {
+        let mid = low + (high - low) / 2;
+        let probe = probe_crt_depth_for_modq_arith(
+            cfg,
             q_level,
-            cfg.p_moduli_bits,
-            cfg.scale,
-            cfg.height,
-        );
-
-        let log_base_q = params.modulus_digits();
-        let log_base_q_small = log_base_q / crt_depth;
-        let ctx = Arc::new(SimulatorContext::new(
-            ring_dim_sqrt.clone(),
-            base.clone(),
-            cfg.d_secret,
-            log_base_q,
-            log_base_q_small,
-        ));
-        let plt_evaluator = NormPltLWEEvaluator::new(ctx.clone(), &error_sigma);
-
-        let out_errors = circuit.simulate_max_error_norm(
-            ctx,
-            input_bound.clone(),
-            circuit.num_input(),
+            mid,
+            &ring_dim_sqrt,
+            &base,
+            &error_sigma,
+            &input_bound,
             &e_init_norm,
-            Some(&plt_evaluator),
-            None,
         );
-
-        assert_eq!(out_errors.len(), 1);
-
-        let threshold = full_q.as_ref() / BigUint::from(2u64 * q_max);
-        let error = &out_errors[0].matrix_norm.poly_norm.norm;
-        let max_error_bits = bigdecimal_bits_ceil(error);
-        let all_ok = *error < BigDecimal::from_biguint(threshold, 0);
-
-        info!(
-            "crt_depth={} q_bits={} max_error_bits={}",
-            crt_depth,
-            params.modulus_bits(),
-            max_error_bits
-        );
-
-        if all_ok {
-            return (crt_depth, params);
+        if probe.search_ok() {
+            high = mid;
+        } else {
+            low = mid + 1;
         }
     }
 
+    let probe = probe_crt_depth_for_modq_arith(
+        cfg,
+        q_level,
+        low,
+        &ring_dim_sqrt,
+        &base,
+        &error_sigma,
+        &input_bound,
+        &e_init_norm,
+    );
+    if probe.search_ok() {
+        info!("selected crt_depth={} for nested-RNS modq arithmetic search", low);
+        return (low, probe.params);
+    }
+
     panic!(
-        "crt_depth satisfying error < q/(2*q_i) for all CRT moduli not found up to MAX_CRT_DEPTH ({})",
+        "crt_depth satisfying error < q/(2*q_i) for all CRT moduli not found up to LWE_NESTED_RNS_MODQ_ARITH_MAX_CRT_DEPTH ({})",
         cfg.max_crt_depth
     );
 }
 
-#[test]
-fn test_gpu_lwe_nested_rns_modq_arith() {
-    let _ = tracing_subscriber::fmt::try_init();
+fn build_lwe_scalar_pubkey_plt_evaluator(
+    params: &GpuDCRTPolyParams,
+    hash_key: [u8; 32],
+    d_secret: usize,
+    dir_path: PathBuf,
+) -> GpuScalarPubKeyPltEvaluator {
+    let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(params, TRAPDOOR_SIGMA);
+    let (trapdoor, pub_matrix) = trapdoor_sampler.trapdoor(params, d_secret);
+    GpuScalarPubKeyPltEvaluator::new(
+        hash_key,
+        trapdoor_sampler,
+        Arc::new(pub_matrix),
+        Arc::new(trapdoor),
+        dir_path,
+    )
+}
+
+fn build_benchmark_public_lut(params: &GpuDCRTPolyParams) -> PublicLut<GpuDCRTPoly> {
+    PublicLut::<GpuDCRTPoly>::new(
+        params,
+        16,
+        move |params, x| {
+            if x >= 16 {
+                return None;
+            }
+            let y_elem = <<GpuDCRTPoly as Poly>::Elem as PolyElem>::constant(
+                &params.modulus(),
+                (x + 1) % 16,
+            );
+            Some((x, y_elem))
+        },
+        None,
+    )
+}
+
+fn build_benchmark_public_lookup_gate(
+    params: &GpuDCRTPolyParams,
+) -> (PublicLut<GpuDCRTPoly>, usize, GateId) {
+    let lut = build_benchmark_public_lut(params);
+    let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    let input = circuit.input(1);
+    let lut_id = circuit.register_public_lookup(lut.clone());
+    let gate_id = circuit.public_lookup_gate(input, lut_id).as_single_wire();
+    (lut, lut_id, gate_id)
+}
+
+fn build_benchmark_slot_transfer_gate(src_slots: &[(u32, Option<u32>)]) -> GateId {
+    let mut circuit = PolyCircuit::<GpuDCRTPoly>::new();
+    let input = circuit.input(1);
+    circuit.slot_transfer_gate(input, src_slots).as_single_wire()
+}
+
+fn identity_slot_transfer_plan(num_slots: usize) -> Vec<(u32, Option<u32>)> {
+    (0..num_slots).map(|slot| (slot as u32, None)).collect()
+}
+
+fn sample_benchmark_pubkeys(
+    params: &GpuDCRTPolyParams,
+    seed: [u8; 32],
+    d_secret: usize,
+    non_constant_key_count: usize,
+    tag: &[u8],
+) -> Vec<BggPublicKey<GpuMatrix>> {
+    let sampler = BGGPublicKeySampler::<_, GpuHashSampler>::new(seed, d_secret);
+    let reveal_plaintexts = vec![true; non_constant_key_count];
+    sampler.sample(params, tag, &reveal_plaintexts)
+}
+
+fn constant_and_shared_benchmark_pubkeys(
+    pubkeys: &[BggPublicKey<GpuMatrix>],
+) -> (&BggPublicKey<GpuMatrix>, &BggPublicKey<GpuMatrix>) {
+    assert!(
+        pubkeys.len() >= 2,
+        "benchmark pubkeys must contain the constant-one key and at least one reusable input key"
+    );
+    (&pubkeys[0], &pubkeys[1])
+}
+
+fn round_div_biguint(value: &BigUint, divisor: &BigUint) -> BigUint {
+    let half = divisor / BigUint::from(2u64);
+    (value + half) / divisor
+}
+
+#[tokio::test]
+async fn test_gpu_lwe_nested_rns_modq_arith() {
+    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
     gpu_device_sync();
     let cfg = ModqArithConfig::from_env();
     info!("nested_rns modq arith test config: {:?}", cfg);
 
-    let q_level = q_level_from_env();
+    let q_level = cfg.active_levels;
     let num_inputs = 1usize
         .checked_shl(cfg.height as u32)
         .expect("LWE_NESTED_RNS_MODQ_ARITH_HEIGHT is too large");
     let (crt_depth, cpu_params) = find_crt_depth_for_modq_arith(&cfg, q_level);
     let (moduli, _, _) = cpu_params.to_crt();
-    let detected_gpu_params =
-        GpuDCRTPolyParams::new(cpu_params.ring_dimension(), moduli.clone(), cpu_params.base_bits());
-    let single_gpu_id = *detected_gpu_params
-        .gpu_ids()
+    let detected_gpu_ids = detected_gpu_device_ids();
+    let detected_gpu_count = detected_gpu_device_count();
+    assert_eq!(
+        detected_gpu_count,
+        detected_gpu_ids.len(),
+        "detected GPU count and ids length must match"
+    );
+    let single_gpu_id = *detected_gpu_ids
         .first()
         .expect("at least one GPU device is required for test_gpu_lwe_nested_rns_modq_arith");
     let params = GpuDCRTPolyParams::new_with_gpu(
@@ -278,22 +600,39 @@ fn test_gpu_lwe_nested_rns_modq_arith() {
         vec![single_gpu_id],
         Some(1),
     );
-    let (all_q_moduli, _, _) = params.to_crt();
-    let (active_q_moduli, active_q, active_q_level) = active_q_moduli_and_modulus(&params, q_level);
-    let (circuit, _ctx) =
-        build_modq_arith_circuit_gpu(&params, q_level, cfg.p_moduli_bits, cfg.scale, cfg.height);
+    let (all_q_moduli, _, actual_crt_depth) = params.to_crt();
+    let active_levels = cfg.active_levels_for_crt_depth(actual_crt_depth, q_level);
+    let (active_q_moduli, active_q, active_q_level) =
+        active_q_moduli_and_modulus(&params, Some(active_levels));
+    let (circuit, _ctx) = build_modq_arith_circuit_gpu(
+        &params,
+        Some(active_levels),
+        cfg.p_moduli_bits,
+        cfg.scale,
+        cfg.height,
+    );
     let gate_counts = circuit.count_gates_by_type_vec();
     let total_gates = circuit.num_gates();
+    let total_lut_entries = circuit.total_registered_public_lut_entries();
+    let total_public_lut_gates = gate_counts.get(&PolyGateKind::PubLut).copied().unwrap_or(0);
+    let total_slot_transfer_gates =
+        gate_counts.get(&PolyGateKind::SlotTransfer).copied().unwrap_or(0);
 
-    info!("forcing single GPU for this test: gpu_id={}", single_gpu_id);
+    info!(
+        "forcing single GPU for this test: eval_gpu_id={} detected_gpu_count={} detected_gpu_ids={:?}",
+        single_gpu_id, detected_gpu_count, detected_gpu_ids
+    );
     info!("found crt_depth={}", crt_depth);
     info!(
-        "selected crt_depth={} ring_dim={} crt_bits={} base_bits={} q_level={:?} q_moduli={:?}",
+        "selected crt_depth={} actual_crt_depth={} cfg_active_levels={:?} ring_dim={} crt_bits={} base_bits={} q_level={:?} active_levels={} q_moduli={:?}",
         crt_depth,
+        actual_crt_depth,
+        cfg.active_levels,
         params.ring_dimension(),
         cfg.crt_bits,
         cfg.base_bits,
         q_level,
+        active_levels,
         all_q_moduli
     );
     info!(
@@ -305,14 +644,269 @@ fn test_gpu_lwe_nested_rns_modq_arith() {
     info!("multiplication tree config: height={} num_inputs={}", cfg.height, num_inputs);
     let non_free_depth_contributions = circuit.non_free_depth_contributions();
     info!(
-        "circuit total_gates={} non_free_depth_contributions={:?} gate_counts={:?}",
-        total_gates, non_free_depth_contributions, gate_counts
+        "circuit total_gates={} non_free_depth_contributions={:?} gate_counts={:?} total_lut_entries={} total_public_lut_gates={} total_slot_transfer_gates={}",
+        total_gates,
+        non_free_depth_contributions,
+        gate_counts,
+        total_lut_entries,
+        total_public_lut_gates,
+        total_slot_transfer_gates
     );
 
     assert_eq!(params.modulus(), cpu_params.modulus());
     assert_eq!(circuit.num_output(), 1, "multiplication tree should emit one output gate");
     assert!(circuit.num_input() > 0, "circuit must expose inputs");
     assert!(total_gates > 0, "circuit must contain gates");
+
+    let dir_name = cfg.dir_name(crt_depth);
+    let dir = Path::new(&dir_name);
+    fs::create_dir_all(dir).expect("failed to create modq arithmetic test directory");
+    init_storage_system(dir.to_path_buf());
+
+    let (pubkey_bench_lut, pubkey_bench_public_lut_id, pubkey_bench_public_lut_gate_id) =
+        build_benchmark_public_lookup_gate(&params);
+    let pubkey_bench_slot_transfer_src_slots = identity_slot_transfer_plan(cfg.num_slots());
+    let pubkey_bench_slot_transfer_gate_id =
+        build_benchmark_slot_transfer_gate(&pubkey_bench_slot_transfer_src_slots);
+    let pubkey_bench_public_keys = sample_benchmark_pubkeys(
+        &params,
+        DEFAULT_BENCH_SEED,
+        cfg.d_secret,
+        1,
+        b"LWE_NESTED_RNS_MODQ_ARITH_PUBKEY_BENCH",
+    );
+    let (pubkey_bench_public_lut_one, pubkey_bench_shared_input) =
+        constant_and_shared_benchmark_pubkeys(&pubkey_bench_public_keys);
+    let pubkey_scalar_bench_plt_evaluator = build_lwe_scalar_pubkey_plt_evaluator(
+        &params,
+        DEFAULT_BENCH_SEED,
+        cfg.d_secret,
+        dir.to_path_buf(),
+    );
+    let pubkey_public_lut_aux_estimate = pubkey_scalar_bench_plt_evaluator
+        .estimate_public_lut_sample_aux_matrices(
+            &params,
+            total_lut_entries,
+            total_public_lut_gates,
+        );
+    gpu_device_sync();
+    info!(
+        "modq_arith scalar pubkey sample_aux estimates: public_lut={:?} total_lut_entries={} public_lut_gates={}",
+        pubkey_public_lut_aux_estimate, total_lut_entries, total_public_lut_gates
+    );
+    let pubkey_scalar_bench_slot_evaluator = GpuPubKeySlotEvaluator::new(
+        DEFAULT_BENCH_SEED,
+        cfg.d_secret,
+        cfg.num_slots(),
+        TRAPDOOR_SIGMA,
+        cfg.error_sigma,
+        dir.to_path_buf(),
+    );
+    let pubkey_scalar_bench = BggPublicKeyBenchEstimator::benchmark(
+        &BggPublicKeyBenchSamples {
+            params: &params,
+            add_lhs: pubkey_bench_shared_input,
+            add_rhs: pubkey_bench_shared_input,
+            sub_lhs: pubkey_bench_shared_input,
+            sub_rhs: pubkey_bench_shared_input,
+            mul_lhs: pubkey_bench_shared_input,
+            mul_rhs: pubkey_bench_shared_input,
+            small_scalar_input: pubkey_bench_shared_input,
+            small_scalar: &[3u32, 5u32],
+            large_scalar_input: pubkey_bench_shared_input,
+            large_scalar: &[BigUint::from(7u32)],
+            public_lut_one: pubkey_bench_public_lut_one,
+            public_lut_input: pubkey_bench_shared_input,
+            public_lut: &pubkey_bench_lut,
+            public_lut_id: pubkey_bench_public_lut_id,
+            public_lut_gate_id: pubkey_bench_public_lut_gate_id,
+            slot_transfer_input: pubkey_bench_shared_input,
+            slot_transfer_src_slots: &pubkey_bench_slot_transfer_src_slots,
+            slot_transfer_gate_id: pubkey_bench_slot_transfer_gate_id,
+        },
+        &pubkey_scalar_bench_plt_evaluator,
+        &pubkey_scalar_bench_slot_evaluator,
+        build_lwe_scalar_pubkey_plt_evaluator(
+            &params,
+            DEFAULT_BENCH_SEED,
+            cfg.d_secret,
+            dir.to_path_buf(),
+        ),
+        GpuPubKeySlotEvaluator::new(
+            DEFAULT_BENCH_SEED,
+            cfg.d_secret,
+            cfg.num_slots(),
+            TRAPDOOR_SIGMA,
+            cfg.error_sigma,
+            dir.to_path_buf(),
+        ),
+        cfg.bench_iterations,
+    );
+    let pubkey_circuit_bench = pubkey_scalar_bench.estimate_circuit_bench(&circuit);
+    info!(
+        "modq_arith scalar bgg pubkey circuit bench estimate: total_time={:.6} latency={:.6} max_parallelism={} peak_vram={}",
+        pubkey_circuit_bench.total_time,
+        pubkey_circuit_bench.latency,
+        pubkey_circuit_bench.max_parallelism,
+        pubkey_circuit_bench.peak_vram
+    );
+
+    let encoding_scalar_bench =
+        BggEncodingBenchEstimator::<GpuMatrix>::benchmark(&params, cfg.bench_iterations);
+    let encoding_circuit_bench = encoding_scalar_bench.estimate_circuit_bench(&circuit);
+    info!(
+        "modq_arith scalar bgg encoding circuit bench estimate: total_time={:.6} latency={:.6} max_parallelism={} peak_vram={}",
+        encoding_circuit_bench.total_time,
+        encoding_circuit_bench.latency,
+        encoding_circuit_bench.max_parallelism,
+        encoding_circuit_bench.peak_vram
+    );
+
+    let input_value = BigUint::from(1u64);
+    let expected_poly = GpuDCRTPoly::from_biguint_to_constant(&params, input_value.clone());
+    let encoded_input = encode_nested_rns_poly(
+        cfg.p_moduli_bits,
+        DEFAULT_MAX_UNREDUCED_MULS_BUDGET,
+        &params,
+        &input_value,
+        Some(active_q_level),
+    );
+    let plaintext_inputs =
+        (0..num_inputs).flat_map(|_| encoded_input.clone()).collect::<Vec<GpuDCRTPoly>>();
+    assert_eq!(
+        plaintext_inputs.len(),
+        circuit.num_input(),
+        "encoded nested-RNS input count must match the multiplication tree circuit input count"
+    );
+
+    let dry_plt_evaluator = PolyPltEvaluator::new();
+    let dry_eval_start = Instant::now();
+    let dry_outputs = circuit.eval(
+        &params,
+        GpuDCRTPoly::const_one(&params),
+        plaintext_inputs.clone(),
+        Some(&dry_plt_evaluator),
+        None,
+        None,
+    );
+    info!("dry eval elapsed_ms={:.3}", dry_eval_start.elapsed().as_secs_f64() * 1000.0);
+    assert_eq!(dry_outputs.len(), 1, "dry-run should output one value polynomial");
+    assert_eq!(
+        dry_outputs[0].coeffs_biguints()[0],
+        BigUint::from(1u64),
+        "all-one multiplication tree output should reconstruct to 1"
+    );
+
+    let actual_eval_dir = dir.join("actual_scalar_bgg");
+    let (actual_hash_key, trapdoor_sampler, trapdoor, pub_matrix) =
+        load_or_create_actual_lwe_checkpoint(&params, cfg.d_secret, &actual_eval_dir);
+    let trapdoor = Arc::new(trapdoor);
+    let pub_matrix = Arc::new(pub_matrix);
+
+    let uniform_sampler = GpuDCRTPolyUniformSampler::new();
+    let secrets =
+        uniform_sampler.sample_uniform(&params, 1, cfg.d_secret, DistType::TernaryDist).get_row(0);
+    let secret_vec = GpuDCRTPolyMatrix::from_poly_vec_row(&params, secrets.clone());
+
+    let pubkey_sampler =
+        BGGPublicKeySampler::<_, GpuHashSampler>::new(actual_hash_key, cfg.d_secret);
+    let reveal_plaintexts = vec![true; circuit.num_input()];
+    let mut pubkeys = pubkey_sampler.sample(
+        &params,
+        b"LWE_NESTED_RNS_MODQ_ARITH_ACTUAL_PUBKEY",
+        &reveal_plaintexts,
+    );
+
+    let encoding_sampler = BGGEncodingSampler::<GpuDCRTPolyUniformSampler>::new(
+        &params,
+        &secrets,
+        Some(cfg.error_sigma),
+    );
+    let mut encodings = encoding_sampler.sample(&params, &pubkeys, &plaintext_inputs);
+    drop(plaintext_inputs);
+    drop(secrets);
+
+    fs::create_dir_all(&actual_eval_dir).expect("failed to create actual scalar BGG eval dir");
+    init_storage_system(actual_eval_dir.clone());
+
+    let pubkey_evaluator = LWEBGGPubKeyPltEvaluator::<
+        GpuDCRTPolyMatrix,
+        GpuDCRTPolyHashSampler<Keccak256>,
+        GpuDCRTPolyTrapdoorSampler,
+    >::new(
+        actual_hash_key,
+        trapdoor_sampler,
+        Arc::clone(&pub_matrix),
+        trapdoor,
+        actual_eval_dir.clone(),
+    );
+
+    let input_pubkeys = pubkeys.split_off(1);
+    let one_pubkey = pubkeys.pop().expect("pubkeys must contain one entry for const one");
+    let pubkey_eval_start = Instant::now();
+    let pubkey_outputs =
+        circuit.eval(&params, one_pubkey, input_pubkeys, Some(&pubkey_evaluator), None, None);
+    info!("pubkey eval elapsed_ms={:.3}", pubkey_eval_start.elapsed().as_secs_f64() * 1000.0);
+    assert_eq!(pubkey_outputs.len(), 1);
+
+    pubkey_evaluator.sample_aux_matrices(&params);
+    wait_for_all_writes(actual_eval_dir.clone())
+        .await
+        .expect("actual scalar BGG pubkey auxiliary writes should complete");
+    drop(pubkey_evaluator);
+
+    let mut c_b = secret_vec.clone() * pub_matrix.as_ref();
+    if cfg.error_sigma != 0.0 {
+        let c_b_error = uniform_sampler.sample_uniform(
+            &params,
+            c_b.row_size(),
+            c_b.col_size(),
+            DistType::GaussDist { sigma: cfg.error_sigma },
+        );
+        c_b = c_b + c_b_error;
+    }
+    let encoding_evaluator = LWEBGGEncodingPltEvaluator::<
+        GpuDCRTPolyMatrix,
+        GpuDCRTPolyHashSampler<Keccak256>,
+    >::new(actual_hash_key, actual_eval_dir, c_b);
+
+    let input_encodings = encodings.split_off(1);
+    let one_encoding = encodings.pop().expect("encodings must contain one entry for const one");
+    let encoding_eval_start = Instant::now();
+    let encoding_outputs =
+        circuit.eval(&params, one_encoding, input_encodings, Some(&encoding_evaluator), None, None);
+    info!("encoding eval elapsed_ms={:.3}", encoding_eval_start.elapsed().as_secs_f64() * 1000.0);
+    assert_eq!(encoding_outputs.len(), 1);
+
+    assert_eq!(encoding_outputs[0].pubkey, pubkey_outputs[0]);
+    assert_eq!(
+        encoding_outputs[0]
+            .plaintext
+            .as_ref()
+            .expect("output encoding plaintext should be revealed"),
+        &expected_poly
+    );
+
+    let expected_times_gadget = secret_vec.clone() *
+        (GpuDCRTPolyMatrix::gadget_matrix(&params, cfg.d_secret) * expected_poly);
+    let s_times_pk = secret_vec.clone() * &pubkey_outputs[0].matrix;
+    let diff = encoding_outputs[0].vector.clone() - s_times_pk + expected_times_gadget;
+    let coeff = diff
+        .entry(0, 0)
+        .coeffs_biguints()
+        .into_iter()
+        .next()
+        .expect("diff poly must have at least one coefficient");
+
+    let q_max = *active_q_moduli.iter().max().expect("active_q_moduli must not be empty");
+    let q_over_qmax = params.modulus().as_ref() / BigUint::from(q_max);
+    let random_int: u64 = rand::random::<u64>() % q_max;
+    let randomized_coeff = coeff + q_over_qmax.clone() * BigUint::from(random_int);
+    let rounded = round_div_biguint(&randomized_coeff, &q_over_qmax);
+    let decoded_random: u64 = (&rounded % BigUint::from(q_max))
+        .try_into()
+        .expect("decoded random coefficient must fit u64");
+    assert_eq!(decoded_random, random_int);
 
     gpu_device_sync();
 }


### PR DESCRIPTION
## Summary
- Add `DiamondIO::simulate_error_growth` with structured error-growth reporting for input injection, PRF refresh rounds, final projection residuals, and final noisy plaintext bounds.
- Reuse the existing input injector and noise-refresh simulators, and add DiamondIO-specific representative circuits for one-output Goldreich PRG evaluation and function-output estimation.
- Tighten several simulation bounds and helper paths, including nested-RNS seed-wire bounds, active-level extrapolation, and noise-refresh rounding assumptions.
- Update related AKY24, ring-GSW, and input-injector plumbing so the new simulation paths share the same error-model conventions.

## Testing
- `cargo check --lib` passed.
- `cargo +nightly fmt --all` passed.
- Not run (not requested).