### PR TITLE
Fix IO benchmark storage setup and defer GPU detection

### DIFF
--- a/tests/test_gpu_aky24_io.rs
+++ b/tests/test_gpu_aky24_io.rs
@@ -987,6 +987,7 @@ async fn build_naive_vec_encoding_bench_estimator(
     bench_dir: PathBuf,
 ) -> NaiveBGGVecBenchEstimator<BggEncodingBenchEstimator<GpuMatrix>> {
     ensure_clean_dir(&bench_dir);
+    init_storage_system(bench_dir.clone());
 
     let (public_lut, public_lut_id, public_lut_gate_id) =
         build_benchmark_public_lookup_gate(params);
@@ -1064,12 +1065,8 @@ async fn test_gpu_aky24_io_error_search_and_bench_estimate() {
         .with(log_filter)
         .with(tracing_subscriber::fmt::layer())
         .try_init();
-    gpu_device_sync();
-
     let cfg = Aky24IOGpuBenchConfig::from_env();
     info!("AKY24IO GPU bench config: {:?}", cfg);
-    let gpu_id =
-        *detected_gpu_device_ids().first().expect("test_gpu_aky24_io requires at least one GPU");
     let temp_dir = tempdir().expect("AKY24IO GPU bench test must create a tempdir");
     init_storage_system(temp_dir.path().to_path_buf());
 
@@ -1170,6 +1167,9 @@ async fn test_gpu_aky24_io_error_search_and_bench_estimate() {
         return;
     }
 
+    gpu_device_sync();
+    let gpu_id =
+        *detected_gpu_device_ids().first().expect("test_gpu_aky24_io requires at least one GPU");
     let (cpu_params, gpu_params) =
         gpu_params_for_crt_depth(&cfg, selected.ring_dim, selected.crt_depth, gpu_id);
     assert_eq!(

--- a/tests/test_gpu_diamond_io.rs
+++ b/tests/test_gpu_diamond_io.rs
@@ -803,6 +803,7 @@ async fn build_naive_vec_encoding_bench_estimator(
     bench_dir: PathBuf,
 ) -> NaiveBGGVecBenchEstimator<BggEncodingBenchEstimator<GpuMatrix>> {
     ensure_clean_dir(&bench_dir);
+    init_storage_system(bench_dir.clone());
 
     let (public_lut, public_lut_id, public_lut_gate_id) =
         build_benchmark_public_lookup_gate(params);
@@ -884,12 +885,8 @@ async fn test_gpu_diamond_io_error_search_and_bench_estimate() {
         .with(log_filter)
         .with(tracing_subscriber::fmt::layer())
         .try_init();
-    gpu_device_sync();
-
     let cfg = DiamondIOGpuBenchConfig::from_env();
     info!("DiamondIO GPU bench config: {:?}", cfg);
-    let gpu_id =
-        *detected_gpu_device_ids().first().expect("test_gpu_diamond_io requires at least one GPU");
     let temp_dir = tempdir().expect("DiamondIO GPU bench test must create a tempdir");
     init_storage_system(temp_dir.path().to_path_buf());
 
@@ -989,6 +986,9 @@ async fn test_gpu_diamond_io_error_search_and_bench_estimate() {
         return;
     }
 
+    gpu_device_sync();
+    let gpu_id =
+        *detected_gpu_device_ids().first().expect("test_gpu_diamond_io requires at least one GPU");
     let (cpu_params, gpu_params) =
         gpu_params_for_crt_depth(&cfg, selected.ring_dim, selected.crt_depth, gpu_id);
     assert_eq!(


### PR DESCRIPTION
## Summary
- Reinitialize storage against the active bench directory before building the naive vector encoding benchmark for both `diamond_io` and `aky24_io`.
- Defer GPU synchronization and device detection until after error simulation selection, so search-only runs can proceed without requiring a local GPU.
- Preserve the selected CRT-depth-driven benchmark flow while keeping the H200 benchmark path aligned with the latest local fix.

## Testing
- `cargo +nightly fmt --all`
- `FIDESLIB_SKIP_SUBMODULE_UPDATE=1 cargo test --release --features gpu --test test_gpu_diamond_io --test test_gpu_aky24_io --no-run`
- Verified the affected H200 benchmark rerun completed past the previous public-LUT checkpoint failure