### PR TITLE
Refactor Diamond injector to per-state B checkpoints

### DIFF
--- a/src/input_injector/diamond_gpu.rs
+++ b/src/input_injector/diamond_gpu.rs
@@ -16,9 +16,9 @@ where
 {
     device_id: i32,
     params: <M::P as Poly>::Params,
-    source_b: M,
-    source_trapdoor: T,
-    target_b: M,
+    source_b_by_state: Vec<M>,
+    source_trapdoor_by_state: Vec<T>,
+    target_b_by_state: Vec<M>,
 }
 
 struct LoadedDiamondPreprocessChunk<M>
@@ -27,7 +27,6 @@ where
 {
     device_slot: usize,
     task: DiamondPreprocessChunkTask,
-    ext_matrix: M,
     target: M,
     load_s: f64,
 }
@@ -144,27 +143,39 @@ where
 
     fn prepare_gpu_k_stage_shared(
         &self,
-        source_b_bytes: &[u8],
-        source_trapdoor_bytes: &[u8],
-        target_b_bytes: &[u8],
+        source_checkpoint_bytes: &[(Arc<[u8]>, Arc<[u8]>)],
+        target_b_bytes: &[Arc<[u8]>],
     ) -> Vec<GpuDiamondKStageShared<M, TS::Trapdoor>> {
         self.effective_gpu_device_ids()
             .into_par_iter()
             .map(|device_id| {
                 let local_params = self.params.params_for_device(device_id);
-                let source_trapdoor = TS::trapdoor_from_bytes(&local_params, source_trapdoor_bytes)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "DiamondInjector failed to decode K-stage trapdoor checkpoint on device {}",
-                            device_id
-                        )
-                    });
+                let source_b_by_state = source_checkpoint_bytes
+                    .iter()
+                    .map(|(b_bytes, _)| M::from_compact_bytes(&local_params, b_bytes.as_ref()))
+                    .collect::<Vec<_>>();
+                let source_trapdoor_by_state = source_checkpoint_bytes
+                    .iter()
+                    .map(|(_, trapdoor_bytes)| {
+                        TS::trapdoor_from_bytes(&local_params, trapdoor_bytes.as_ref())
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "DiamondInjector failed to decode K-stage trapdoor checkpoint on device {}",
+                                    device_id
+                                )
+                            })
+                    })
+                    .collect::<Vec<_>>();
+                let target_b_by_state = target_b_bytes
+                    .iter()
+                    .map(|bytes| M::from_compact_bytes(&local_params, bytes.as_ref()))
+                    .collect::<Vec<_>>();
                 GpuDiamondKStageShared {
                     device_id,
                     params: local_params.clone(),
-                    source_b: M::from_compact_bytes(&local_params, source_b_bytes),
-                    source_trapdoor,
-                    target_b: M::from_compact_bytes(&local_params, target_b_bytes),
+                    source_b_by_state,
+                    source_trapdoor_by_state,
+                    target_b_by_state,
                 }
             })
             .collect()
@@ -233,12 +244,10 @@ where
     fn preprocess_k_stage_gpu(
         &self,
         dir_path: &Path,
-        hash_key: [u8; 32],
         level: usize,
         tasks: Vec<DiamondPreprocessChunkTask>,
-        source_b_bytes: &[u8],
-        source_trapdoor_bytes: &[u8],
-        target_b_bytes: &[u8],
+        source_checkpoint_bytes: &[(Arc<[u8]>, Arc<[u8]>)],
+        target_b_bytes: &[Arc<[u8]>],
         secret_mask_bytes: &HashMap<usize, Arc<[u8]>>,
     ) -> usize {
         if tasks.is_empty() {
@@ -248,7 +257,7 @@ where
         let stage_started = Instant::now();
         let trap_sampler = TS::new(&self.params, self.trapdoor_sigma);
         let shared_by_device =
-            self.prepare_gpu_k_stage_shared(source_b_bytes, source_trapdoor_bytes, target_b_bytes);
+            self.prepare_gpu_k_stage_shared(source_checkpoint_bytes, target_b_bytes);
         let device_count = shared_by_device.len().max(1);
         let task_batches = round_robin_batches(&tasks, device_count);
         let wave_count = task_batches.iter().map(Vec::len).max().unwrap_or(0);
@@ -288,24 +297,13 @@ where
                             })
                             .as_ref(),
                     );
-                    let ext_matrix = if self.new_bit_idx_for_state(level, state_idx).is_some() {
-                        self.sample_w_block_with_params(&shared.params, hash_key, 0, level - 1)
-                    } else {
-                        self.sample_w_block_with_params(
-                            &shared.params,
-                            hash_key,
-                            state_idx,
-                            level - 1,
-                        )
-                    };
                     let target = self.build_k_target_chunk_with_params(
                         &shared.params,
-                        hash_key,
                         level,
                         digit_value,
                         state_idx,
                         &secret_mask,
-                        &shared.target_b,
+                        &shared.target_b_by_state[state_idx],
                         chunk_idx,
                     );
                     drop(secret_mask);
@@ -321,7 +319,6 @@ where
                     Some(LoadedDiamondPreprocessChunk {
                         device_slot,
                         task,
-                        ext_matrix,
                         target,
                         load_s: maybe_elapsed_s(load_started),
                     })
