### PR TITLE
Treat plaintext PolyNorm values as constant polynomials in error simulation

### DIFF
--- a/src/simulator/error_norm.rs
+++ b/src/simulator/error_norm.rs
@@ -28,7 +28,7 @@ pub struct ErrorNorm {
 impl ErrorNorm {
     pub fn new(plaintext_norm: PolyNorm, matrix_norm: PolyMatrixNorm) -> Self {
         debug_assert_eq!(plaintext_norm.ctx, matrix_norm.clone_ctx());
-        Self { plaintext_norm, matrix_norm }
+        Self { plaintext_norm: plaintext_norm.into_constant(), matrix_norm }
     }
 
     #[inline]
@@ -85,7 +85,7 @@ impl Evaluable for ErrorNorm {
 
     fn small_scalar_mul(&self, _: &Self::Params, scalar: &[u32]) -> Self {
         let scalar_max = BigDecimal::from(*scalar.iter().max().unwrap());
-        let scalar_poly = PolyNorm::new(self.clone_ctx(), scalar_max);
+        let scalar_poly = PolyNorm::constant(self.clone_ctx(), scalar_max);
         ErrorNorm {
             matrix_norm: self.matrix_norm.clone() * &scalar_poly,
             plaintext_norm: self.plaintext_norm.clone() * &scalar_poly,
@@ -95,7 +95,7 @@ impl Evaluable for ErrorNorm {
     fn large_scalar_mul(&self, _: &Self::Params, scalar: &[BigUint]) -> Self {
         let scalar_max = scalar.iter().max().unwrap().clone();
         let scalar_bd = BigDecimal::from(num_bigint::BigInt::from(scalar_max));
-        let scalar_poly = PolyNorm::new(self.clone_ctx(), scalar_bd);
+        let scalar_poly = PolyNorm::constant(self.clone_ctx(), scalar_bd);
         ErrorNorm {
             matrix_norm: self.matrix_norm.clone() *
                 PolyMatrixNorm::gadget_decomposed(self.clone_ctx(), self.ctx().m_g),

--- a/src/simulator/eval_error/evaluators.rs
+++ b/src/simulator/eval_error/evaluators.rs
@@ -273,7 +273,7 @@ impl PltEvaluator<ErrorNorm> for NormPltLWEEvaluator {
         let matrix_norm = &self.e_b_times_k_high + (&input.matrix_norm * &self.k_low);
         let plaintext_bd =
             BigDecimal::from(num_bigint::BigInt::from(plt.max_output_row().1.value().clone()));
-        let plaintext_norm = PolyNorm::new(input.clone_ctx(), plaintext_bd);
+        let plaintext_norm = PolyNorm::constant(input.clone_ctx(), plaintext_bd);
         ErrorNorm { matrix_norm, plaintext_norm }
     }
 }
@@ -288,7 +288,7 @@ impl AffinePltEvaluator for NormPltLWEEvaluator {
     ) -> ErrorNormSummaryExpr {
         let plaintext_bd =
             BigDecimal::from(num_bigint::BigInt::from(plt.max_output_row().1.value().clone()));
-        let plaintext_norm = PolyNorm::new(input.plaintext_norm.ctx.clone(), plaintext_bd);
+        let plaintext_norm = PolyNorm::constant(input.plaintext_norm.ctx.clone(), plaintext_bd);
         let matrix_expr = input
             .matrix_expr
             .transform_matrix(&self.k_low)
@@ -512,7 +512,7 @@ impl PltEvaluator<ErrorNorm> for NormPltGGH15Evaluator {
     ) -> ErrorNorm {
         let plaintext_bd =
             BigDecimal::from(num_bigint::BigInt::from(plt.max_output_row().1.value().clone()));
-        let plaintext_norm = PolyNorm::new(input.clone_ctx(), plaintext_bd);
+        let plaintext_norm = PolyNorm::constant(input.clone_ctx(), plaintext_bd);
         let plaintext_term = self.input_plaintext_multiplier.clone() * &input.plaintext_norm;
         let matrix_norm =
             &self.const_term + &plaintext_term + &input.matrix_norm * &self.e_input_multiplier;
@@ -530,7 +530,7 @@ impl AffinePltEvaluator for NormPltGGH15Evaluator {
     ) -> ErrorNormSummaryExpr {
         let plaintext_bd =
             BigDecimal::from(num_bigint::BigInt::from(plt.max_output_row().1.value().clone()));
-        let plaintext_norm = PolyNorm::new(input.plaintext_norm.ctx.clone(), plaintext_bd);
+        let plaintext_norm = PolyNorm::constant(input.plaintext_norm.ctx.clone(), plaintext_bd);
         let plaintext_term = self.input_plaintext_multiplier.clone() * &input.plaintext_norm;
         let matrix_expr = input
             .matrix_expr
@@ -641,7 +641,7 @@ impl PltEvaluator<ErrorNorm> for NormPltCommitEvaluator {
     ) -> ErrorNorm {
         let plaintext_bd =
             BigDecimal::from(num_bigint::BigInt::from(plt.max_output_row().1.value().clone()));
-        let plaintext_norm = PolyNorm::new(input.clone_ctx(), plaintext_bd);
+        let plaintext_norm = PolyNorm::constant(input.clone_ctx(), plaintext_bd);
         let ctx = input.clone_ctx();
         let m_b = ctx.m_b;
         let m_g = ctx.m_g;
@@ -666,7 +666,7 @@ impl AffinePltEvaluator for NormPltCommitEvaluator {
         let m_g = ctx.m_g;
         let plaintext_bd =
             BigDecimal::from(num_bigint::BigInt::from(plt.max_output_row().1.value().clone()));
-        let plaintext_norm = PolyNorm::new(input.plaintext_norm.ctx.clone(), plaintext_bd);
+        let plaintext_norm = PolyNorm::constant(input.plaintext_norm.ctx.clone(), plaintext_bd);
         let matrix_expr = input
             .matrix_expr
             .transform_matrix(&PolyMatrixNorm::gadget_decomposed(ctx, m_b))

--- a/src/simulator/eval_error/gates.rs
+++ b/src/simulator/eval_error/gates.rs
@@ -23,7 +23,7 @@ impl PolyCircuit<DCRTPoly> {
             PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_g, e_init_norm.clone(), None),
         );
         let input_error = ErrorNorm::new(
-            PolyNorm::new(ctx.clone(), input_norm_bound.clone()),
+            PolyNorm::constant(ctx.clone(), input_norm_bound.clone()),
             PolyMatrixNorm::new(ctx.clone(), 1, ctx.m_g, e_init_norm.clone(), None),
         );
         info!("e_init_norm bits {}", bigdecimal_bits_ceil(e_init_norm));

--- a/src/simulator/eval_error/mod.rs
+++ b/src/simulator/eval_error/mod.rs
@@ -59,6 +59,7 @@ type ErrorNormSubCircuitSummaryCache =
 struct ErrorNormPolyNormKey {
     ctx_id: usize,
     norm: String,
+    is_constant: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -124,7 +125,11 @@ struct ErrorNormSummaryRegistry {
 
 /// Convert a runtime `PolyNorm` into the reduced cache-key representation used by summary caches.
 fn error_norm_poly_norm_key(norm: &PolyNorm) -> ErrorNormPolyNormKey {
-    ErrorNormPolyNormKey { ctx_id: Arc::as_ptr(&norm.ctx) as usize, norm: norm.norm.to_string() }
+    ErrorNormPolyNormKey {
+        ctx_id: Arc::as_ptr(&norm.ctx) as usize,
+        norm: norm.norm.to_string(),
+        is_constant: norm.is_constant,
+    }
 }
 
 /// Build the cache key for one sub-circuit summary request.
@@ -179,8 +184,10 @@ fn validate_input_plaintext_norms_against_ranges(
         for range in ranges {
             let max_norm_bd = BigDecimal::from(num_bigint::BigInt::from(range.norm.clone()));
             normalized.extend(
-                std::iter::repeat_with(|| PolyNorm::new(Arc::clone(norm_ctx), max_norm_bd.clone()))
-                    .take(range.len()),
+                std::iter::repeat_with(|| {
+                    PolyNorm::constant(Arc::clone(norm_ctx), max_norm_bd.clone())
+                })
+                .take(range.len()),
             );
         }
         return Arc::from(normalized);
@@ -205,7 +212,7 @@ fn validate_input_plaintext_norms_against_ranges(
                 actual_norm.norm,
                 max_norm_bd
             );
-            normalized.push(PolyNorm::new(Arc::clone(norm_ctx), max_norm_bd.clone()));
+            normalized.push(PolyNorm::constant(Arc::clone(norm_ctx), max_norm_bd.clone()));
         }
     }
     Arc::from(normalized)
@@ -1009,7 +1016,7 @@ impl ErrorNormSummaryExpr {
         if scalar == &BigDecimal::one() {
             return self.clone();
         }
-        let scalar_poly = PolyNorm::new(self.plaintext_norm.ctx.clone(), scalar.clone());
+        let scalar_poly = PolyNorm::constant(self.plaintext_norm.ctx.clone(), scalar.clone());
         Self {
             plaintext_norm: self.plaintext_norm.clone() * &scalar_poly,
             matrix_expr: self.matrix_expr.transform_scalar(scalar),
@@ -1031,7 +1038,7 @@ impl ErrorNormSummaryExpr {
 
     fn small_scalar_mul_bound(&self, scalar: &[u32]) -> Self {
         let scalar_max = BigDecimal::from(*scalar.iter().max().unwrap());
-        let scalar_poly = PolyNorm::new(self.plaintext_norm.ctx.clone(), scalar_max.clone());
+        let scalar_poly = PolyNorm::constant(self.plaintext_norm.ctx.clone(), scalar_max.clone());
         Self {
             plaintext_norm: self.plaintext_norm.clone() * &scalar_poly,
             matrix_expr: self.matrix_expr.transform_scalar(&scalar_max),
@@ -1041,7 +1048,7 @@ impl ErrorNormSummaryExpr {
     fn large_scalar_mul_bound(&self, scalar: &[BigUint]) -> Self {
         let scalar_max = scalar.iter().max().unwrap().clone();
         let scalar_bd = BigDecimal::from(num_bigint::BigInt::from(scalar_max));
-        let scalar_poly = PolyNorm::new(self.plaintext_norm.ctx.clone(), scalar_bd);
+        let scalar_poly = PolyNorm::constant(self.plaintext_norm.ctx.clone(), scalar_bd);
         Self {
             plaintext_norm: self.plaintext_norm.clone() * &scalar_poly,
             matrix_expr: self.matrix_expr.transform_matrix(&PolyMatrixNorm::gadget_decomposed(

--- a/src/simulator/eval_error/summary.rs
+++ b/src/simulator/eval_error/summary.rs
@@ -910,7 +910,7 @@ impl PolyCircuit<DCRTPoly> {
                         let scalar_max =
                             *scalar.resolve_small_scalar(param_bindings).iter().max().unwrap();
                         let scalar_bd = BigDecimal::from(scalar_max);
-                        let scalar_poly = PolyNorm::new(norm_ctx.clone(), scalar_bd);
+                        let scalar_poly = PolyNorm::constant(norm_ctx.clone(), scalar_bd);
                         plaintext_norms
                             .get(&gate.input_gates[0])
                             .unwrap_or_else(|| {
@@ -927,7 +927,7 @@ impl PolyCircuit<DCRTPoly> {
                             .unwrap()
                             .clone();
                         let scalar_bd = BigDecimal::from(num_bigint::BigInt::from(scalar_max));
-                        let scalar_poly = PolyNorm::new(norm_ctx.clone(), scalar_bd);
+                        let scalar_poly = PolyNorm::constant(norm_ctx.clone(), scalar_bd);
                         plaintext_norms
                             .get(&gate.input_gates[0])
                             .unwrap_or_else(|| {
@@ -944,7 +944,7 @@ impl PolyCircuit<DCRTPoly> {
                             .max()
                             .unwrap_or(1);
                         let scalar_bd = BigDecimal::from(scalar_max);
-                        let scalar_poly = PolyNorm::new(norm_ctx.clone(), scalar_bd);
+                        let scalar_poly = PolyNorm::constant(norm_ctx.clone(), scalar_bd);
                         plaintext_norms
                             .get(&gate.input_gates[0])
                             .unwrap_or_else(|| {
@@ -975,7 +975,7 @@ impl PolyCircuit<DCRTPoly> {
                         let plaintext_bd = BigDecimal::from(num_bigint::BigInt::from(
                             plt.max_output_row().1.value().clone(),
                         ));
-                        PolyNorm::new(norm_ctx.clone(), plaintext_bd)
+                        PolyNorm::constant(norm_ctx.clone(), plaintext_bd)
                     }
                     PolyGateType::Input => {
                         panic!("input gate {gate_id} should already have a plaintext norm")

--- a/src/simulator/eval_error/tests.rs
+++ b/src/simulator/eval_error/tests.rs
@@ -43,7 +43,7 @@ fn simulate_max_error_norm_via_generic_eval_reference<P: AffinePltEvaluator>(
 }
 
 const E_B_SIGMA: f64 = 4.0;
-const E_INIT_NORM: u32 = 1 << 14;
+const E_INIT_NORM: u32 = 26;
 
 #[test]
 fn test_compute_preimage_norm_uses_optional_sigma() {
@@ -57,6 +57,26 @@ fn test_compute_preimage_norm_uses_optional_sigma() {
 
     assert_eq!(default_norm, explicit_default_norm);
     assert!(larger_sigma_norm > default_norm);
+}
+
+#[test]
+fn test_constant_poly_norm_mul_skips_ring_dim_sqrt() {
+    let ctx = make_ctx();
+    let lhs = PolyNorm::constant(ctx.clone(), BigDecimal::from(3u64));
+    let rhs = PolyNorm::constant(ctx.clone(), BigDecimal::from(5u64));
+    let product = &lhs * &rhs;
+
+    assert_eq!(product.norm, BigDecimal::from(15u64));
+    assert!(product.is_constant);
+
+    let general = PolyNorm::new(ctx.clone(), BigDecimal::from(5u64));
+    let mixed = &lhs * &general;
+    assert_eq!(mixed.norm, BigDecimal::from(15u64));
+    assert!(!mixed.is_constant);
+
+    let general_product = &general * &general;
+    assert_eq!(general_product.norm, BigDecimal::from(25u64) * &ctx.ring_dim_sqrt);
+    assert!(!general_product.is_constant);
 }
 
 #[test]
@@ -169,10 +189,10 @@ fn test_wire_norm_simulator_multiplication_matches_generic_eval() {
 
 #[test]
 fn test_wire_norm_simulator_mul_binary_tree_plaintext_one_matches_generic_eval() {
-    let tree_height = 10usize;
+    let tree_height = 12usize;
     let input_size = 1usize << tree_height;
     let input_plaintext_norm = BigDecimal::one();
-    let ring_dim_sqrt = BigDecimal::from(1u64 << 16);
+    let ring_dim_sqrt = BigDecimal::from(1u64 << 8);
     let base = BigDecimal::from(14u64);
     let secret_size = 1usize;
     let log_base_q = 2usize * 30;

--- a/src/simulator/poly_norm.rs
+++ b/src/simulator/poly_norm.rs
@@ -10,44 +10,73 @@ use std::{
 pub struct PolyNorm {
     pub ctx: Arc<SimulatorContext>,
     pub norm: BigDecimal,
+    pub is_constant: bool,
 }
 
 impl PolyNorm {
     pub fn new(ctx: Arc<SimulatorContext>, norm: BigDecimal) -> Self {
-        PolyNorm { ctx, norm }
+        PolyNorm { ctx, norm, is_constant: false }
+    }
+
+    pub fn constant(ctx: Arc<SimulatorContext>, norm: BigDecimal) -> Self {
+        PolyNorm { ctx, norm, is_constant: true }
+    }
+
+    pub fn into_constant(mut self) -> Self {
+        self.is_constant = true;
+        self
     }
 
     pub fn one(ctx: Arc<SimulatorContext>) -> Self {
-        Self::new(ctx, BigDecimal::one())
+        Self::constant(ctx, BigDecimal::one())
     }
 
     pub fn sample_gauss(ctx: Arc<SimulatorContext>, sigma: BigDecimal) -> Self {
         let norm = sigma * BigDecimal::from_f32(6.5).unwrap();
-        PolyNorm { ctx, norm }
+        PolyNorm { ctx, norm, is_constant: false }
     }
 }
 
 impl_binop_with_refs!(PolyNorm => Add::add(self, rhs: &PolyNorm) -> PolyNorm {
     assert!(self.ctx == rhs.ctx, "ctx must match");
-    PolyNorm { ctx: self.ctx.clone(), norm: &self.norm + &rhs.norm }
+    PolyNorm {
+        ctx: self.ctx.clone(),
+        norm: &self.norm + &rhs.norm,
+        is_constant: self.is_constant && rhs.is_constant,
+    }
 });
 
 impl AddAssign for PolyNorm {
     fn add_assign(&mut self, rhs: Self) {
         assert!(self.ctx == rhs.ctx, "ctx must match");
         self.norm += rhs.norm;
+        self.is_constant = self.is_constant && rhs.is_constant;
     }
 }
 
 impl_binop_with_refs!(PolyNorm => Mul::mul(self, rhs: &PolyNorm) -> PolyNorm {
     assert!(self.ctx == rhs.ctx, "ctx must match");
-    PolyNorm { ctx: self.ctx.clone(), norm: &self.norm * &rhs.norm * &self.ctx.ring_dim_sqrt }
+    let mut norm = &self.norm * &rhs.norm;
+    if !self.is_constant && !rhs.is_constant {
+        norm *= &self.ctx.ring_dim_sqrt;
+    }
+    PolyNorm {
+        ctx: self.ctx.clone(),
+        norm,
+        is_constant: self.is_constant && rhs.is_constant,
+    }
 });
 
 impl MulAssign for PolyNorm {
     fn mul_assign(&mut self, rhs: Self) {
         assert!(self.ctx == rhs.ctx, "ctx must match");
-        self.norm = &self.norm * rhs.norm * &self.ctx.ring_dim_sqrt;
+        let lhs_is_constant = self.is_constant;
+        let rhs_is_constant = rhs.is_constant;
+        self.norm = &self.norm * rhs.norm;
+        if !lhs_is_constant && !rhs_is_constant {
+            self.norm *= &self.ctx.ring_dim_sqrt;
+        }
+        self.is_constant = lhs_is_constant && rhs_is_constant;
     }
 }
 
@@ -61,13 +90,13 @@ impl Mul<BigDecimal> for PolyNorm {
 impl Mul<&BigDecimal> for PolyNorm {
     type Output = Self;
     fn mul(self, rhs: &BigDecimal) -> Self::Output {
-        PolyNorm { ctx: self.ctx, norm: self.norm * rhs }
+        PolyNorm { ctx: self.ctx, norm: self.norm * rhs, is_constant: self.is_constant }
     }
 }
 
 impl Mul<PolyNorm> for BigDecimal {
     type Output = PolyNorm;
     fn mul(self, rhs: PolyNorm) -> Self::Output {
-        PolyNorm { ctx: rhs.ctx, norm: rhs.norm * self }
+        PolyNorm { ctx: rhs.ctx, norm: rhs.norm * self, is_constant: rhs.is_constant }
     }
 }


### PR DESCRIPTION
## Summary
- Add constant-polynomial metadata to `PolyNorm` and skip `ring_dim_sqrt` when multiplying constant plaintext bounds.
- Propagate constant plaintext semantics through `ErrorNorm`, PLT evaluators, summary handling, and simulator entry points.
- Add a focused unit test covering constant vs general `PolyNorm` multiplication.

## Testing
- `cargo +nightly fmt --all`
- `cargo test simulator::eval_error::tests:: --lib -- --nocapture`
- `cargo build --lib`