@@ -336,11 +333,12 @@ where
                 .map(|loaded| {
                     let shared = &shared_by_device[loaded.device_slot];
                     let compute_started = Instant::now();
-                    let output = trap_sampler.preimage_extend(
+                    let DiamondPreprocessChunkTask::K { level, state_idx, .. } = loaded.task;
+                    let source_state_idx = self.transition_source_state_idx(level, state_idx);
+                    let output = trap_sampler.preimage(
                         &shared.params,
-                        &shared.source_trapdoor,
-                        &shared.source_b,
-                        &loaded.ext_matrix,
+                        &shared.source_trapdoor_by_state[source_state_idx],
+                        &shared.source_b_by_state[source_state_idx],
                         &loaded.target,
                     );
                     ComputedDiamondPreprocessChunk {
@@ -563,16 +561,9 @@ where
             .collect()
     }
 
-    pub(super) fn preprocess_gpu(&self, dir_path: &Path, hash_key: [u8; 32], k: &M::P) {
+    pub(super) fn preprocess_gpu(&self, dir_path: &Path, k: &M::P) {
         self.ensure_dir(dir_path);
-        self.write_metadata(
-            dir_path,
-            &super::DiamondInjectorMetadata {
-                input_count: self.input_count,
-                base: self.base,
-                batch_bits: self.batch_bits,
-            },
-        );
+        self.write_metadata(dir_path, &self.current_metadata());
         self.write_bytes(dir_path, self.k_plaintext_id(), &k.to_compact_bytes());
 
         let preprocess_started = Instant::now();
@@ -585,10 +576,10 @@ where
         let secret_epsilon_bytes =
             self.load_or_sample_secret_epsilon_bytes(dir_path, self.secret_epsilon_id());
         if !self.matrix_exists(dir_path, self.p_epsilon_id()) {
-            let (b0_bytes, _) = self.load_or_sample_b_checkpoint_bytes(dir_path, 0);
+            let (b0_bytes, _) = self.load_or_sample_b_checkpoint_bytes(dir_path, 0, 0);
             let b0_matrix = M::from_compact_bytes(&self.params, &b0_bytes);
             let secret_epsilon = M::from_compact_bytes(&self.params, &secret_epsilon_bytes);
-            let p_epsilon = self.build_initial_encoding(hash_key, &b0_matrix, &secret_epsilon, k);
+            let p_epsilon = self.build_initial_encoding(&b0_matrix, &secret_epsilon, k);
             self.write_matrix(dir_path, self.p_epsilon_id(), &p_epsilon);
             drop(p_epsilon);
             drop(secret_epsilon);
@@ -615,7 +606,7 @@ where
                 .collect::<HashMap<_, _>>();
             let mut stage_tasks = Vec::new();
             for digit_value in 0..self.base {
-                for state_idx in 0..self.expanded_state_count_after_level(level) {
+                for state_idx in 0..self.state_count_at_level(level) {
                     for chunk_idx in 0..column_chunk_count(state_cols) {
                         let task = DiamondPreprocessChunkTask::K {
                             level,
@@ -630,9 +621,20 @@ where
                 }
             }
             total_tasks += stage_tasks.len();
-            let (source_b_bytes, source_trapdoor_bytes) =
-                self.load_or_sample_b_checkpoint_bytes(dir_path, level - 1);
-            let (target_b_bytes, _) = self.load_or_sample_b_checkpoint_bytes(dir_path, level);
+            let source_checkpoint_bytes = (0..self.state_count_at_level(level - 1))
+                .map(|source_idx| {
+                    let (b_bytes, t_bytes) =
+                        self.load_or_sample_b_checkpoint_bytes(dir_path, level - 1, source_idx);
+                    (Arc::<[u8]>::from(b_bytes), Arc::<[u8]>::from(t_bytes))
+                })
+                .collect::<Vec<_>>();
+            let target_b_bytes = (0..self.state_count_at_level(level))
+                .map(|state_idx| {
+                    let (b_bytes, _) =
+                        self.load_or_sample_b_checkpoint_bytes(dir_path, level, state_idx);
+                    Arc::<[u8]>::from(b_bytes)
+                })
+                .collect::<Vec<_>>();
             if stage_tasks.is_empty() {
                 info!(
                     level,
@@ -642,11 +644,9 @@ where
             } else {
                 completed_tasks += self.preprocess_k_stage_gpu(
                     dir_path,
-                    hash_key,
                     level,
                     stage_tasks,
-                    &source_b_bytes,
-                    &source_trapdoor_bytes,
+                    &source_checkpoint_bytes,
                     &target_b_bytes,
                     &secret_mask_bytes,
                 );
@@ -677,20 +677,12 @@ where
     ) -> Vec<M> {
         self.validate_digits(input_digits);
         assert_eq!(
-            self.read_bytes(dir_path, self.preprocess_hash_key_id()).as_slice(),
-            &preprocess_out.hash_key,
-            "DiamondInjector gpu online_eval preprocess hash key mismatch"
+            preprocess_out.final_state_count(),
+            self.state_count_at_level(self.input_count),
+            "DiamondInjector final checkpoint count mismatch"
         );
         let metadata = self.read_metadata(dir_path);
-        assert_eq!(
-            metadata.input_count, self.input_count,
-            "DiamondInjector metadata input count mismatch"
-        );
-        assert_eq!(metadata.base, self.base, "DiamondInjector metadata base mismatch");
-        assert_eq!(
-            metadata.batch_bits, self.batch_bits,
-            "DiamondInjector metadata batch_bits mismatch"
-        );
+        self.assert_current_metadata(&metadata);
 
         let online_started = Instant::now();
         let state_cols = self.state_col_size(&self.params);
@@ -704,7 +696,7 @@ where
             // Schedule one matrix-product family per active branch. The helper
             // below splits the right-hand-side chunks across devices and then
             // reassembles each branch on CPU from compact bytes.
-            let family_specs = (0..self.expanded_state_count_after_level(level))
+            let family_specs = (0..self.state_count_at_level(level))
                 .map(|state_idx| {
                     let lhs_bytes = if self.new_bit_idx_for_state(level, state_idx).is_some() {
                         prev_p0_bytes.clone()
@@ -722,7 +714,7 @@ where
                 })
                 .collect::<HashMap<_, _>>();
             let outputs = self.gpu_left_mul_families(family_specs);
-            states = (0..self.expanded_state_count_after_level(level))
+            states = (0..self.state_count_at_level(level))
                 .map(|state_idx| {
                     outputs
                         .get(&DiamondEvalFamily::State(state_idx))
@@ -826,9 +818,7 @@ mod tests {
             );
             secret_matrix = secret_matrix * secret_mask;
         }
-        let base_public_matrix =
-            preprocess_out.final_pub_matrix.concat_columns(&[&injector
-                .sample_w_block_with_params(&params, preprocess_out.hash_key, 0, input_count)]);
+        let base_public_matrix = preprocess_out.final_pub_matrices[0].clone();
         let base_selector = GpuDCRTPolyMatrix::from_poly_vec_row(
             &params,
             vec![secret_matrix.entry(0, 0), k.clone()],
@@ -840,14 +830,7 @@ mod tests {
                 let state_idx = injector.bit_state_idx(digit_idx, bit_idx);
                 let bit_value = ((digits[digit_idx] as usize) >> bit_idx) & 1;
                 let bit_plaintext = TestPoly::from_usize_to_constant(&params, bit_value);
-                let bit_public_matrix =
-                    preprocess_out.final_pub_matrix.concat_columns(&[&injector
-                        .sample_w_block_with_params(
-                            &params,
-                            preprocess_out.hash_key,
-                            state_idx,
-                            input_count,
-                        )]);
+                let bit_public_matrix = preprocess_out.final_pub_matrices[state_idx].clone();
                 let bit_selector = GpuDCRTPolyMatrix::from_poly_vec_row(
                     &params,
                     vec![secret_matrix.entry(0, 0), secret_matrix.entry(0, 0) * &bit_plaintext],

--- a/src/input_injector/mod.rs
+++ b/src/input_injector/mod.rs
@@ -72,17 +72,38 @@ struct DiamondInjectorMetadata {
 #[derive(Debug, Clone)]
 /// Compact in-memory data returned by Diamond preprocessing.
 ///
-/// `hash_key` identifies the hash-derived transition public matrices, while
-/// `final_trapdoor` and `final_pub_matrix` are the trapdoor pair for the final
-/// Diamond state basis. Callers use that pair to sample their own final output
-/// projection preimages.
+/// Callers use the final state-specific trapdoor public bases to sample their
+/// own final output projection preimages.
 pub struct DiamondInjectorPreprocessOut<M, T>
 where
     M: PolyMatrix,
 {
-    pub hash_key: [u8; 32],
-    pub final_trapdoor: T,
-    pub final_pub_matrix: M,
+    pub final_trapdoors: Vec<T>,
+    pub final_pub_matrices: Vec<M>,
+}
+
+impl<M, T> DiamondInjectorPreprocessOut<M, T>
+where
+    M: PolyMatrix,
+{
+    pub fn final_state_count(&self) -> usize {
+        debug_assert_eq!(
+            self.final_trapdoors.len(),
+            self.final_pub_matrices.len(),
+            "DiamondInjector final checkpoint vector length mismatch"
+        );
+        self.final_pub_matrices.len()
+    }
+
+    pub fn final_checkpoint(&self, state_idx: usize) -> (&T, &M) {
+        assert!(
+            state_idx < self.final_state_count(),
+            "DiamondInjector final state index out of range: {} >= {}",
+            state_idx,
+            self.final_state_count()
+        );
+        (&self.final_trapdoors[state_idx], &self.final_pub_matrices[state_idx])
+    }
 }
 
 impl<M, US, HS, TS> DiamondInjector<M, US, HS, TS>
@@ -175,6 +196,26 @@ where
         serde_json::from_slice(&bytes).expect("DiamondInjector metadata should decode")
     }
 
+    fn current_metadata(&self) -> DiamondInjectorMetadata {
+        DiamondInjectorMetadata {
+            input_count: self.input_count,
+            base: self.base,
+            batch_bits: self.batch_bits,
+        }
+    }
+
+    fn assert_current_metadata(&self, metadata: &DiamondInjectorMetadata) {
+        assert_eq!(
+            metadata.input_count, self.input_count,
+            "DiamondInjector metadata input count mismatch"
+        );
+        assert_eq!(metadata.base, self.base, "DiamondInjector metadata base mismatch");
+        assert_eq!(
+            metadata.batch_bits, self.batch_bits,
+            "DiamondInjector metadata batch_bits mismatch"
+        );
+    }
+
     fn write_matrix(&self, dir_path: &Path, id: &str, matrix: &M) {
         self.write_matrix_bytes(dir_path, id, &matrix.to_compact_bytes());
     }
@@ -232,8 +273,6 @@ where
 
     fn state_col_size(&self, params: &<M::P as Poly>::Params) -> usize {
         self.b_public_col_size(params)
-            .checked_add(self.gadget_col_size(params))
-            .expect("DiamondInjector state column count overflow")
     }
 
     fn chunk_id(&self, id: &str, chunk_idx: usize) -> String {
@@ -248,42 +287,24 @@ where
         format!("diamond_secret_tensor_{level}_{digit_value}")
     }
 
-    fn b_matrix_id(&self, level: usize) -> String {
-        format!("diamond_b_tensor_{level}")
+    fn b_matrix_id(&self, level: usize, state_idx: usize) -> String {
+        format!("diamond_b_tensor_{level}_{state_idx}")
     }
 
-    fn b_trapdoor_id(&self, level: usize) -> String {
-        format!("diamond_b_tensor_{level}_trapdoor")
+    fn b_trapdoor_id(&self, level: usize, state_idx: usize) -> String {
+        format!("diamond_b_tensor_{level}_{state_idx}_trapdoor")
     }
 
     fn p_epsilon_id(&self) -> &'static str {
-        "diamond_p_epsilon_tensor_0"
+        "diamond_initial_state_tensor"
     }
 
     fn k_plaintext_id(&self) -> &'static str {
         "diamond_k_plaintext"
     }
 
-    fn preprocess_hash_key_id(&self) -> &'static str {
-        "diamond_preprocess_hash_key"
-    }
-
     fn k_id(&self, level: usize, digit_value: usize, state_idx: usize) -> String {
-        format!("diamond_k_bit_tensor_{level}_{digit_value}_{state_idx}")
-    }
-
-    fn load_or_sample_preprocess_hash_key(&self, dir_path: &Path) -> [u8; 32] {
-        let id = self.preprocess_hash_key_id();
-        if self.bytes_exists(dir_path, id) {
-            let bytes = self.read_bytes(dir_path, id);
-            return bytes
-                .as_slice()
-                .try_into()
-                .unwrap_or_else(|_| panic!("DiamondInjector preprocess hash key must be 32 bytes"));
-        }
-        let hash_key = rand::random::<[u8; 32]>();
-        self.write_bytes(dir_path, id, &hash_key);
-        hash_key
+        format!("diamond_transition_tensor_{level}_{digit_value}_{state_idx}")
     }
 
     fn sample_secret_epsilon_with_params(&self, params: &<M::P as Poly>::Params) -> M {
@@ -318,7 +339,7 @@ where
         self.batch_bits
     }
 
-    fn expanded_state_count_after_level(&self, level: usize) -> usize {
+    fn state_count_at_level(&self, level: usize) -> usize {
         1usize
             .checked_add(
                 level
@@ -364,6 +385,11 @@ where
         let end =
             first.checked_add(self.batch_bits()).expect("DiamondInjector bit state index overflow");
         if (first..end).contains(&state_idx) { Some(state_idx - first) } else { None }
+    }
+
+    fn transition_source_state_idx(&self, level: usize, state_idx: usize) -> usize {
+        assert!(level > 0, "DiamondInjector transition level must be positive");
+        if self.new_bit_idx_for_state(level, state_idx).is_some() { 0 } else { state_idx }
     }
 
     pub fn digit_bit_value(&self, digit_value: usize, bit_idx: usize) -> usize {
@@ -437,19 +463,22 @@ where
     }
 
     #[cfg(not(feature = "gpu"))]
-    fn load_or_sample_b_checkpoint(&self, dir_path: &Path, level: usize) -> (TS::Trapdoor, M) {
-        // Checkpoint one trapdoor public matrix per level. Later preimage
-        // sampling uses this stored pair as the source side of a
-        // preimage_extend call, while the hashed W blocks are reconstructed on
-        // demand.
-        let matrix_id = self.b_matrix_id(level);
-        let trapdoor_id = self.b_trapdoor_id(level);
+    fn load_or_sample_b_checkpoint(
+        &self,
+        dir_path: &Path,
+        level: usize,
+        state_idx: usize,
+    ) -> (TS::Trapdoor, M) {
+        // Checkpoint one trapdoor public matrix per level/state. Later
+        // preimage sampling uses this stored pair directly.
+        let matrix_id = self.b_matrix_id(level, state_idx);
+        let trapdoor_id = self.b_trapdoor_id(level, state_idx);
         if self.matrix_exists(dir_path, &matrix_id) && self.bytes_exists(dir_path, &trapdoor_id) {
             let trapdoor =
                 TS::trapdoor_from_bytes(&self.params, &self.read_bytes(dir_path, &trapdoor_id))
                     .unwrap_or_else(|| {
                         panic!(
-                            "DiamondInjector failed to decode trapdoor checkpoint for level {level}"
+                            "DiamondInjector failed to decode trapdoor checkpoint for level {level}, state {state_idx}"
                         )
                     });
             let matrix = self.read_matrix(dir_path, &matrix_id);
@@ -468,9 +497,10 @@ where
         &self,
         dir_path: &Path,
         level: usize,
+        state_idx: usize,
     ) -> (Vec<u8>, Vec<u8>) {
-        let matrix_id = self.b_matrix_id(level);
-        let trapdoor_id = self.b_trapdoor_id(level);
+        let matrix_id = self.b_matrix_id(level, state_idx);
+        let trapdoor_id = self.b_trapdoor_id(level, state_idx);
         if self.matrix_exists(dir_path, &matrix_id) && self.bytes_exists(dir_path, &trapdoor_id) {
             return (
                 self.read_matrix_bytes(dir_path, &matrix_id),
@@ -487,87 +517,21 @@ where
         (matrix_bytes, trapdoor_bytes)
     }
 
-    fn sample_w_block_with_params(
-        &self,
-        params: &<M::P as Poly>::Params,
-        hash_key: [u8; 32],
-        block_idx: usize,
-        level: usize,
-    ) -> M {
-        // Reconstruct one deterministic hashed extension block W_{block_idx,
-        // level}. This keeps preprocessing storage focused on preimages rather
-        // than on the hash-derived public side.
-        HS::new().sample_hash(
-            params,
-            hash_key,
-            format!("diamond_w_{block_idx}_{level}"),
-            self.state_row_size(),
-            self.gadget_col_size(params),
-            DistType::FinRingDist,
-        )
-    }
-
-    fn sample_w_block_columns_with_params(
-        &self,
-        params: &<M::P as Poly>::Params,
-        hash_key: [u8; 32],
-        block_idx: usize,
-        level: usize,
-        col_start: usize,
-        col_len: usize,
-    ) -> M {
-        HS::new().sample_hash_columns(
-            params,
-            hash_key,
-            format!("diamond_w_{block_idx}_{level}"),
-            self.state_row_size(),
-            self.gadget_col_size(params),
-            col_start,
-            col_len,
-            DistType::FinRingDist,
-        )
-    }
-
     fn state_public_chunk_with_params(
         &self,
         params: &<M::P as Poly>::Params,
-        hash_key: [u8; 32],
         b_matrix: &M,
-        block_idx: usize,
-        level: usize,
         chunk_idx: usize,
     ) -> M {
-        // Materialize a column slice of the effective public matrix
-        // (B_level | W_{block_idx, level}). Transition matrices, one-outputs,
-        // bit-outputs, and decoder outputs are all sampled against this
-        // concatenated view.
         let total_cols = self.state_col_size(params);
-        let b_cols = self.b_public_col_size(params);
         let (col_start, col_len) = column_chunk_bounds(total_cols, chunk_idx);
         let col_end = col_start + col_len;
-        if col_end <= b_cols {
-            return b_matrix.slice_columns(col_start, col_end);
-        }
-        if col_start >= b_cols {
-            return self.sample_w_block_columns_with_params(
-                params,
-                hash_key,
-                block_idx,
-                level,
-                col_start - b_cols,
-                col_len,
-            );
-        }
-        let b_chunk = b_matrix.slice_columns(col_start, b_cols);
-        let w_chunk = self.sample_w_block_columns_with_params(
-            params,
-            hash_key,
-            block_idx,
-            level,
-            0,
-            col_end - b_cols,
+        debug_assert_eq!(
+            b_matrix.col_size(),
+            total_cols,
+            "DiamondInjector B matrix column count must equal state_col_size"
         );
-        b_chunk.concat_columns(&[&w_chunk])
+        b_matrix.slice_columns(col_start, col_end)
     }
 
     fn transition_selector_with_params(
@@ -609,19 +573,12 @@ where
         top.concat_rows(&[&bottom])
     }
 
-    fn build_initial_encoding(
-        &self,
-        hash_key: [u8; 32],
-        b0_matrix: &M,
-        secret_epsilon: &M,
-        k: &M::P,
-    ) -> M {
+    fn build_initial_encoding(&self, b0_matrix: &M, secret_epsilon: &M, k: &M::P) -> M {
         // Build the state that represents the empty input prefix. It is the
         // only online-evaluation seed that exists before any digit is chosen.
         let selector =
             M::from_poly_vec_row(&self.params, vec![secret_epsilon.entry(0, 0), k.clone()]);
-        let w00 = self.sample_w_block_with_params(&self.params, hash_key, 0, 0);
-        let mut p_epsilon = selector * b0_matrix.concat_columns(&[&w00]);
+        let mut p_epsilon = selector * b0_matrix;
         p_epsilon.add_in_place(&self.sample_error_matrix_with_dims(
             &self.params,
             1,
@@ -633,7 +590,6 @@ where
     fn build_k_target_chunk_with_params(
         &self,
         params: &<M::P as Poly>::Params,
-        hash_key: [u8; 32],
         level: usize,
         digit_value: usize,
         state_idx: usize,
@@ -645,9 +601,7 @@ where
         // transition matrix. Existing branches use the identity-style selector,
         // while each newly born branch for the current digit uses the special
         // selector above so one chosen bit is embedded into that path.
-        let public_chunk = self.state_public_chunk_with_params(
-            params, hash_key, b_matrix, state_idx, level, chunk_idx,
-        );
+        let public_chunk = self.state_public_chunk_with_params(params, b_matrix, chunk_idx);
         let selector = if let Some(bit_idx) = self.new_bit_idx_for_state(level, state_idx) {
             let bit_value = self.digit_bit_value(digit_value, bit_idx);
             self.special_transition_selector_with_params(params, bit_value, secret_mask)
@@ -726,42 +680,47 @@ where
     type State = M;
 
     fn preprocess(&self, dir_path: &Path, k: &M::P) -> Self::PreprocessOut {
-        let hash_key = self.load_or_sample_preprocess_hash_key(dir_path);
         #[cfg(feature = "gpu")]
         {
-            self.preprocess_gpu(dir_path, hash_key, k);
-            let (final_pub_matrix_bytes, final_trapdoor_bytes) =
-                self.load_or_sample_b_checkpoint_bytes(dir_path, self.input_count);
-            return DiamondInjectorPreprocessOut {
-                hash_key,
-                final_trapdoor: TS::trapdoor_from_bytes(&self.params, &final_trapdoor_bytes)
-                    .expect("DiamondInjector final trapdoor checkpoint must decode"),
-                final_pub_matrix: M::from_compact_bytes(&self.params, &final_pub_matrix_bytes),
-            };
+            self.preprocess_gpu(dir_path, k);
+            let mut final_trapdoors =
+                Vec::with_capacity(self.state_count_at_level(self.input_count));
+            let mut final_pub_matrices =
+                Vec::with_capacity(self.state_count_at_level(self.input_count));
+            for state_idx in 0..self.state_count_at_level(self.input_count) {
+                let (final_pub_matrix_bytes, final_trapdoor_bytes) =
+                    self.load_or_sample_b_checkpoint_bytes(dir_path, self.input_count, state_idx);
+                final_trapdoors.push(
+                    TS::trapdoor_from_bytes(&self.params, &final_trapdoor_bytes)
+                        .expect("DiamondInjector final trapdoor checkpoint must decode"),
+                );
+                final_pub_matrices
+                    .push(M::from_compact_bytes(&self.params, &final_pub_matrix_bytes));
+            }
+            return DiamondInjectorPreprocessOut { final_trapdoors, final_pub_matrices };
         }
 
         #[cfg(not(feature = "gpu"))]
         {
             self.ensure_dir(dir_path);
-            self.write_metadata(
-                dir_path,
-                &DiamondInjectorMetadata {
-                    input_count: self.input_count,
-                    base: self.base,
-                    batch_bits: self.batch_bits,
-                },
-            );
+            self.write_metadata(dir_path, &self.current_metadata());
             self.write_bytes(dir_path, self.k_plaintext_id(), &k.to_compact_bytes());
 
             let trap_sampler = TS::new(&self.params, self.trapdoor_sigma);
             let mut b_checkpoints = Vec::with_capacity(self.input_count + 1);
             let mut trapdoors = Vec::with_capacity(self.input_count + 1);
-            // Load or sample the per-level trapdoor checkpoints that all later
-            // preimage samplers will reference.
             for level in 0..=self.input_count {
-                let (trapdoor, b_matrix) = self.load_or_sample_b_checkpoint(dir_path, level);
-                trapdoors.push(trapdoor);
-                b_checkpoints.push(b_matrix);
+                let state_count = self.state_count_at_level(level);
+                let mut level_b = Vec::with_capacity(state_count);
+                let mut level_t = Vec::with_capacity(state_count);
+                for state_idx in 0..state_count {
+                    let (trapdoor, b_matrix) =
+                        self.load_or_sample_b_checkpoint(dir_path, level, state_idx);
+                    level_t.push(trapdoor);
+                    level_b.push(b_matrix);
+                }
+                trapdoors.push(level_t);
+                b_checkpoints.push(level_b);
             }
 
             // Sample the empty-prefix seed once and persist it if it does not
@@ -772,7 +731,7 @@ where
                 self.write_matrix(
                     dir_path,
                     self.p_epsilon_id(),
-                    &self.build_initial_encoding(hash_key, &b_checkpoints[0], &secret_epsilon, k),
+                    &self.build_initial_encoding(&b_checkpoints[0][0], &secret_epsilon, k),
                 );
             }
 
@@ -788,23 +747,12 @@ where
                         dir_path,
                         &self.digit_secret_id(level, digit_value),
                     );
-                    let prev_ext_w0 =
-                        self.sample_w_block_with_params(&self.params, hash_key, 0, level - 1);
-                    for state_idx in 0..self.expanded_state_count_after_level(level) {
+                    for state_idx in 0..self.state_count_at_level(level) {
                         let k_id = self.k_id(level, digit_value, state_idx);
                         if self.has_all_chunks(dir_path, &k_id, state_cols) {
                             continue;
                         }
-                        let ext_matrix = if self.new_bit_idx_for_state(level, state_idx).is_some() {
-                            &prev_ext_w0
-                        } else {
-                            &self.sample_w_block_with_params(
-                                &self.params,
-                                hash_key,
-                                state_idx,
-                                level - 1,
-                            )
-                        };
+                        let source_state_idx = self.transition_source_state_idx(level, state_idx);
                         for chunk_idx in 0..column_chunk_count(state_cols) {
                             let chunk_id = self.chunk_id(&k_id, chunk_idx);
                             if self.matrix_exists(dir_path, &chunk_id) {
@@ -812,19 +760,17 @@ where
                             }
                             let target_chunk = self.build_k_target_chunk_with_params(
                                 &self.params,
-                                hash_key,
                                 level,
                                 digit_value,
                                 state_idx,
                                 &secret_mask,
-                                &b_checkpoints[level],
+                                &b_checkpoints[level][state_idx],
                                 chunk_idx,
                             );
-                            let k_chunk = trap_sampler.preimage_extend(
+                            let k_chunk = trap_sampler.preimage(
                                 &self.params,
-                                &trapdoors[level - 1],
-                                &b_checkpoints[level - 1],
-                                ext_matrix,
+                                &trapdoors[level - 1][source_state_idx],
+                                &b_checkpoints[level - 1][source_state_idx],
                                 &target_chunk,
                             );
                             self.write_matrix(dir_path, &chunk_id, &k_chunk);
@@ -833,13 +779,12 @@ where
                 }
             }
             DiamondInjectorPreprocessOut {
-                hash_key,
-                final_trapdoor: trapdoors
+                final_trapdoors: trapdoors
                     .pop()
-                    .expect("DiamondInjector must keep final trapdoor checkpoint"),
-                final_pub_matrix: b_checkpoints
+                    .expect("DiamondInjector must keep final trapdoor checkpoints"),
+                final_pub_matrices: b_checkpoints
                     .pop()
-                    .expect("DiamondInjector must keep final public matrix checkpoint"),
+                    .expect("DiamondInjector must keep final public matrix checkpoints"),
             }
         }
     }
@@ -859,20 +804,12 @@ where
         {
             self.validate_digits(input_digits);
             assert_eq!(
-                self.read_bytes(dir_path, self.preprocess_hash_key_id()).as_slice(),
-                &preprocess_out.hash_key,
-                "DiamondInjector online_eval preprocess hash key mismatch"
+                preprocess_out.final_state_count(),
+                self.state_count_at_level(self.input_count),
+                "DiamondInjector final checkpoint count mismatch"
             );
             let metadata = self.read_metadata(dir_path);
-            assert_eq!(
-                metadata.input_count, self.input_count,
-                "DiamondInjector metadata input count mismatch"
-            );
-            assert_eq!(metadata.base, self.base, "DiamondInjector metadata base mismatch");
-            assert_eq!(
-                metadata.batch_bits, self.batch_bits,
-                "DiamondInjector metadata batch_bits mismatch"
-            );
+            self.assert_current_metadata(&metadata);
 
             // Start from the persisted empty-prefix seed.
             let mut states = vec![self.read_matrix(dir_path, self.p_epsilon_id())];
@@ -881,12 +818,11 @@ where
                 let level = digit_idx + 1;
                 let prev_states = std::mem::take(&mut states);
                 let prev_p0 = prev_states[0].clone();
-                let mut next_states =
-                    Vec::with_capacity(self.expanded_state_count_after_level(level));
+                let mut next_states = Vec::with_capacity(self.state_count_at_level(level));
                 // Advance every currently alive branch through the transition
                 // matrix for the chosen digit, and spawn the new branch that
                 // records each bit of the current digit.
-                for state_idx in 0..self.expanded_state_count_after_level(level) {
+                for state_idx in 0..self.state_count_at_level(level) {
                     let lhs = if self.new_bit_idx_for_state(level, state_idx).is_some() {
                         prev_p0.clone()
                     } else {
@@ -965,9 +901,7 @@ mod tests {
             assert_eq!(secret_mask.size(), (DIAMOND_SECRET_SIZE, DIAMOND_SECRET_SIZE));
             secret_matrix = secret_matrix * secret_mask;
         }
-        let base_public_matrix =
-            preprocess_out.final_pub_matrix.concat_columns(&[&injector
-                .sample_w_block_with_params(&params, preprocess_out.hash_key, 0, input_count)]);
+        let base_public_matrix = preprocess_out.final_pub_matrices[0].clone();
         let base_selector =
             DCRTPolyMatrix::from_poly_vec_row(&params, vec![secret_matrix.entry(0, 0), k.clone()]);
         assert_eq!(states[0], base_selector * base_public_matrix);
@@ -977,14 +911,7 @@ mod tests {
                 let state_idx = injector.bit_state_idx(digit_idx, bit_idx);
                 let bit_value = ((digits[digit_idx] as usize) >> bit_idx) & 1;
                 let bit_plaintext = TestPoly::from_usize_to_constant(&params, bit_value);
-                let bit_public_matrix =
-                    preprocess_out.final_pub_matrix.concat_columns(&[&injector
-                        .sample_w_block_with_params(
-                            &params,
-                            preprocess_out.hash_key,
-                            state_idx,
-                            input_count,
-                        )]);
+                let bit_public_matrix = preprocess_out.final_pub_matrices[state_idx].clone();
                 let bit_selector = DCRTPolyMatrix::from_poly_vec_row(
                     &params,
                     vec![secret_matrix.entry(0, 0), secret_matrix.entry(0, 0) * &bit_plaintext],

--- a/src/io/diamond_io.rs
+++ b/src/io/diamond_io.rs
@@ -107,8 +107,9 @@ pub struct DiamondIOObf<M, T>
 where
     M: PolyMatrix,
 {
-    /// Hash key sampled by `DiamondInjector::preprocess` and required by
-    /// `DiamondInjector::online_eval` to identify the persisted preimages.
+    /// Final state-specific trapdoor public bases returned by
+    /// `DiamondInjector::preprocess`. Large transition preimage matrices are
+    /// stored under the artifact directory passed to obfuscation.
     pub preprocess_out: DiamondInjectorPreprocessOut<M, T>,
     /// Hash key used to deterministically sample the BGG public keys in this
     /// obfuscation instance.
@@ -405,24 +406,11 @@ where
         let lookup_top = enc_lookup_base_matrix.clone();
         let lookup_bottom = M::zero(params, DIAMOND_SECRET_SIZE, lookup_top.col_size());
         let lookup_target = lookup_top.concat_rows(&[&lookup_bottom]);
-        let final_w_block_col_size = DIAMOND_SECRET_SIZE
-            .checked_mul(params.modulus_digits())
-            .expect("DiamondIO final W block column count overflow");
-        let lookup_ext_matrix = HS::new().sample_hash(
+        let (lookup_trapdoor, lookup_public_matrix) = preprocess_out.final_checkpoint(0);
+        let lookup_base_preimage = TS::new(params, self.injector.trapdoor_sigma).preimage(
             params,
-            preprocess_out.hash_key,
-            format!("diamond_w_{}_{}", 0, self.injector.input_count),
-            2usize
-                .checked_mul(DIAMOND_SECRET_SIZE)
-                .expect("DiamondIO lookup bridge state row count overflow"),
-            final_w_block_col_size,
-            DistType::FinRingDist,
-        );
-        let lookup_base_preimage = TS::new(params, self.injector.trapdoor_sigma).preimage_extend(
-            params,
-            &preprocess_out.final_trapdoor,
-            &preprocess_out.final_pub_matrix,
-            &lookup_ext_matrix,
+            lookup_trapdoor,
+            lookup_public_matrix,
             &lookup_target,
         );
         Self::write_io_matrix(dir_path, Self::enc_lookup_base_preimage_id(), &lookup_base_preimage);
@@ -505,30 +493,16 @@ where
             );
             Self::write_io_matrix(dir_path, &Self::input_preimage_id(bit_idx), &preimage);
         }
-        let final_w_block_col_size = DIAMOND_SECRET_SIZE
-            .checked_mul(params.modulus_digits())
-            .expect("DiamondIO final W block column count overflow");
-        let final_state_row_count = 2usize
-            .checked_mul(DIAMOND_SECRET_SIZE)
-            .expect("DiamondIO final state row count overflow");
         let decoder = MaskedHighBitDecoder::<M, _, _, _>::new(
             params,
             DIAMOND_SECRET_SIZE,
             DirectoryDecoderArtifacts::new(dir_path, "diamond_io"),
             |_, target| {
-                let ext_matrix = HS::new().sample_hash(
+                let (trapdoor, public_matrix) = preprocess_out.final_checkpoint(0);
+                TS::new(params, self.injector.trapdoor_sigma).preimage(
                     params,
-                    preprocess_out.hash_key,
-                    format!("diamond_w_{}_{}", 0, self.injector.input_count),
-                    final_state_row_count,
-                    final_w_block_col_size,
-                    DistType::FinRingDist,
-                );
-                TS::new(params, self.injector.trapdoor_sigma).preimage_extend(
-                    params,
-                    &preprocess_out.final_trapdoor,
-                    &preprocess_out.final_pub_matrix,
-                    &ext_matrix,
+                    trapdoor,
+                    public_matrix,
                     target,
                 )
             },

--- a/src/io/diamond_io/bench_estimator.rs
+++ b/src/io/diamond_io/bench_estimator.rs
@@ -150,18 +150,14 @@ pub struct DiamondIOBenchEstimator<'a, PKBE, EncBE, NBE> {
     pub encoding_estimator: &'a EncBE,
     /// Cost model for sampling one Diamond trapdoor/public-matrix checkpoint.
     pub trapdoor_checkpoint: CircuitBenchEstimate,
-    /// Cost model for one `preimage_extend` call.
-    pub trapdoor_preimage_extend: CircuitBenchEstimate,
-    /// Cost model for one ordinary final-output `preimage_extend` call.
-    pub final_output_preimage_extend: CircuitBenchEstimate,
-    /// Cost model for one final decoder `preimage_extend` call with a one-column target.
-    pub final_decoder_preimage_extend: CircuitBenchEstimate,
-    /// Cost model for the lookup-table bridge `preimage_extend` call.
-    pub lookup_bridge_preimage_extend: CircuitBenchEstimate,
-    /// Cost model for hashing one full Diamond W block.
-    pub full_w_block_hash_sample: CircuitBenchEstimate,
-    /// Cost model for hashing one W-column chunk used while building transition targets.
-    pub transition_w_chunk_hash_sample: CircuitBenchEstimate,
+    /// Cost model for one transition trapdoor `preimage` call.
+    pub trapdoor_preimage: CircuitBenchEstimate,
+    /// Cost model for one ordinary final-output `preimage` call.
+    pub final_output_preimage: CircuitBenchEstimate,
+    /// Cost model for one final decoder `preimage` call with a one-column target.
+    pub final_decoder_preimage: CircuitBenchEstimate,
+    /// Cost model for the lookup-table bridge `preimage` call.
+    pub lookup_bridge_preimage: CircuitBenchEstimate,
     /// Size-aware estimator for native polynomial-vector arithmetic.
     pub native_estimator: &'a NBE,
     /// Cost model for sampling one scalar BGG public key.
@@ -197,12 +193,10 @@ where
             encoding_estimator,
             native_estimator,
             trapdoor_checkpoint: units.trapdoor_checkpoint,
-            trapdoor_preimage_extend: units.trapdoor_preimage_extend,
-            final_output_preimage_extend: units.final_output_preimage_extend,
-            final_decoder_preimage_extend: units.final_decoder_preimage_extend,
-            lookup_bridge_preimage_extend: units.lookup_bridge_preimage_extend,
-            full_w_block_hash_sample: units.full_w_block_hash_sample,
-            transition_w_chunk_hash_sample: units.transition_w_chunk_hash_sample,
+            trapdoor_preimage: units.trapdoor_preimage,
+            final_output_preimage: units.final_output_preimage,
+            final_decoder_preimage: units.final_decoder_preimage,
+            lookup_bridge_preimage: units.lookup_bridge_preimage,
             bgg_public_key_sample: units.bgg_public_key_sample,
             ring_gsw_public_key_sample: units.ring_gsw_public_key_sample,
             ring_gsw_encrypt_bit: units.ring_gsw_encrypt_bit,
@@ -235,7 +229,6 @@ where
             gadget_col_size,
             state_col_size = shape.state_col_size,
             transition_chunk_len = column_chunk_bounds(shape.state_col_size, 0).1,
-            transition_w_hash_max_col_len = shape.transition_w_hash_max_col_len,
             lookup_bridge_cols = shape.lookup_bridge_cols,
             modulus_digits = params.modulus_digits(),
             ring_dimension = params.ring_dimension(),
@@ -253,95 +246,25 @@ where
 
         let trap_sampler = TS::new(params, diamond.injector.trapdoor_sigma);
         let (trapdoor, public_matrix) = trap_sampler.trapdoor(params, state_row_size);
-        let ext_matrix = HS::new().sample_hash(
-            params,
-            [0x51u8; 32],
-            b"diamond_io_bench_preimage_extend_ext",
-            state_row_size,
-            gadget_col_size,
-            DistType::FinRingDist,
-        );
         let transition_chunk_len = column_chunk_bounds(shape.state_col_size, 0).1;
         let one_column_target = M::zero(params, state_row_size, 1);
 
-        // Measure `preimage_extend` with one target column and compact serialization, then scale
+        // Measure `preimage` with one target column and compact serialization, then scale
         // the parallel work by the real target width while keeping latency at the measured one-
         // column value. Running the full-width serialized benchmark can exceed the H200 pod's CPU
         // cgroup memory limit before the estimator reaches the final composed estimate.
-        let trapdoor_preimage_extend_one_col =
-            bench_estimate_named("trapdoor_preimage_extend_one_col", iterations, || {
-                let preimage = trap_sampler.preimage_extend(
-                    params,
-                    &trapdoor,
-                    &public_matrix,
-                    &ext_matrix,
-                    &one_column_target,
-                );
-                preimage.to_compact_bytes()
-            });
-        let trapdoor_preimage_extend =
-            scale_independent_estimate(trapdoor_preimage_extend_one_col, transition_chunk_len);
-
-        let final_output_preimage_extend_one_col =
-            bench_estimate_named("final_output_preimage_extend_one_col", iterations, || {
-                let preimage = trap_sampler.preimage_extend(
-                    params,
-                    &trapdoor,
-                    &public_matrix,
-                    &ext_matrix,
-                    &one_column_target,
-                );
-                preimage.to_compact_bytes()
-            });
-        let final_output_preimage_extend = scale_independent_estimate(
-            final_output_preimage_extend_one_col.clone(),
-            gadget_col_size,
-        );
-        let final_decoder_preimage_extend = final_output_preimage_extend_one_col;
-
-        let lookup_bridge_preimage_extend_one_col =
-            bench_estimate_named("lookup_bridge_preimage_extend_one_col", iterations, || {
-                let preimage = trap_sampler.preimage_extend(
-                    params,
-                    &trapdoor,
-                    &public_matrix,
-                    &ext_matrix,
-                    &one_column_target,
-                );
-                preimage.to_compact_bytes()
-            });
-        let lookup_bridge_preimage_extend = scale_independent_estimate(
-            lookup_bridge_preimage_extend_one_col,
-            shape.lookup_bridge_cols,
-        );
-
-        let full_w_block_hash_sample =
-            bench_estimate_named("full_w_block_hash_sample", iterations, || {
-                let matrix = HS::new().sample_hash(
-                    params,
-                    [0x52u8; 32],
-                    b"diamond_io_bench_full_w_block_hash",
-                    state_row_size,
-                    gadget_col_size,
-                    DistType::FinRingDist,
-                );
-                matrix.to_compact_bytes()
-            });
-
-        let transition_w_chunk_hash_sample =
-            bench_estimate_named("transition_w_chunk_hash_sample", iterations, || {
-                let matrix = HS::new().sample_hash_columns(
-                    params,
-                    [0x53u8; 32],
-                    b"diamond_io_bench_transition_w_chunk_hash",
-                    state_row_size,
-                    gadget_col_size,
-                    0,
-                    shape.transition_w_hash_max_col_len,
-                    DistType::FinRingDist,
-                );
-                matrix.to_compact_bytes()
-            });
+        let preimage_one_col = bench_estimate_named("preimage_one_col", iterations, || {
+            let preimage =
+                trap_sampler.preimage(params, &trapdoor, &public_matrix, &one_column_target);
+            preimage.to_compact_bytes()
+        });
+        let trapdoor_preimage =
+            scale_independent_estimate(preimage_one_col.clone(), transition_chunk_len);
+        let final_output_preimage =
+            scale_independent_estimate(preimage_one_col.clone(), gadget_col_size);
+        let final_decoder_preimage = preimage_one_col.clone();
+        let lookup_bridge_preimage =
+            scale_independent_estimate(preimage_one_col, shape.lookup_bridge_cols);
 
         let mut bgg_public_key_tag = diamond.bgg_tag.clone();
         bgg_public_key_tag.extend_from_slice(b":public_keys");
@@ -480,12 +403,10 @@ where
 
         debug!(
             ?trapdoor_checkpoint,
-            ?trapdoor_preimage_extend,
-            ?final_output_preimage_extend,
-            ?final_decoder_preimage_extend,
-            ?lookup_bridge_preimage_extend,
-            ?full_w_block_hash_sample,
-            ?transition_w_chunk_hash_sample,
+            ?trapdoor_preimage,
+            ?final_output_preimage,
+            ?final_decoder_preimage,
+            ?lookup_bridge_preimage,
             ?bgg_public_key_sample,
             ?ring_gsw_public_key_sample,
             ?ring_gsw_encrypt_bit,
@@ -494,12 +415,10 @@ where
 
         DiamondIOBenchUnitEstimates {
             trapdoor_checkpoint,
-            trapdoor_preimage_extend,
-            final_output_preimage_extend,
-            final_decoder_preimage_extend,
-            lookup_bridge_preimage_extend,
-            full_w_block_hash_sample,
-            transition_w_chunk_hash_sample,
+            trapdoor_preimage,
+            final_output_preimage,
+            final_decoder_preimage,
+            lookup_bridge_preimage,
             bgg_public_key_sample,
             ring_gsw_public_key_sample,
             ring_gsw_encrypt_bit,
@@ -638,36 +557,15 @@ where
 
         let final_projection_standard_preimages = shape.final_projection_standard_preimage_count();
         let final_projection_decoder_preimages = shape.final_decoder_count();
-        let lookup_bridge_hash_sampling = estimate_summary(self.full_w_block_hash_sample.clone());
-        let lookup_bridge_preimage = estimate_summary(self.lookup_bridge_preimage_extend.clone());
-        let lookup_bridge_work = sequential_summaries(&[
-            lookup_bridge_hash_sampling.clone(),
-            lookup_bridge_preimage.clone(),
-        ]);
-        let final_projection_hash_sampling = scale_estimate(
-            self.full_w_block_hash_sample.clone(),
-            final_projection_standard_preimages
-                .checked_add(final_projection_decoder_preimages)
-                .expect("DiamondIO final projection hash count overflow"),
-        );
+        let lookup_bridge_work = estimate_summary(self.lookup_bridge_preimage.clone());
         let final_projection_target_building =
             shape.estimate_final_projection_target_building(self.native_estimator);
         let final_projection_preimages = parallel_summaries(&[
-            scale_estimate(
-                self.final_output_preimage_extend.clone(),
-                final_projection_standard_preimages,
-            ),
-            scale_estimate(
-                self.final_decoder_preimage_extend.clone(),
-                final_projection_decoder_preimages,
-            ),
-        ]);
-        let final_projection_inputs = parallel_summaries(&[
-            final_projection_hash_sampling.clone(),
-            final_projection_target_building.clone(),
+            scale_estimate(self.final_output_preimage.clone(), final_projection_standard_preimages),
+            scale_estimate(self.final_decoder_preimage.clone(), final_projection_decoder_preimages),
         ]);
         let final_projection_work = sequential_summaries(&[
-            final_projection_inputs.clone(),
+            final_projection_target_building.clone(),
             final_projection_preimages.clone(),
         ]);
 
@@ -712,10 +610,7 @@ where
             ?function_public_key_eval,
             final_projection_standard_preimages,
             final_projection_decoder_preimages,
-            ?lookup_bridge_hash_sampling,
-            ?lookup_bridge_preimage,
             ?lookup_bridge_work,
-            ?final_projection_hash_sampling,
             ?final_projection_target_building,
             ?final_projection_preimages,
             ?final_projection_work,
@@ -865,7 +760,7 @@ where
 
     fn estimate_input_injection<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
         &self,
-        diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
+        _diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
         shape: DiamondIOBenchShape,
     ) -> DiamondIOInputInjectionBenchEstimateParts
     where
@@ -875,16 +770,13 @@ where
         HS: PolyHashSampler<[u8; 32], M = M> + Send + Sync,
         TS: PolyTrapdoorSampler<M = M> + Send + Sync,
     {
-        // Corresponds to `load_or_sample_b_checkpoint` for levels `0..=input_count`. Checkpoints
-        // do not depend on each other, so enough GPUs can sample them concurrently.
+        // Corresponds to `load_or_sample_b_checkpoint` for every level/state pair.
         let checkpoint_sampling =
-            scale_estimate(self.trapdoor_checkpoint.clone(), diamond.injector.input_count + 1);
+            scale_estimate(self.trapdoor_checkpoint.clone(), shape.checkpoint_count);
 
         // Corresponds to `build_initial_encoding`: one native product plus an error addition for
-        // the empty prefix state. The W block is deterministic hash-derived public data, so it is
-        // regenerated rather than stored, but preprocessing still pays the sampling cost.
+        // the empty prefix state.
         let initial_state = sequential_summaries(&[
-            estimate_summary(self.full_w_block_hash_sample.clone()),
             self.native_estimator
                 .estimate_vector_matrix_product(shape.state_row_size, shape.state_col_size),
             estimate_summary(self.native_estimator.estimate_vector_add(shape.state_col_size)),
@@ -893,29 +785,14 @@ where
         // Corresponds to `build_k_target_chunk_with_params` for every level/digit/state/chunk.
         // Target construction precedes the matching preimage sample, but all chunks in a stage are
         // independent.
-        let transition_ext_w_hash_sampling = scale_estimate(
-            self.full_w_block_hash_sample.clone(),
-            shape.transition_ext_w_hash_count,
-        );
-        let transition_target_w_hash_sampling = scale_estimate(
-            self.transition_w_chunk_hash_sample.clone(),
-            shape.transition_target_w_hash_chunk_count,
-        );
         let transition_target_building =
             shape.estimate_transition_target_building(self.native_estimator);
 
-        // Corresponds to the chunked `preimage_extend` calls inside `DiamondInjector::preprocess`.
-        let transition_preimages = scale_estimate(
-            self.trapdoor_preimage_extend.clone(),
-            shape.transition_preimage_chunk_count,
-        );
+        // Corresponds to the chunked `preimage` calls inside `DiamondInjector::preprocess`.
+        let transition_preimages =
+            scale_estimate(self.trapdoor_preimage.clone(), shape.transition_preimage_chunk_count);
 
-        let transition_public_hashing = parallel_summaries(&[
-            transition_ext_w_hash_sampling.clone(),
-            transition_target_w_hash_sampling.clone(),
-        ]);
         let transition_stage = sequential_summaries(&[
-            transition_public_hashing.clone(),
             transition_target_building.clone(),
             transition_preimages.clone(),
         ]);
@@ -927,8 +804,6 @@ where
         debug!(
             ?checkpoint_sampling,
             ?initial_state,
-            ?transition_ext_w_hash_sampling,
-            ?transition_target_w_hash_sampling,
             ?transition_target_building,
             ?transition_preimages,
             ?preprocess_total,
@@ -1079,18 +954,10 @@ where
             BigUint::from(shape.ring_dim) *
             BigUint::from(branch_rebase_branch_count);
         let refresh_decoder_work_per_round = match mode {
-            PrfBenchMode::PublicKeyPreprocess => sequential_summaries(&[
-                scale_estimate_biguint(
-                    self.full_w_block_hash_sample.clone(),
-                    &(&noise_refresh_decoder_count_per_round +
-                        &branch_rebase_decoder_count_per_round),
-                ),
-                scale_estimate_biguint(
-                    self.final_output_preimage_extend.clone(),
-                    &(&noise_refresh_decoder_count_per_round +
-                        &branch_rebase_decoder_count_per_round),
-                ),
-            ]),
+            PrfBenchMode::PublicKeyPreprocess => scale_estimate_biguint(
+                self.final_output_preimage.clone(),
+                &(&noise_refresh_decoder_count_per_round + &branch_rebase_decoder_count_per_round),
+            ),
             PrfBenchMode::EncodingOnline => {
                 let decoder_unit = self
                     .native_estimator
@@ -1546,12 +1413,10 @@ struct DiamondIOInputInjectionBenchEstimateParts {
 #[derive(Debug, Clone)]
 struct DiamondIOBenchUnitEstimates {
     trapdoor_checkpoint: CircuitBenchEstimate,
-    trapdoor_preimage_extend: CircuitBenchEstimate,
-    final_output_preimage_extend: CircuitBenchEstimate,
-    final_decoder_preimage_extend: CircuitBenchEstimate,
-    lookup_bridge_preimage_extend: CircuitBenchEstimate,
-    full_w_block_hash_sample: CircuitBenchEstimate,
-    transition_w_chunk_hash_sample: CircuitBenchEstimate,
+    trapdoor_preimage: CircuitBenchEstimate,
+    final_output_preimage: CircuitBenchEstimate,
+    final_decoder_preimage: CircuitBenchEstimate,
+    lookup_bridge_preimage: CircuitBenchEstimate,
     bgg_public_key_sample: CircuitBenchEstimate,
     ring_gsw_public_key_sample: CircuitBenchEstimate,
     ring_gsw_encrypt_bit: CircuitBenchEstimate,

--- a/src/io/diamond_io/bench_estimator_shape.rs
+++ b/src/io/diamond_io/bench_estimator_shape.rs
@@ -43,11 +43,9 @@ pub(super) struct DiamondIOBenchShape {
     pub(super) state_col_size: usize,
     pub(super) b_public_col_size: usize,
     pub(super) checkpoint_count: usize,
+    pub(super) final_checkpoint_count: usize,
     pub(super) transition_matrix_count: usize,
     pub(super) transition_preimage_chunk_count: usize,
-    pub(super) transition_ext_w_hash_count: usize,
-    pub(super) transition_target_w_hash_chunk_count: usize,
-    pub(super) transition_w_hash_max_col_len: usize,
     pub(super) input_injection_transition_preimage_bytes: usize,
     pub(super) online_level_state_counts: Vec<usize>,
     pub(super) transition_chunk_col_lens: Vec<usize>,
@@ -84,14 +82,10 @@ impl DiamondIOBenchShape {
             .expect("DiamondIO modulus bits must fit in u16 for compact-byte estimates");
         let state_row_size =
             2usize.checked_mul(DIAMOND_SECRET_SIZE).expect("DiamondIO state row size overflow");
-        let gadget_col_size = DIAMOND_SECRET_SIZE
-            .checked_mul(modulus_digits)
-            .expect("DiamondIO gadget column count overflow");
         let b_public_col_size = state_row_size
             .checked_mul(modulus_digits + 2)
             .expect("DiamondIO B public column count overflow");
-        let state_col_size =
-            b_public_col_size.checked_add(gadget_col_size).expect("DiamondIO state cols overflow");
+        let state_col_size = b_public_col_size;
         let chunk_count = column_chunk_count(state_col_size);
         let transition_chunk_col_lens = (0..chunk_count)
             .map(|chunk_idx| column_chunk_bounds(state_col_size, chunk_idx).1)
@@ -103,27 +97,11 @@ impl DiamondIOBenchShape {
             })
             .collect::<Vec<_>>();
         let transition_preimage_bytes_per_matrix = transition_chunk_bytes.iter().sum::<usize>();
-        let transition_w_chunk_lens = (0..chunk_count)
-            .filter_map(|chunk_idx| {
-                let (col_start, col_len) = column_chunk_bounds(state_col_size, chunk_idx);
-                let col_end = col_start + col_len;
-                let w_start = b_public_col_size;
-                (col_end > w_start)
-                    .then_some(col_end - col_start.max(w_start))
-                    .filter(|&w_len| w_len > 0)
-            })
-            .collect::<Vec<_>>();
-        let transition_w_hash_chunks_per_matrix = transition_w_chunk_lens.len();
-        let transition_w_hash_max_col_len =
-            transition_w_chunk_lens.iter().copied().max().unwrap_or(1);
-
         let mut transition_preimage_chunk_count = 0usize;
         let mut transition_matrix_count = 0usize;
-        let mut transition_ext_w_hash_count = 0usize;
         let mut online_level_state_counts = Vec::with_capacity(diamond.injector.input_count);
         for level in 1..=diamond.injector.input_count {
-            let state_count = expanded_state_count_after_level(diamond, level);
-            let old_state_count = state_count.saturating_sub(diamond.injector.batch_bits());
+            let state_count = state_count_at_level(diamond, level);
             transition_matrix_count = transition_matrix_count
                 .checked_add(
                     diamond
@@ -143,29 +121,13 @@ impl DiamondIOBenchShape {
                         .expect("DiamondIO transition chunk count overflow"),
                 )
                 .expect("DiamondIO transition chunk count overflow");
-            // `DiamondInjector::preprocess` materializes one full hashed W block for the previous
-            // empty-prefix state before iterating states, then one more full W block for every
-            // non-new state. New states reuse that first previous-level block. These matrices are
-            // deterministic hash-derived public data, so storage does not count them, but their
-            // sampling work is part of preprocessing latency and total work.
-            transition_ext_w_hash_count = transition_ext_w_hash_count
-                .checked_add(
-                    diamond
-                        .injector
-                        .base
-                        .checked_mul(
-                            old_state_count
-                                .checked_add(1)
-                                .expect("DiamondIO transition W hash count overflow"),
-                        )
-                        .expect("DiamondIO transition W hash count overflow"),
-                )
-                .expect("DiamondIO transition W hash count overflow");
             online_level_state_counts.push(state_count);
         }
-        let transition_target_w_hash_chunk_count = transition_matrix_count
-            .checked_mul(transition_w_hash_chunks_per_matrix)
-            .expect("DiamondIO transition target W hash chunk count overflow");
+        let checkpoint_count = (0..=diamond.injector.input_count)
+            .map(|level| state_count_at_level(diamond, level))
+            .try_fold(0usize, |acc, count| acc.checked_add(count))
+            .expect("DiamondIO checkpoint count overflow");
+        let final_checkpoint_count = state_count_at_level(diamond, diamond.injector.input_count);
 
         let input_injection_transition_preimage_bytes = transition_preimage_bytes_per_matrix
             .checked_mul(transition_matrix_count)
@@ -216,12 +178,10 @@ impl DiamondIOBenchShape {
             state_row_size,
             state_col_size,
             b_public_col_size,
-            checkpoint_count: diamond.injector.input_count + 1,
+            checkpoint_count,
+            final_checkpoint_count,
             transition_matrix_count,
             transition_preimage_chunk_count,
-            transition_ext_w_hash_count,
-            transition_target_w_hash_chunk_count,
-            transition_w_hash_max_col_len,
             input_injection_transition_preimage_bytes,
             online_level_state_counts,
             transition_chunk_col_lens,
@@ -240,48 +200,42 @@ impl DiamondIOBenchShape {
         // * `metadata_estimate` is a fixed conservative allowance for the JSON metadata written by
         //   `DiamondInjector::write_metadata`; it stores only `input_count` and `base`, so the
         //   actual encoded file is tiny and independent of the polynomial parameters.
-        // * `hash_key_bytes` is the 32-byte `diamond_preprocess_hash_key`. It is needed at eval
-        //   time to check that the selected preprocessed transition chunks belong to the same
-        //   deterministic hash-derived public side.
-        // * `p_epsilon_bytes` estimates `diamond_p_epsilon_tensor_0`, the initial empty-prefix
+        // * `p_epsilon_bytes` estimates `diamond_initial_state_tensor`, the initial empty-prefix
         //   state read before the first input digit is applied. Its shape is `(state_row_size / 2)
         //   x state_col_size`, matching the secret-side half-state produced by
         //   `build_initial_encoding`.
         let metadata_estimate = 128usize;
-        let hash_key_bytes = 32usize;
         let p_epsilon_bytes = bench_utils::matrix_compact_bytes_for_shape(
             self.state_row_size / 2,
             self.state_col_size,
             self.ring_dim,
             self.modulus_bits,
         );
-        BigUint::from(metadata_estimate + hash_key_bytes + p_epsilon_bytes)
+        BigUint::from(metadata_estimate + p_epsilon_bytes)
     }
 
     pub(super) fn input_injection_public_checkpoint_bytes(&self) -> usize {
-        // This counts the public `B` checkpoint matrices persisted by
-        // `DiamondInjector::load_or_sample_b_checkpoint` for levels `0..=input_count`. The matching
-        // trapdoors are intentionally not counted because they are preprocessing secrets rather
-        // than obfuscated-circuit data. Online eval does not multiply by these checkpoints
-        // directly; they are counted here only because the current preprocessing implementation
-        // persists the public matrices as reusable checkpoint artifacts.
+        // Only final-level public `B` checkpoint matrices are included in the obfuscated circuit.
+        // Intermediate-level checkpoints are preprocessing artifacts used to sample transition
+        // preimages and are intentionally not counted here. Trapdoors are preprocessing secrets and
+        // are also excluded.
         bench_utils::matrix_compact_bytes_for_shape(
             self.state_row_size,
             self.b_public_col_size,
             self.ring_dim,
             self.modulus_bits,
         )
-        .checked_mul(self.checkpoint_count)
+        .checked_mul(self.final_checkpoint_count)
         .expect("DiamondIO B checkpoint byte count overflow")
     }
 
     pub(super) fn input_injection_bytes(&self) -> BigUint {
         // Input-injection persisted bytes are grouped by the artifacts that survive preprocessing:
         //
-        // 1. Small metadata, the 32-byte hash key, and the empty-prefix seed state `p_epsilon`.
-        // 2. Public `B` checkpoint matrices for the per-level trapdoor chain, excluding trapdoors.
-        // 3. Chunked transition preimages `diamond_k_bit_tensor_*`, which are the large artifacts
-        //    read by online eval to advance the selected input-dependent branch states.
+        // 1. Small metadata and the empty-prefix seed state `p_epsilon`.
+        // 2. Final-level public `B` checkpoint matrices, excluding trapdoors.
+        // 3. Chunked transition preimages `diamond_transition_tensor_*`, which are the large
+        //    artifacts read by online eval to advance the selected input-dependent branch states.
         self.input_injection_metadata_and_seed_bytes() +
             BigUint::from(self.input_injection_public_checkpoint_bytes()) +
             BigUint::from(self.input_injection_transition_preimage_bytes)
@@ -521,7 +475,7 @@ impl DiamondIOBenchShape {
     }
 }
 
-fn expanded_state_count_after_level<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+fn state_count_at_level<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
     diamond: &DiamondIO<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
     level: usize,
 ) -> usize
@@ -581,11 +535,9 @@ mod tests {
             state_col_size: 3,
             b_public_col_size: 4,
             checkpoint_count: 0,
+            final_checkpoint_count: 0,
             transition_matrix_count: 0,
             transition_preimage_chunk_count: 0,
-            transition_ext_w_hash_count: 0,
-            transition_target_w_hash_chunk_count: 0,
-            transition_w_hash_max_col_len: 0,
             input_injection_transition_preimage_bytes: 0,
             online_level_state_counts: Vec::new(),
             transition_chunk_col_lens: Vec::new(),

--- a/src/io/diamond_io/simulation.rs
+++ b/src/io/diamond_io/simulation.rs
@@ -106,8 +106,8 @@ pub struct DiamondIOCrtDepthSearchResult {
     pub total_noisy_plaintext_error: PolyMatrixNorm,
     /// Representative input-injection contribution used to seed the DiamondIO simulation.
     ///
-    /// This is `input_injection.state_errors[0] * input_injection.output_preimage`, matching the
-    /// projected state error used as the `one`, decryption-key, and decoder input bound.
+    /// This is `input_injection.state_errors[0] * input_injection.output_preimage`, where
+    /// `output_preimage` is the B-only final projection preimage for state 0.
     pub input_injection_projection_error: PolyMatrixNorm,
 }
 
@@ -1728,6 +1728,7 @@ fn simulator_context(params: &DCRTPolyParams) -> Arc<SimulatorContext> {
 fn diamond_io_input_injection_projection_error(
     input_injection: &DiamondInputErrorSimulation,
 ) -> PolyMatrixNorm {
+    // State 0 final B-only projection error.
     input_injection
         .state_errors
         .first()

--- a/src/io/diamond_io/utils.rs
+++ b/src/io/diamond_io/utils.rs
@@ -597,7 +597,7 @@ where
     pub(super) fn sample_final_output_preimage(
         &self,
         preprocess_out: &DiamondInjectorPreprocessOut<M, TS::Trapdoor>,
-        block_idx: usize,
+        state_idx: usize,
         pubkey: &BggPublicKey<M>,
         top_gadget_plaintext: Option<&M::P>,
         bottom_gadget_plaintext: Option<&M::P>,
@@ -616,21 +616,11 @@ where
             bottom = bottom - &(gadget * plaintext);
         }
         let target = top.concat_rows(&[&bottom]);
-        let ext_matrix = HS::new().sample_hash(
+        let (trapdoor, public_matrix) = preprocess_out.final_checkpoint(state_idx);
+        TS::new(params, self.injector.trapdoor_sigma).preimage(
             params,
-            preprocess_out.hash_key,
-            format!("diamond_w_{}_{}", block_idx, self.injector.input_count),
-            2usize
-                .checked_mul(DIAMOND_SECRET_SIZE)
-                .expect("DiamondIO final state row count overflow"),
-            final_gadget_col_size,
-            DistType::FinRingDist,
-        );
-        TS::new(params, self.injector.trapdoor_sigma).preimage_extend(
-            params,
-            &preprocess_out.final_trapdoor,
-            &preprocess_out.final_pub_matrix,
-            &ext_matrix,
+            trapdoor,
+            public_matrix,
             &target,
         )
     }

--- a/src/we/diamond_we.rs
+++ b/src/we/diamond_we.rs
@@ -180,24 +180,6 @@ where
         "we_enc_lookup_base_preimage"
     }
 
-    fn sample_w_block(
-        &self,
-        preprocess_out: &DiamondInjectorPreprocessOut<M, TS::Trapdoor>,
-        block_idx: usize,
-        cols: usize,
-    ) -> M {
-        HS::new().sample_hash(
-            &self.injector.params,
-            preprocess_out.hash_key,
-            format!("diamond_w_{}_{}", block_idx, self.injector.input_count),
-            2usize
-                .checked_mul(DIAMOND_SECRET_SIZE)
-                .expect("DiamondWE final state row count overflow"),
-            cols,
-            DistType::FinRingDist,
-        )
-    }
-
     fn sample_bgg_public_keys(
         &self,
         hash_key: [u8; 32],
@@ -226,7 +208,7 @@ where
     fn sample_output_preimage(
         &self,
         preprocess_out: &DiamondInjectorPreprocessOut<M, TS::Trapdoor>,
-        block_idx: usize,
+        state_idx: usize,
         pubkey: &BggPublicKey<M>,
         top_gadget_plaintext: Option<&M::P>,
         bottom_gadget_plaintext: Option<&M::P>,
@@ -245,11 +227,11 @@ where
             bottom = bottom - &(gadget * plaintext);
         }
         let target = top.concat_rows(&[&bottom]);
-        TS::new(params, self.injector.trapdoor_sigma).preimage_extend(
+        let (trapdoor, public_matrix) = preprocess_out.final_checkpoint(state_idx);
+        TS::new(params, self.injector.trapdoor_sigma).preimage(
             params,
-            &preprocess_out.final_trapdoor,
-            &preprocess_out.final_pub_matrix,
-            &self.sample_w_block(preprocess_out, block_idx, cols),
+            trapdoor,
+            public_matrix,
             &target,
         )
     }
@@ -267,14 +249,11 @@ where
         );
         let identity = M::identity(params, DIAMOND_SECRET_SIZE, None);
         let target = k_pubkey.matrix.concat_rows(&[&identity]);
-        let ext_cols = DIAMOND_SECRET_SIZE
-            .checked_mul(params.modulus_digits())
-            .expect("DiamondWE final W block column count overflow");
-        TS::new(params, self.injector.trapdoor_sigma).preimage_extend(
+        let (trapdoor, public_matrix) = preprocess_out.final_checkpoint(0);
+        TS::new(params, self.injector.trapdoor_sigma).preimage(
             params,
-            &preprocess_out.final_trapdoor,
-            &preprocess_out.final_pub_matrix,
-            &self.sample_w_block(preprocess_out, 0, ext_cols),
+            trapdoor,
+            public_matrix,
             &target,
         )
     }
@@ -287,14 +266,11 @@ where
         let params = &self.injector.params;
         let bottom = M::zero(params, DIAMOND_SECRET_SIZE, dec_pubkey_matrix.col_size());
         let target = dec_pubkey_matrix.concat_rows(&[&bottom]);
-        let ext_cols = DIAMOND_SECRET_SIZE
-            .checked_mul(params.modulus_digits())
-            .expect("DiamondWE final W block column count overflow");
-        TS::new(params, self.injector.trapdoor_sigma).preimage_extend(
+        let (trapdoor, public_matrix) = preprocess_out.final_checkpoint(0);
+        TS::new(params, self.injector.trapdoor_sigma).preimage(
             params,
-            &preprocess_out.final_trapdoor,
-            &preprocess_out.final_pub_matrix,
-            &self.sample_w_block(preprocess_out, 0, ext_cols),
+            trapdoor,
+            public_matrix,
             &target,
         )
     }
@@ -312,11 +288,11 @@ where
         let params = &self.injector.params;
         let lookup_bottom = M::zero(params, DIAMOND_SECRET_SIZE, lookup_base_matrix.col_size());
         let target = lookup_base_matrix.concat_rows(&[&lookup_bottom]);
-        TS::new(params, self.injector.trapdoor_sigma).preimage_extend(
+        let (trapdoor, public_matrix) = preprocess_out.final_checkpoint(0);
+        TS::new(params, self.injector.trapdoor_sigma).preimage(
             params,
-            &preprocess_out.final_trapdoor,
-            &preprocess_out.final_pub_matrix,
-            &self.sample_w_block(preprocess_out, 0, target.col_size()),
+            trapdoor,
+            public_matrix,
             &target,
         )
     }

--- a/src/we/diamond_we/bench_estimator.rs
+++ b/src/we/diamond_we/bench_estimator.rs
@@ -40,10 +40,8 @@ pub struct DiamondWEBenchEstimator<'a, PKBE, EncBE, NBE> {
     pub encoding_estimator: &'a EncBE,
     pub native_estimator: &'a NBE,
     pub trapdoor_checkpoint: CircuitBenchEstimate,
-    pub trapdoor_preimage_extend: CircuitBenchEstimate,
-    pub final_preimage_extend_one_column: CircuitBenchEstimate,
-    pub w_hash_one_column: CircuitBenchEstimate,
-    pub transition_w_chunk_hash_sample: CircuitBenchEstimate,
+    pub trapdoor_preimage: CircuitBenchEstimate,
+    pub final_preimage_one_column: CircuitBenchEstimate,
     pub bgg_public_key_sample: CircuitBenchEstimate,
     pub scalar_matrix_hash_sample: CircuitBenchEstimate,
 }
@@ -75,10 +73,8 @@ where
             encoding_estimator,
             native_estimator,
             trapdoor_checkpoint: units.trapdoor_checkpoint,
-            trapdoor_preimage_extend: units.trapdoor_preimage_extend,
-            final_preimage_extend_one_column: units.final_preimage_extend_one_column,
-            w_hash_one_column: units.w_hash_one_column,
-            transition_w_chunk_hash_sample: units.transition_w_chunk_hash_sample,
+            trapdoor_preimage: units.trapdoor_preimage,
+            final_preimage_one_column: units.final_preimage_one_column,
             bgg_public_key_sample: units.bgg_public_key_sample,
             scalar_matrix_hash_sample: units.scalar_matrix_hash_sample,
         }
@@ -90,10 +86,8 @@ where
         encoding_estimator: &'a EncBE,
         native_estimator: &'a NBE,
         trapdoor_checkpoint: CircuitBenchEstimate,
-        trapdoor_preimage_extend: CircuitBenchEstimate,
-        final_preimage_extend_one_column: CircuitBenchEstimate,
-        w_hash_one_column: CircuitBenchEstimate,
-        transition_w_chunk_hash_sample: CircuitBenchEstimate,
+        trapdoor_preimage: CircuitBenchEstimate,
+        final_preimage_one_column: CircuitBenchEstimate,
         bgg_public_key_sample: CircuitBenchEstimate,
         scalar_matrix_hash_sample: CircuitBenchEstimate,
     ) -> Self {
@@ -102,10 +96,8 @@ where
             encoding_estimator,
             native_estimator,
             trapdoor_checkpoint,
-            trapdoor_preimage_extend,
-            final_preimage_extend_one_column,
-            w_hash_one_column,
-            transition_w_chunk_hash_sample,
+            trapdoor_preimage,
+            final_preimage_one_column,
             bgg_public_key_sample,
             scalar_matrix_hash_sample,
         }
@@ -292,26 +284,14 @@ where
             ]),
             shape.ordinary_preimage_count(),
         );
-        let ordinary_hashing = scale_summary(
-            self.w_hash_summary_for_width(shape.modulus_digits),
-            shape.ordinary_preimage_count(),
-        );
         let ordinary_preimages = scale_summary(
             self.final_preimage_summary_for_width(shape.modulus_digits),
             shape.ordinary_preimage_count(),
         );
-        let k_hashing = self.w_hash_summary_for_width(shape.modulus_digits);
         let k_preimage = self.final_preimage_summary_for_width(1);
 
-        let mut parts = vec![
-            ordinary_hashing,
-            ordinary_target_building,
-            ordinary_preimages,
-            k_hashing,
-            k_preimage,
-        ];
+        let mut parts = vec![ordinary_target_building, ordinary_preimages, k_preimage];
         if let Some(lookup_cols) = shape.lookup_bridge_cols {
-            parts.push(self.w_hash_summary_for_width(lookup_cols));
             parts.push(self.final_preimage_summary_for_width(lookup_cols));
         }
         parallel_summaries(parts.as_slice())
@@ -329,10 +309,7 @@ where
                 .estimate_vector_matrix_product(shape.modulus_digits, DIAMOND_SECRET_SIZE),
             estimate_summary(self.native_estimator.estimate_vector_add(DIAMOND_SECRET_SIZE)),
         ]);
-        sequential_summaries(&[
-            parallel_summaries(&[self.w_hash_summary_for_width(shape.modulus_digits), target]),
-            self.final_preimage_summary_for_width(1),
-        ])
+        sequential_summaries(&[target, self.final_preimage_summary_for_width(1)])
     }
 
     fn estimate_dec_circuit_input_path<M>(
@@ -387,38 +364,16 @@ where
         let checkpoint_sampling =
             scale_estimate(self.trapdoor_checkpoint.clone(), shape.checkpoint_count);
         let initial_state = sequential_summaries(&[
-            self.w_hash_summary_for_width(shape.modulus_digits),
             self.native_estimator
                 .estimate_vector_matrix_product(shape.state_row_size, shape.state_col_size),
             estimate_summary(self.native_estimator.estimate_vector_add(shape.state_col_size)),
         ]);
-        let transition_ext_w_hash_sampling = scale_summary(
-            self.w_hash_summary_for_width(shape.modulus_digits),
-            shape.transition_ext_w_hash_count,
-        );
-        let transition_w_hash_per_matrix = shape
-            .transition_w_chunk_col_lens
-            .par_iter()
-            .map(|&col_len| self.w_hash_summary_for_width(col_len))
-            .collect::<Vec<_>>();
-        let transition_target_w_hash_sampling = scale_summary(
-            parallel_summaries(transition_w_hash_per_matrix.as_slice()),
-            shape.transition_matrix_count,
-        );
         let transition_target_building =
             shape.estimate_transition_target_building(self.native_estimator);
-        let transition_preimages = scale_estimate(
-            self.trapdoor_preimage_extend.clone(),
-            shape.transition_preimage_chunk_count,
-        );
-        let transition_stage = sequential_summaries(&[
-            parallel_summaries(&[
-                transition_ext_w_hash_sampling,
-                transition_target_w_hash_sampling,
-            ]),
-            transition_target_building,
-            transition_preimages,
-        ]);
+        let transition_preimages =
+            scale_estimate(self.trapdoor_preimage.clone(), shape.transition_preimage_chunk_count);
+        let transition_stage =
+            sequential_summaries(&[transition_target_building, transition_preimages]);
         let enc = sequential_summaries(&[
             checkpoint_sampling.clone(),
             parallel_summaries(&[initial_state.clone(), transition_stage.clone()]),
@@ -427,12 +382,8 @@ where
         DiamondWEInputInjectionBenchEstimateParts { enc, dec }
     }
 
-    fn w_hash_summary_for_width(&self, width: usize) -> CircuitBenchSummary {
-        scale_estimate(self.w_hash_one_column.clone(), width)
-    }
-
     fn final_preimage_summary_for_width(&self, width: usize) -> CircuitBenchSummary {
-        scale_estimate(self.final_preimage_extend_one_column.clone(), width)
+        scale_estimate(self.final_preimage_one_column.clone(), width)
     }
 
     fn estimate_storage(&self, shape: DiamondWEBenchShape) -> DiamondWEStorageEstimate {
@@ -470,13 +421,12 @@ struct DiamondWEBenchShape {
     state_col_size: usize,
     b_public_col_size: usize,
     checkpoint_count: usize,
+    final_checkpoint_count: usize,
     transition_matrix_count: usize,
     transition_preimage_chunk_count: usize,
     input_injection_transition_preimage_bytes: usize,
-    transition_ext_w_hash_count: usize,
     online_level_state_counts: Vec<usize>,
     transition_chunk_col_lens: Vec<usize>,
-    transition_w_chunk_col_lens: Vec<usize>,
     lookup_bridge_cols: Option<usize>,
     dec_lookup_bridge_cols: Option<usize>,
 }
@@ -512,14 +462,10 @@ impl DiamondWEBenchShape {
             .expect("DiamondWE modulus bits must fit in u16 for compact-byte estimates");
         let state_row_size =
             2usize.checked_mul(DIAMOND_SECRET_SIZE).expect("DiamondWE state row size overflow");
-        let gadget_col_size = DIAMOND_SECRET_SIZE
-            .checked_mul(modulus_digits)
-            .expect("DiamondWE gadget column count overflow");
         let b_public_col_size = state_row_size
             .checked_mul(modulus_digits + 2)
             .expect("DiamondWE B public column count overflow");
-        let state_col_size =
-            b_public_col_size.checked_add(gadget_col_size).expect("DiamondWE state cols overflow");
+        let state_col_size = b_public_col_size;
         let chunk_count = column_chunk_count(state_col_size);
         let transition_chunk_col_lens = (0..chunk_count)
             .map(|chunk_idx| column_chunk_bounds(state_col_size, chunk_idx).1)
@@ -531,26 +477,11 @@ impl DiamondWEBenchShape {
             })
             .collect::<Vec<_>>();
         let transition_preimage_bytes_per_matrix = transition_chunk_bytes.iter().sum::<usize>();
-        let transition_w_chunk_lens = (0..chunk_count)
-            .filter_map(|chunk_idx| {
-                let (col_start, col_len) = column_chunk_bounds(state_col_size, chunk_idx);
-                let col_end = col_start + col_len;
-                let w_start = b_public_col_size;
-                if col_end <= w_start {
-                    None
-                } else {
-                    let w_len = col_end - col_start.max(w_start);
-                    (w_len > 0).then_some(w_len)
-                }
-            })
-            .collect::<Vec<_>>();
         let mut transition_matrix_count = 0usize;
         let mut transition_preimage_chunk_count = 0usize;
-        let mut transition_ext_w_hash_count = 0usize;
         let mut online_level_state_counts = Vec::with_capacity(diamond.injector.input_count);
         for level in 1..=diamond.injector.input_count {
-            let state_count = expanded_state_count_after_level(diamond, level);
-            let old_state_count = state_count.saturating_sub(diamond.injector.batch_bits());
+            let state_count = state_count_at_level(diamond, level);
             transition_matrix_count = transition_matrix_count
                 .checked_add(
                     diamond
@@ -570,21 +501,13 @@ impl DiamondWEBenchShape {
                         .expect("DiamondWE transition chunk count overflow"),
                 )
                 .expect("DiamondWE transition chunk count overflow");
-            transition_ext_w_hash_count = transition_ext_w_hash_count
-                .checked_add(
-                    diamond
-                        .injector
-                        .base
-                        .checked_mul(
-                            old_state_count
-                                .checked_add(1)
-                                .expect("DiamondWE transition W hash count overflow"),
-                        )
-                        .expect("DiamondWE transition W hash count overflow"),
-                )
-                .expect("DiamondWE transition W hash count overflow");
             online_level_state_counts.push(state_count);
         }
+        let checkpoint_count = (0..=diamond.injector.input_count)
+            .map(|level| state_count_at_level(diamond, level))
+            .try_fold(0usize, |acc, count| acc.checked_add(count))
+            .expect("DiamondWE checkpoint count overflow");
+        let final_checkpoint_count = state_count_at_level(diamond, diamond.injector.input_count);
         let input_injection_transition_preimage_bytes = transition_preimage_bytes_per_matrix
             .checked_mul(transition_matrix_count)
             .expect("DiamondWE transition preimage byte count overflow");
@@ -605,14 +528,13 @@ impl DiamondWEBenchShape {
             state_row_size,
             state_col_size,
             b_public_col_size,
-            checkpoint_count: diamond.injector.input_count + 1,
+            checkpoint_count,
+            final_checkpoint_count,
             transition_matrix_count,
             transition_preimage_chunk_count,
             input_injection_transition_preimage_bytes,
-            transition_ext_w_hash_count,
             online_level_state_counts,
             transition_chunk_col_lens,
-            transition_w_chunk_col_lens: transition_w_chunk_lens,
             lookup_bridge_cols,
             dec_lookup_bridge_cols,
         }
@@ -624,14 +546,13 @@ impl DiamondWEBenchShape {
 
     fn input_injection_metadata_and_seed_bytes(&self) -> BigUint {
         let metadata_estimate = 128usize;
-        let hash_key_bytes = 32usize;
         let p_epsilon_bytes = matrix_compact_bytes_for_shape(
             self.state_row_size / 2,
             self.state_col_size,
             self.ring_dim,
             self.modulus_bits,
         );
-        BigUint::from(metadata_estimate + hash_key_bytes + p_epsilon_bytes)
+        BigUint::from(metadata_estimate + p_epsilon_bytes)
     }
 
     fn input_injection_public_checkpoint_bytes(&self) -> usize {
@@ -641,7 +562,7 @@ impl DiamondWEBenchShape {
             self.ring_dim,
             self.modulus_bits,
         )
-        .checked_mul(self.checkpoint_count)
+        .checked_mul(self.final_checkpoint_count)
         .expect("DiamondWE B checkpoint byte count overflow")
     }
 
@@ -668,9 +589,7 @@ impl DiamondWEBenchShape {
             .lookup_bridge_cols
             .map(|lookup_cols| {
                 matrix_compact_bytes_for_shape(
-                    self.b_public_col_size
-                        .checked_add(lookup_cols)
-                        .expect("DiamondWE lookup preimage row count overflow"),
+                    self.state_col_size,
                     lookup_cols,
                     self.ring_dim,
                     self.modulus_bits,
@@ -757,10 +676,8 @@ struct DiamondWEInputInjectionBenchEstimateParts {
 #[derive(Debug, Clone)]
 struct DiamondWEBenchUnitEstimates {
     trapdoor_checkpoint: CircuitBenchEstimate,
-    trapdoor_preimage_extend: CircuitBenchEstimate,
-    final_preimage_extend_one_column: CircuitBenchEstimate,
-    w_hash_one_column: CircuitBenchEstimate,
-    transition_w_chunk_hash_sample: CircuitBenchEstimate,
+    trapdoor_preimage: CircuitBenchEstimate,
+    final_preimage_one_column: CircuitBenchEstimate,
     bgg_public_key_sample: CircuitBenchEstimate,
     scalar_matrix_hash_sample: CircuitBenchEstimate,
 }
@@ -790,47 +707,22 @@ impl DiamondWEBenchUnitEstimates {
 
         let trap_sampler = TS::new(params, diamond.injector.trapdoor_sigma);
         let (trapdoor, public_matrix) = trap_sampler.trapdoor(params, state_row_size);
-        let ext_matrix = HS::new().sample_hash(
-            params,
-            [0x71u8; 32],
-            b"diamond_we_bench_preimage_ext",
-            state_row_size,
-            modulus_digits,
-            DistType::FinRingDist,
-        );
         let one_column_target = M::zero(params, state_row_size, 1);
         let preimage_one_column = bench_estimate(iterations, || {
-            let preimage = trap_sampler.preimage_extend(
-                params,
-                &trapdoor,
-                &public_matrix,
-                &ext_matrix,
-                &one_column_target,
-            );
+            let preimage =
+                trap_sampler.preimage(params, &trapdoor, &public_matrix, &one_column_target);
             black_box(preimage.to_compact_bytes())
         });
-        let transition_preimage_extend = scale_independent_estimate(
+        let transition_preimage = scale_independent_estimate(
             preimage_one_column.clone(),
             column_chunk_bounds(
                 state_row_size
                     .checked_mul(modulus_digits + 2)
-                    .and_then(|b_cols| b_cols.checked_add(modulus_digits))
                     .expect("DiamondWE benchmark state col overflow"),
                 0,
             )
             .1,
         );
-        let w_hash_one_column = bench_estimate(iterations, || {
-            let matrix = HS::new().sample_hash(
-                params,
-                [0x72u8; 32],
-                b"diamond_we_bench_w_hash_one_column",
-                state_row_size,
-                1,
-                DistType::FinRingDist,
-            );
-            black_box(matrix.to_compact_bytes())
-        });
         let bgg_public_key_sample = bench_estimate(iterations, || {
             BGGPublicKeySampler::<[u8; 32], HS>::new([0x73u8; 32], DIAMOND_SECRET_SIZE).sample(
                 params,
@@ -851,17 +743,15 @@ impl DiamondWEBenchUnitEstimates {
         });
         Self {
             trapdoor_checkpoint,
-            trapdoor_preimage_extend: transition_preimage_extend,
-            final_preimage_extend_one_column: preimage_one_column,
-            w_hash_one_column: w_hash_one_column.clone(),
-            transition_w_chunk_hash_sample: w_hash_one_column,
+            trapdoor_preimage: transition_preimage,
+            final_preimage_one_column: preimage_one_column,
             bgg_public_key_sample,
             scalar_matrix_hash_sample,
         }
     }
 }
 
-fn expanded_state_count_after_level<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
+fn state_count_at_level<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>(
     diamond: &DiamondWE<M, US, HS, TS, PKPE, PKST, ENCPE, ENCST>,
     level: usize,
 ) -> usize
@@ -1177,8 +1067,6 @@ mod tests {
             unit(3.0),
             unit(4.0),
             unit(5.0),
-            unit(6.0),
-            unit(7.0),
         )
     }
 

--- a/src/we/diamond_we/simulation.rs
+++ b/src/we/diamond_we/simulation.rs
@@ -178,6 +178,7 @@ where
         );
 
         let input_injection = self.injector.simulate_output_error_bounds();
+        // B-only final projection preimage: B_{input_count,state_idx} * R = target.
         let ctx = input_injection.output_preimage.clone_ctx();
         let one_plaintext = PolyNorm::one(ctx.clone());
         let q = self.injector.params.modulus();

--- a/tests/test_gpu_diamond_injector_q_bits_vs_max_error_plot_generates_svg.rs
+++ b/tests/test_gpu_diamond_injector_q_bits_vs_max_error_plot_generates_svg.rs
@@ -14,7 +14,6 @@ use mxx::{
         },
     },
     sampler::{
-        DistType, PolyHashSampler,
         gpu::{GpuDCRTPolyHashSampler, GpuDCRTPolyUniformSampler},
         trapdoor::GpuDCRTPolyTrapdoorSampler,
     },
@@ -41,7 +40,6 @@ type TestInjector = DiamondInjector<
     GpuDCRTPolyTrapdoorSampler,
 >;
 
-const DIAMOND_INJECTOR_SECRET_SIZE: usize = 1;
 const DIAMOND_INJECTOR_TRAPDOOR_SIGMA: f64 = 4.578;
 const DIAMOND_INJECTOR_ERROR_SIGMA: f64 = 4.578;
 const DEFAULT_RING_DIM: u32 = 1u32 << 16;
@@ -107,22 +105,6 @@ fn gpu_params_for_crt_depth(
         cpu_params.base_bits(),
         vec![gpu_ids[0]],
         Some(1),
-    )
-}
-
-fn sample_final_w_block(
-    params: &GpuDCRTPolyParams,
-    hash_key: [u8; 32],
-    block_idx: usize,
-    input_count: usize,
-) -> GpuDCRTPolyMatrix {
-    GpuDCRTPolyHashSampler::<Keccak256>::new().sample_hash(
-        params,
-        hash_key,
-        format!("diamond_w_{block_idx}_{input_count}"),
-        2 * DIAMOND_INJECTOR_SECRET_SIZE,
-        DIAMOND_INJECTOR_SECRET_SIZE * params.modulus_digits(),
-        DistType::FinRingDist,
     )
 }
 
@@ -277,9 +259,7 @@ fn verify_gpu_online_eval_errors_below_simulation(
     );
 
     let secret_product = reconstruct_secret_product(&params, dir.path(), &input_digits);
-    let base_public_matrix = preprocess_out
-        .final_pub_matrix
-        .concat_columns(&[&sample_final_w_block(&params, preprocess_out.hash_key, 0, input_count)]);
+    let base_public_matrix = preprocess_out.final_pub_matrices[0].clone();
     let base_selector =
         GpuDCRTPolyMatrix::from_poly_vec_row(&params, vec![secret_product.entry(0, 0), k]);
     assert_state_residual_below_bound(
@@ -300,13 +280,7 @@ fn verify_gpu_online_eval_errors_below_simulation(
                 &params,
                 vec![secret_product.entry(0, 0), secret_product.entry(0, 0) * &bit_plaintext],
             );
-            let bit_public_matrix =
-                preprocess_out.final_pub_matrix.concat_columns(&[&sample_final_w_block(
-                    &params,
-                    preprocess_out.hash_key,
-                    state_idx,
-                    input_count,
-                )]);
+            let bit_public_matrix = preprocess_out.final_pub_matrices[state_idx].clone();
             assert_state_residual_below_bound(
                 &format!("bit_state_{state_idx}"),
                 &params,


### PR DESCRIPTION
## Summary
- Remove `W`-based Diamond injector paths and switch transitions/final projections to per-(level, state) `B` checkpoints
- Replace `preimage_extend` usage with `preimage` across Diamond injector, DiamondWE, and DiamondIO flows
- Update storage and benchmark estimators, GPU paths, and affected tests to match the new shape and checkpoint layout

## Testing
- `cargo +nightly fmt --all`
- `cargo test diamond_injector`
- `cargo test diamond_we`
- `cargo test diamond_io`
- `cargo check --lib --features gpu`
- Targeted GPU relation and plot test validation passed