### PR TITLE
Fuse GPU trapdoor preimage sampling

### DIFF
--- a/cuda/include/matrix/MatrixTrapdoor.cuh
+++ b/cuda/include/matrix/MatrixTrapdoor.cuh
@@ -112,10 +112,8 @@ extern "C"
         const GpuMatrix *p1,
         const GpuMatrix *p2);
 
-    int gpu_matrix_preimage_assemble(
+    int gpu_matrix_preimage_add_correction(
         GpuMatrix *out,
-        const GpuMatrix *p1,
-        const GpuMatrix *p2,
         const GpuMatrix *r,
         const GpuMatrix *e,
         const GpuMatrix *z);

--- a/cuda/include/matrix/MatrixTrapdoor.cuh
+++ b/cuda/include/matrix/MatrixTrapdoor.cuh
@@ -99,6 +99,27 @@ extern "C"
         gpu_chacha::GpuRngSeed seed,
         GpuMatrix *out);
 
+    int gpu_matrix_mul_vertical_pair(
+        GpuMatrix *out,
+        const GpuMatrix *top,
+        const GpuMatrix *bottom,
+        const GpuMatrix *rhs);
+
+    int gpu_matrix_preimage_residual(
+        GpuMatrix *out,
+        const GpuMatrix *target,
+        const GpuMatrix *public_matrix,
+        const GpuMatrix *p1,
+        const GpuMatrix *p2);
+
+    int gpu_matrix_preimage_assemble(
+        GpuMatrix *out,
+        const GpuMatrix *p1,
+        const GpuMatrix *p2,
+        const GpuMatrix *r,
+        const GpuMatrix *e,
+        const GpuMatrix *z);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cuda/src/matrix/MatrixTrapdoor.cu
+++ b/cuda/src/matrix/MatrixTrapdoor.cu
@@ -92,6 +92,507 @@ struct GpuP1CovarianceCache
     double *update_coeff = nullptr;  // [coeff][sampled_row][updated_row]
 };
 
+namespace
+{
+    // These are CUDA block-shape constants, not a preimage chunk limit. Every
+    // kernel below receives the runtime column count selected by
+    // AUX_SAMPLING_CHUNK_WIDTH and covers any final partial tile.
+    constexpr int kPreimageTileM = 4;
+    constexpr int kPreimageTileN = 32;
+    constexpr int kPreimageTileK = 16;
+
+    __device__ __forceinline__ uint64_t sub_mod_preimage_u64(
+        uint64_t lhs,
+        uint64_t rhs,
+        uint64_t modulus)
+    {
+        return lhs >= rhs ? lhs - rhs : modulus - (rhs - lhs);
+    }
+
+    __global__ void matrix_mul_vertical_pair_kernel(
+        const uint8_t *top_base,
+        const uint8_t *bottom_base,
+        const uint8_t *rhs_base,
+        uint8_t *out_base,
+        size_t top_rows,
+        size_t bottom_rows,
+        size_t inner,
+        size_t cols,
+        size_t n,
+        size_t top_stride_bytes,
+        size_t bottom_stride_bytes,
+        size_t rhs_stride_bytes,
+        size_t out_stride_bytes,
+        uint8_t top_coeff_bytes,
+        uint8_t bottom_coeff_bytes,
+        uint8_t rhs_coeff_bytes,
+        uint8_t out_coeff_bytes,
+        uint64_t modulus)
+    {
+        __shared__ uint64_t lhs_tile[kPreimageTileM][kPreimageTileK];
+        __shared__ uint64_t rhs_tile[kPreimageTileK][kPreimageTileN];
+
+        const size_t row_base = static_cast<size_t>(blockIdx.y) * kPreimageTileM;
+        const size_t col_base = static_cast<size_t>(blockIdx.x) * kPreimageTileN;
+        const size_t row = row_base + threadIdx.y;
+        const size_t col = col_base + threadIdx.x;
+        const size_t total_rows = top_rows + bottom_rows;
+        const int tid = static_cast<int>(threadIdx.y) * blockDim.x + threadIdx.x;
+        const int thread_count = blockDim.x * blockDim.y;
+
+        for (size_t coeff_idx = static_cast<size_t>(blockIdx.z);
+             coeff_idx < n;
+             coeff_idx += static_cast<size_t>(gridDim.z))
+        {
+            uint64_t acc = 0;
+            for (size_t k0 = 0; k0 < inner; k0 += kPreimageTileK)
+            {
+                for (int i = tid; i < kPreimageTileM * kPreimageTileK; i += thread_count)
+                {
+                    const int local_row = i / kPreimageTileK;
+                    const int local_k = i - local_row * kPreimageTileK;
+                    const size_t input_row = row_base + static_cast<size_t>(local_row);
+                    const size_t input_k = k0 + static_cast<size_t>(local_k);
+                    uint64_t value = 0;
+                    if (input_row < total_rows && input_k < inner)
+                    {
+                        if (input_row < top_rows)
+                        {
+                            value = matrix_load_limb_u64(
+                                top_base,
+                                input_row * inner + input_k,
+                                coeff_idx,
+                                top_stride_bytes,
+                                top_coeff_bytes);
+                        }
+                        else
+                        {
+                            value = matrix_load_limb_u64(
+                                bottom_base,
+                                (input_row - top_rows) * inner + input_k,
+                                coeff_idx,
+                                bottom_stride_bytes,
+                                bottom_coeff_bytes);
+                        }
+                    }
+                    lhs_tile[local_row][local_k] = value;
+                }
+                for (int i = tid; i < kPreimageTileK * kPreimageTileN; i += thread_count)
+                {
+                    const int local_k = i / kPreimageTileN;
+                    const int local_col = i - local_k * kPreimageTileN;
+                    const size_t input_k = k0 + static_cast<size_t>(local_k);
+                    const size_t input_col = col_base + static_cast<size_t>(local_col);
+                    uint64_t value = 0;
+                    if (input_k < inner && input_col < cols)
+                    {
+                        value = matrix_load_limb_u64(
+                            rhs_base,
+                            input_k * cols + input_col,
+                            coeff_idx,
+                            rhs_stride_bytes,
+                            rhs_coeff_bytes);
+                    }
+                    rhs_tile[local_k][local_col] = value;
+                }
+                __syncthreads();
+
+                if (row < total_rows && col < cols)
+                {
+                    for (int local_k = 0; local_k < kPreimageTileK; ++local_k)
+                    {
+                        acc = add_mod_u64(
+                            acc,
+                            mul_mod_u64(
+                                lhs_tile[threadIdx.y][local_k],
+                                rhs_tile[local_k][threadIdx.x],
+                                modulus),
+                            modulus);
+                    }
+                }
+                __syncthreads();
+            }
+
+            if (row < total_rows && col < cols)
+            {
+                matrix_store_limb_u64(
+                    out_base,
+                    row * cols + col,
+                    coeff_idx,
+                    out_stride_bytes,
+                    out_coeff_bytes,
+                    acc);
+            }
+        }
+    }
+
+    __global__ void matrix_preimage_residual_kernel(
+        const uint8_t *target_base,
+        const uint8_t *public_base,
+        const uint8_t *p1_base,
+        const uint8_t *p2_base,
+        uint8_t *out_base,
+        size_t rows,
+        size_t p1_rows,
+        size_t p2_rows,
+        size_t p1_cols,
+        size_t p2_cols,
+        size_t out_cols,
+        size_t n,
+        size_t target_stride_bytes,
+        size_t public_stride_bytes,
+        size_t p1_stride_bytes,
+        size_t p2_stride_bytes,
+        size_t out_stride_bytes,
+        uint8_t target_coeff_bytes,
+        uint8_t public_coeff_bytes,
+        uint8_t p1_coeff_bytes,
+        uint8_t p2_coeff_bytes,
+        uint8_t out_coeff_bytes,
+        uint64_t modulus)
+    {
+        __shared__ uint64_t public_tile[kPreimageTileM][kPreimageTileK];
+        __shared__ uint64_t perturbation_tile[kPreimageTileK][kPreimageTileN];
+
+        const size_t row_base = static_cast<size_t>(blockIdx.y) * kPreimageTileM;
+        const size_t col_base = static_cast<size_t>(blockIdx.x) * kPreimageTileN;
+        const size_t row = row_base + threadIdx.y;
+        const size_t col = col_base + threadIdx.x;
+        const size_t inner = p1_rows + p2_rows;
+        const int tid = static_cast<int>(threadIdx.y) * blockDim.x + threadIdx.x;
+        const int thread_count = blockDim.x * blockDim.y;
+
+        for (size_t coeff_idx = static_cast<size_t>(blockIdx.z);
+             coeff_idx < n;
+             coeff_idx += static_cast<size_t>(gridDim.z))
+        {
+            uint64_t acc = 0;
+            if (row < rows && col < out_cols)
+            {
+                acc = matrix_load_limb_u64(
+                    target_base,
+                    row * out_cols + col,
+                    coeff_idx,
+                    target_stride_bytes,
+                    target_coeff_bytes);
+            }
+
+            for (size_t k0 = 0; k0 < inner; k0 += kPreimageTileK)
+            {
+                for (int i = tid; i < kPreimageTileM * kPreimageTileK; i += thread_count)
+                {
+                    const int local_row = i / kPreimageTileK;
+                    const int local_k = i - local_row * kPreimageTileK;
+                    const size_t input_row = row_base + static_cast<size_t>(local_row);
+                    const size_t input_k = k0 + static_cast<size_t>(local_k);
+                    uint64_t value = 0;
+                    if (input_row < rows && input_k < inner)
+                    {
+                        value = matrix_load_limb_u64(
+                            public_base,
+                            input_row * inner + input_k,
+                            coeff_idx,
+                            public_stride_bytes,
+                            public_coeff_bytes);
+                    }
+                    public_tile[local_row][local_k] = value;
+                }
+                for (int i = tid; i < kPreimageTileK * kPreimageTileN; i += thread_count)
+                {
+                    const int local_k = i / kPreimageTileN;
+                    const int local_col = i - local_k * kPreimageTileN;
+                    const size_t input_k = k0 + static_cast<size_t>(local_k);
+                    const size_t input_col = col_base + static_cast<size_t>(local_col);
+                    uint64_t value = 0;
+                    if (input_k < inner && input_col < out_cols)
+                    {
+                        if (input_k < p1_rows)
+                        {
+                            value = matrix_load_limb_u64(
+                                p1_base,
+                                input_k * p1_cols + input_col,
+                                coeff_idx,
+                                p1_stride_bytes,
+                                p1_coeff_bytes);
+                        }
+                        else
+                        {
+                            value = matrix_load_limb_u64(
+                                p2_base,
+                                (input_k - p1_rows) * p2_cols + input_col,
+                                coeff_idx,
+                                p2_stride_bytes,
+                                p2_coeff_bytes);
+                        }
+                    }
+                    perturbation_tile[local_k][local_col] = value;
+                }
+                __syncthreads();
+
+                if (row < rows && col < out_cols)
+                {
+                    for (int local_k = 0; local_k < kPreimageTileK; ++local_k)
+                    {
+                        acc = sub_mod_preimage_u64(
+                            acc,
+                            mul_mod_u64(
+                                public_tile[threadIdx.y][local_k],
+                                perturbation_tile[local_k][threadIdx.x],
+                                modulus),
+                            modulus);
+                    }
+                }
+                __syncthreads();
+            }
+
+            if (row < rows && col < out_cols)
+            {
+                matrix_store_limb_u64(
+                    out_base,
+                    row * out_cols + col,
+                    coeff_idx,
+                    out_stride_bytes,
+                    out_coeff_bytes,
+                    acc);
+            }
+        }
+    }
+
+    __global__ void matrix_preimage_assemble_top_kernel(
+        const uint8_t *p1_base,
+        const uint8_t *r_base,
+        const uint8_t *e_base,
+        const uint8_t *z_base,
+        uint8_t *out_base,
+        size_t d,
+        size_t inner,
+        size_t p1_cols,
+        size_t z_cols,
+        size_t out_cols,
+        size_t n,
+        size_t p1_stride_bytes,
+        size_t r_stride_bytes,
+        size_t e_stride_bytes,
+        size_t z_stride_bytes,
+        size_t out_stride_bytes,
+        uint8_t p1_coeff_bytes,
+        uint8_t r_coeff_bytes,
+        uint8_t e_coeff_bytes,
+        uint8_t z_coeff_bytes,
+        uint8_t out_coeff_bytes,
+        uint64_t modulus)
+    {
+        __shared__ uint64_t trapdoor_tile[kPreimageTileM][kPreimageTileK];
+        __shared__ uint64_t z_tile[kPreimageTileK][kPreimageTileN];
+
+        const size_t row_base = static_cast<size_t>(blockIdx.y) * kPreimageTileM;
+        const size_t col_base = static_cast<size_t>(blockIdx.x) * kPreimageTileN;
+        const size_t row = row_base + threadIdx.y;
+        const size_t col = col_base + threadIdx.x;
+        const size_t top_rows = 2 * d;
+        const int tid = static_cast<int>(threadIdx.y) * blockDim.x + threadIdx.x;
+        const int thread_count = blockDim.x * blockDim.y;
+
+        for (size_t coeff_idx = static_cast<size_t>(blockIdx.z);
+             coeff_idx < n;
+             coeff_idx += static_cast<size_t>(gridDim.z))
+        {
+            uint64_t acc = 0;
+            if (row < top_rows && col < out_cols)
+            {
+                acc = matrix_load_limb_u64(
+                    p1_base,
+                    row * p1_cols + col,
+                    coeff_idx,
+                    p1_stride_bytes,
+                    p1_coeff_bytes);
+            }
+
+            for (size_t k0 = 0; k0 < inner; k0 += kPreimageTileK)
+            {
+                for (int i = tid; i < kPreimageTileM * kPreimageTileK; i += thread_count)
+                {
+                    const int local_row = i / kPreimageTileK;
+                    const int local_k = i - local_row * kPreimageTileK;
+                    const size_t input_row = row_base + static_cast<size_t>(local_row);
+                    const size_t input_k = k0 + static_cast<size_t>(local_k);
+                    uint64_t value = 0;
+                    if (input_row < top_rows && input_k < inner)
+                    {
+                        if (input_row < d)
+                        {
+                            value = matrix_load_limb_u64(
+                                r_base,
+                                input_row * inner + input_k,
+                                coeff_idx,
+                                r_stride_bytes,
+                                r_coeff_bytes);
+                        }
+                        else
+                        {
+                            value = matrix_load_limb_u64(
+                                e_base,
+                                (input_row - d) * inner + input_k,
+                                coeff_idx,
+                                e_stride_bytes,
+                                e_coeff_bytes);
+                        }
+                    }
+                    trapdoor_tile[local_row][local_k] = value;
+                }
+                for (int i = tid; i < kPreimageTileK * kPreimageTileN; i += thread_count)
+                {
+                    const int local_k = i / kPreimageTileN;
+                    const int local_col = i - local_k * kPreimageTileN;
+                    const size_t input_k = k0 + static_cast<size_t>(local_k);
+                    const size_t input_col = col_base + static_cast<size_t>(local_col);
+                    uint64_t value = 0;
+                    if (input_k < inner && input_col < out_cols)
+                    {
+                        value = matrix_load_limb_u64(
+                            z_base,
+                            input_k * z_cols + input_col,
+                            coeff_idx,
+                            z_stride_bytes,
+                            z_coeff_bytes);
+                    }
+                    z_tile[local_k][local_col] = value;
+                }
+                __syncthreads();
+
+                if (row < top_rows && col < out_cols)
+                {
+                    for (int local_k = 0; local_k < kPreimageTileK; ++local_k)
+                    {
+                        acc = add_mod_u64(
+                            acc,
+                            mul_mod_u64(
+                                trapdoor_tile[threadIdx.y][local_k],
+                                z_tile[local_k][threadIdx.x],
+                                modulus),
+                            modulus);
+                    }
+                }
+                __syncthreads();
+            }
+
+            if (row < top_rows && col < out_cols)
+            {
+                matrix_store_limb_u64(
+                    out_base,
+                    row * out_cols + col,
+                    coeff_idx,
+                    out_stride_bytes,
+                    out_coeff_bytes,
+                    acc);
+            }
+        }
+    }
+
+    __global__ void matrix_preimage_assemble_bottom_kernel(
+        const uint8_t *p2_base,
+        const uint8_t *z_base,
+        uint8_t *out_base,
+        size_t p1_rows,
+        size_t p2_rows,
+        size_t p2_cols,
+        size_t z_cols,
+        size_t out_cols,
+        size_t n,
+        size_t p2_stride_bytes,
+        size_t z_stride_bytes,
+        size_t out_stride_bytes,
+        uint8_t p2_coeff_bytes,
+        uint8_t z_coeff_bytes,
+        uint8_t out_coeff_bytes,
+        uint64_t modulus)
+    {
+        const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+        const size_t total = p2_rows * out_cols * n;
+        if (idx >= total)
+        {
+            return;
+        }
+        const size_t coeff_idx = idx % n;
+        const size_t out_poly_idx = idx / n;
+        const size_t row = out_poly_idx / out_cols;
+        const size_t col = out_poly_idx % out_cols;
+        const uint64_t p2_value = matrix_load_limb_u64(
+            p2_base,
+            row * p2_cols + col,
+            coeff_idx,
+            p2_stride_bytes,
+            p2_coeff_bytes);
+        const uint64_t z_value = matrix_load_limb_u64(
+            z_base,
+            row * z_cols + col,
+            coeff_idx,
+            z_stride_bytes,
+            z_coeff_bytes);
+        matrix_store_limb_u64(
+            out_base,
+            p1_rows * out_cols + out_poly_idx,
+            coeff_idx,
+            out_stride_bytes,
+            out_coeff_bytes,
+            add_mod_u64(p2_value, z_value, modulus));
+    }
+
+    int preimage_const_limb_view(
+        const GpuMatrix *matrix,
+        const dim3 &limb_id,
+        const uint8_t **base,
+        size_t *stride_bytes,
+        uint8_t *coeff_bytes,
+        int *device)
+    {
+        if (!matrix || !base || !stride_bytes || !coeff_bytes || !device)
+        {
+            return set_error("invalid preimage_const_limb_view arguments");
+        }
+        *base = matrix_limb_ptr_by_id(matrix, 0, limb_id);
+        if (!*base)
+        {
+            return set_error("null matrix limb in preimage_const_limb_view");
+        }
+        if (!matrix_limb_metadata_by_id(matrix, limb_id, stride_bytes, coeff_bytes))
+        {
+            return set_error("invalid matrix limb metadata in preimage_const_limb_view");
+        }
+        return matrix_limb_device(matrix, limb_id, device);
+    }
+
+    int preimage_mut_limb_view(
+        GpuMatrix *matrix,
+        const dim3 &limb_id,
+        uint8_t **base,
+        size_t *stride_bytes,
+        uint8_t *coeff_bytes,
+        int *device,
+        cudaStream_t *stream)
+    {
+        if (!matrix || !base || !stride_bytes || !coeff_bytes || !device || !stream)
+        {
+            return set_error("invalid preimage_mut_limb_view arguments");
+        }
+        *base = matrix_limb_ptr_by_id(matrix, 0, limb_id);
+        if (!*base)
+        {
+            return set_error("null matrix limb in preimage_mut_limb_view");
+        }
+        if (!matrix_limb_metadata_by_id(matrix, limb_id, stride_bytes, coeff_bytes))
+        {
+            return set_error("invalid matrix limb metadata in preimage_mut_limb_view");
+        }
+        int status = matrix_limb_device(matrix, limb_id, device);
+        if (status != 0)
+        {
+            return status;
+        }
+        return matrix_limb_stream(matrix, limb_id, stream);
+    }
+}
+
 __global__ void matrix_precompute_p1_covariance_kernel(
     const uint8_t *a_base,
     const uint8_t *b_base,
@@ -1668,6 +2169,541 @@ int launch_scatter_p1_integer_to_limb_kernel_device(
     return 0;
 }
 
+
+extern "C" int gpu_matrix_mul_vertical_pair(
+    GpuMatrix *out,
+    const GpuMatrix *top,
+    const GpuMatrix *bottom,
+    const GpuMatrix *rhs)
+{
+    if (!out || !top || !bottom || !rhs)
+    {
+        return set_error("invalid gpu_matrix_mul_vertical_pair arguments");
+    }
+    if (top->ctx != bottom->ctx || top->ctx != rhs->ctx || top->ctx != out->ctx ||
+        top->level != bottom->level || top->level != rhs->level || top->level != out->level)
+    {
+        return set_error("context mismatch in gpu_matrix_mul_vertical_pair");
+    }
+    if (top->format != GPU_POLY_FORMAT_EVAL || bottom->format != GPU_POLY_FORMAT_EVAL ||
+        rhs->format != GPU_POLY_FORMAT_EVAL)
+    {
+        return set_error("gpu_matrix_mul_vertical_pair requires Eval inputs");
+    }
+    if (top->cols != bottom->cols || top->cols != rhs->rows ||
+        out->rows != top->rows + bottom->rows || out->cols != rhs->cols)
+    {
+        return set_error("shape mismatch in gpu_matrix_mul_vertical_pair");
+    }
+    if (!top->ctx || top->level < 0)
+    {
+        return set_error("invalid context in gpu_matrix_mul_vertical_pair");
+    }
+    if (out->rows == 0 || out->cols == 0 || top->cols == 0)
+    {
+        out->format = GPU_POLY_FORMAT_EVAL;
+        return 0;
+    }
+
+    const size_t n = static_cast<size_t>(top->ctx->N);
+    const size_t crt_depth = static_cast<size_t>(top->level + 1);
+    if (top->ctx->limb_gpu_ids.size() < crt_depth || top->ctx->moduli.size() < crt_depth)
+    {
+        return set_error("unexpected context size in gpu_matrix_mul_vertical_pair");
+    }
+
+    for (size_t limb = 0; limb < crt_depth; ++limb)
+    {
+        const dim3 limb_id = top->ctx->limb_gpu_ids[limb];
+        const uint8_t *top_base = nullptr;
+        const uint8_t *bottom_base = nullptr;
+        const uint8_t *rhs_base = nullptr;
+        uint8_t *out_base = nullptr;
+        size_t top_stride = 0;
+        size_t bottom_stride = 0;
+        size_t rhs_stride = 0;
+        size_t out_stride = 0;
+        uint8_t top_coeff_bytes = 0;
+        uint8_t bottom_coeff_bytes = 0;
+        uint8_t rhs_coeff_bytes = 0;
+        uint8_t out_coeff_bytes = 0;
+        int top_device = -1;
+        int bottom_device = -1;
+        int rhs_device = -1;
+        int out_device = -1;
+        cudaStream_t stream = nullptr;
+        int status = preimage_const_limb_view(
+            top,
+            limb_id,
+            &top_base,
+            &top_stride,
+            &top_coeff_bytes,
+            &top_device);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = preimage_const_limb_view(
+            bottom,
+            limb_id,
+            &bottom_base,
+            &bottom_stride,
+            &bottom_coeff_bytes,
+            &bottom_device);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = preimage_const_limb_view(
+            rhs,
+            limb_id,
+            &rhs_base,
+            &rhs_stride,
+            &rhs_coeff_bytes,
+            &rhs_device);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = preimage_mut_limb_view(
+            out,
+            limb_id,
+            &out_base,
+            &out_stride,
+            &out_coeff_bytes,
+            &out_device,
+            &stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        if (top_device != out_device || bottom_device != out_device || rhs_device != out_device)
+        {
+            return set_error("device mismatch in gpu_matrix_mul_vertical_pair");
+        }
+        if (top_coeff_bytes != bottom_coeff_bytes || top_coeff_bytes != rhs_coeff_bytes ||
+            top_coeff_bytes != out_coeff_bytes)
+        {
+            return set_error("coefficient width mismatch in gpu_matrix_mul_vertical_pair");
+        }
+        status = matrix_wait_limb_stream(top, limb_id, out_device, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = matrix_wait_limb_stream(bottom, limb_id, out_device, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = matrix_wait_limb_stream(rhs, limb_id, out_device, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+
+        cudaError_t err = cudaSetDevice(out_device);
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        const dim3 threads(kPreimageTileN, kPreimageTileM);
+        const dim3 blocks(
+            static_cast<unsigned int>((out->cols + kPreimageTileN - 1) / kPreimageTileN),
+            static_cast<unsigned int>((out->rows + kPreimageTileM - 1) / kPreimageTileM),
+            static_cast<unsigned int>(std::min<size_t>(n, 65535)));
+        matrix_mul_vertical_pair_kernel<<<blocks, threads, 0, stream>>>(
+            top_base,
+            bottom_base,
+            rhs_base,
+            out_base,
+            top->rows,
+            bottom->rows,
+            top->cols,
+            out->cols,
+            n,
+            top_stride,
+            bottom_stride,
+            rhs_stride,
+            out_stride,
+            top_coeff_bytes,
+            bottom_coeff_bytes,
+            rhs_coeff_bytes,
+            out_coeff_bytes,
+            top->ctx->moduli[limb]);
+        err = cudaGetLastError();
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        status = matrix_track_limb_consumer(top, limb_id, out_device, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = matrix_track_limb_consumer(bottom, limb_id, out_device, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = matrix_track_limb_consumer(rhs, limb_id, out_device, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        status = matrix_record_limb_write(out, limb_id, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+    }
+    out->format = GPU_POLY_FORMAT_EVAL;
+    return 0;
+}
+
+extern "C" int gpu_matrix_preimage_residual(
+    GpuMatrix *out,
+    const GpuMatrix *target,
+    const GpuMatrix *public_matrix,
+    const GpuMatrix *p1,
+    const GpuMatrix *p2)
+{
+    if (!out || !target || !public_matrix || !p1 || !p2)
+    {
+        return set_error("invalid gpu_matrix_preimage_residual arguments");
+    }
+    if (target->ctx != public_matrix->ctx || target->ctx != p1->ctx || target->ctx != p2->ctx ||
+        target->ctx != out->ctx || target->level != public_matrix->level ||
+        target->level != p1->level || target->level != p2->level || target->level != out->level)
+    {
+        return set_error("context mismatch in gpu_matrix_preimage_residual");
+    }
+    if (target->format != GPU_POLY_FORMAT_EVAL || public_matrix->format != GPU_POLY_FORMAT_EVAL ||
+        p1->format != GPU_POLY_FORMAT_EVAL || p2->format != GPU_POLY_FORMAT_EVAL)
+    {
+        return set_error("gpu_matrix_preimage_residual requires Eval inputs");
+    }
+    if (target->rows != public_matrix->rows || target->rows != out->rows ||
+        target->cols > p1->cols || target->cols > p2->cols || target->cols != out->cols ||
+        public_matrix->cols != p1->rows + p2->rows)
+    {
+        return set_error("shape mismatch in gpu_matrix_preimage_residual");
+    }
+    if (!target->ctx || target->level < 0)
+    {
+        return set_error("invalid context in gpu_matrix_preimage_residual");
+    }
+    if (out->rows == 0 || out->cols == 0)
+    {
+        out->format = GPU_POLY_FORMAT_EVAL;
+        return 0;
+    }
+
+    const size_t n = static_cast<size_t>(target->ctx->N);
+    const size_t crt_depth = static_cast<size_t>(target->level + 1);
+    if (target->ctx->limb_gpu_ids.size() < crt_depth || target->ctx->moduli.size() < crt_depth)
+    {
+        return set_error("unexpected context size in gpu_matrix_preimage_residual");
+    }
+
+    for (size_t limb = 0; limb < crt_depth; ++limb)
+    {
+        const dim3 limb_id = target->ctx->limb_gpu_ids[limb];
+        const GpuMatrix *inputs[] = {target, public_matrix, p1, p2};
+        const uint8_t *bases[4] = {};
+        size_t strides[4] = {};
+        uint8_t coeff_bytes[4] = {};
+        int devices[4] = {};
+        for (size_t input_idx = 0; input_idx < 4; ++input_idx)
+        {
+            int status = preimage_const_limb_view(
+                inputs[input_idx],
+                limb_id,
+                &bases[input_idx],
+                &strides[input_idx],
+                &coeff_bytes[input_idx],
+                &devices[input_idx]);
+            if (status != 0)
+            {
+                return status;
+            }
+        }
+        uint8_t *out_base = nullptr;
+        size_t out_stride = 0;
+        uint8_t out_coeff_bytes = 0;
+        int out_device = -1;
+        cudaStream_t stream = nullptr;
+        int status = preimage_mut_limb_view(
+            out,
+            limb_id,
+            &out_base,
+            &out_stride,
+            &out_coeff_bytes,
+            &out_device,
+            &stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        for (size_t input_idx = 0; input_idx < 4; ++input_idx)
+        {
+            if (devices[input_idx] != out_device)
+            {
+                return set_error("device mismatch in gpu_matrix_preimage_residual");
+            }
+            if (coeff_bytes[input_idx] != out_coeff_bytes)
+            {
+                return set_error("coefficient width mismatch in gpu_matrix_preimage_residual");
+            }
+            status = matrix_wait_limb_stream(inputs[input_idx], limb_id, out_device, stream);
+            if (status != 0)
+            {
+                return status;
+            }
+        }
+
+        cudaError_t err = cudaSetDevice(out_device);
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        const dim3 threads(kPreimageTileN, kPreimageTileM);
+        const dim3 blocks(
+            static_cast<unsigned int>((out->cols + kPreimageTileN - 1) / kPreimageTileN),
+            static_cast<unsigned int>((out->rows + kPreimageTileM - 1) / kPreimageTileM),
+            static_cast<unsigned int>(std::min<size_t>(n, 65535)));
+        matrix_preimage_residual_kernel<<<blocks, threads, 0, stream>>>(
+            bases[0],
+            bases[1],
+            bases[2],
+            bases[3],
+            out_base,
+            out->rows,
+            p1->rows,
+            p2->rows,
+            p1->cols,
+            p2->cols,
+            out->cols,
+            n,
+            strides[0],
+            strides[1],
+            strides[2],
+            strides[3],
+            out_stride,
+            coeff_bytes[0],
+            coeff_bytes[1],
+            coeff_bytes[2],
+            coeff_bytes[3],
+            out_coeff_bytes,
+            target->ctx->moduli[limb]);
+        err = cudaGetLastError();
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        for (const GpuMatrix *input : inputs)
+        {
+            status = matrix_track_limb_consumer(input, limb_id, out_device, stream);
+            if (status != 0)
+            {
+                return status;
+            }
+        }
+        status = matrix_record_limb_write(out, limb_id, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+    }
+    out->format = GPU_POLY_FORMAT_EVAL;
+    return 0;
+}
+
+extern "C" int gpu_matrix_preimage_assemble(
+    GpuMatrix *out,
+    const GpuMatrix *p1,
+    const GpuMatrix *p2,
+    const GpuMatrix *r,
+    const GpuMatrix *e,
+    const GpuMatrix *z)
+{
+    if (!out || !p1 || !p2 || !r || !e || !z)
+    {
+        return set_error("invalid gpu_matrix_preimage_assemble arguments");
+    }
+    if (p1->ctx != p2->ctx || p1->ctx != r->ctx || p1->ctx != e->ctx || p1->ctx != z->ctx ||
+        p1->ctx != out->ctx || p1->level != p2->level || p1->level != r->level ||
+        p1->level != e->level || p1->level != z->level || p1->level != out->level)
+    {
+        return set_error("context mismatch in gpu_matrix_preimage_assemble");
+    }
+    if (p1->format != GPU_POLY_FORMAT_EVAL || p2->format != GPU_POLY_FORMAT_EVAL ||
+        r->format != GPU_POLY_FORMAT_EVAL || e->format != GPU_POLY_FORMAT_EVAL ||
+        z->format != GPU_POLY_FORMAT_EVAL)
+    {
+        return set_error("gpu_matrix_preimage_assemble requires Eval inputs");
+    }
+    if (r->rows != e->rows || r->cols != e->cols || p1->rows != r->rows + e->rows ||
+        p2->rows != z->rows || r->cols != z->rows || p1->cols != p2->cols ||
+        z->cols > p1->cols || out->rows != p1->rows + p2->rows || out->cols != z->cols)
+    {
+        return set_error("shape mismatch in gpu_matrix_preimage_assemble");
+    }
+    if (!p1->ctx || p1->level < 0)
+    {
+        return set_error("invalid context in gpu_matrix_preimage_assemble");
+    }
+    if (out->rows == 0 || out->cols == 0)
+    {
+        out->format = GPU_POLY_FORMAT_EVAL;
+        return 0;
+    }
+
+    const size_t n = static_cast<size_t>(p1->ctx->N);
+    const size_t crt_depth = static_cast<size_t>(p1->level + 1);
+    if (p1->ctx->limb_gpu_ids.size() < crt_depth || p1->ctx->moduli.size() < crt_depth)
+    {
+        return set_error("unexpected context size in gpu_matrix_preimage_assemble");
+    }
+
+    for (size_t limb = 0; limb < crt_depth; ++limb)
+    {
+        const dim3 limb_id = p1->ctx->limb_gpu_ids[limb];
+        const GpuMatrix *inputs[] = {p1, p2, r, e, z};
+        const uint8_t *bases[5] = {};
+        size_t strides[5] = {};
+        uint8_t coeff_bytes[5] = {};
+        int devices[5] = {};
+        for (size_t input_idx = 0; input_idx < 5; ++input_idx)
+        {
+            int status = preimage_const_limb_view(
+                inputs[input_idx],
+                limb_id,
+                &bases[input_idx],
+                &strides[input_idx],
+                &coeff_bytes[input_idx],
+                &devices[input_idx]);
+            if (status != 0)
+            {
+                return status;
+            }
+        }
+        uint8_t *out_base = nullptr;
+        size_t out_stride = 0;
+        uint8_t out_coeff_bytes = 0;
+        int out_device = -1;
+        cudaStream_t stream = nullptr;
+        int status = preimage_mut_limb_view(
+            out,
+            limb_id,
+            &out_base,
+            &out_stride,
+            &out_coeff_bytes,
+            &out_device,
+            &stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        for (size_t input_idx = 0; input_idx < 5; ++input_idx)
+        {
+            if (devices[input_idx] != out_device)
+            {
+                return set_error("device mismatch in gpu_matrix_preimage_assemble");
+            }
+            if (coeff_bytes[input_idx] != out_coeff_bytes)
+            {
+                return set_error("coefficient width mismatch in gpu_matrix_preimage_assemble");
+            }
+            status = matrix_wait_limb_stream(inputs[input_idx], limb_id, out_device, stream);
+            if (status != 0)
+            {
+                return status;
+            }
+        }
+
+        cudaError_t err = cudaSetDevice(out_device);
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        const dim3 top_threads(kPreimageTileN, kPreimageTileM);
+        const dim3 top_blocks(
+            static_cast<unsigned int>((out->cols + kPreimageTileN - 1) / kPreimageTileN),
+            static_cast<unsigned int>((p1->rows + kPreimageTileM - 1) / kPreimageTileM),
+            static_cast<unsigned int>(std::min<size_t>(n, 65535)));
+        matrix_preimage_assemble_top_kernel<<<top_blocks, top_threads, 0, stream>>>(
+            bases[0],
+            bases[2],
+            bases[3],
+            bases[4],
+            out_base,
+            r->rows,
+            z->rows,
+            p1->cols,
+            z->cols,
+            out->cols,
+            n,
+            strides[0],
+            strides[2],
+            strides[3],
+            strides[4],
+            out_stride,
+            coeff_bytes[0],
+            coeff_bytes[2],
+            coeff_bytes[3],
+            coeff_bytes[4],
+            out_coeff_bytes,
+            p1->ctx->moduli[limb]);
+        err = cudaGetLastError();
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+
+        const size_t bottom_entry_count = p2->rows * out->cols * n;
+        const int bottom_threads = 256;
+        const unsigned int bottom_blocks =
+            static_cast<unsigned int>((bottom_entry_count + bottom_threads - 1) / bottom_threads);
+        matrix_preimage_assemble_bottom_kernel<<<bottom_blocks, bottom_threads, 0, stream>>>(
+            bases[1],
+            bases[4],
+            out_base,
+            p1->rows,
+            p2->rows,
+            p2->cols,
+            z->cols,
+            out->cols,
+            n,
+            strides[1],
+            strides[4],
+            out_stride,
+            coeff_bytes[1],
+            coeff_bytes[4],
+            out_coeff_bytes,
+            p1->ctx->moduli[limb]);
+        err = cudaGetLastError();
+        if (err != cudaSuccess)
+        {
+            return set_error(err);
+        }
+        for (const GpuMatrix *input : inputs)
+        {
+            status = matrix_track_limb_consumer(input, limb_id, out_device, stream);
+            if (status != 0)
+            {
+                return status;
+            }
+        }
+        status = matrix_record_limb_write(out, limb_id, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+    }
+    out->format = GPU_POLY_FORMAT_EVAL;
+    return 0;
+}
 
 extern "C" int gpu_matrix_gauss_samp_gq_arb_base(
     GpuMatrix *src,

--- a/cuda/src/matrix/MatrixTrapdoor.cu
+++ b/cuda/src/matrix/MatrixTrapdoor.cu
@@ -358,24 +358,20 @@ namespace
         }
     }
 
-    __global__ void matrix_preimage_assemble_top_kernel(
-        const uint8_t *p1_base,
+    __global__ void matrix_preimage_add_correction_top_kernel(
         const uint8_t *r_base,
         const uint8_t *e_base,
         const uint8_t *z_base,
         uint8_t *out_base,
         size_t d,
         size_t inner,
-        size_t p1_cols,
         size_t z_cols,
         size_t out_cols,
         size_t n,
-        size_t p1_stride_bytes,
         size_t r_stride_bytes,
         size_t e_stride_bytes,
         size_t z_stride_bytes,
         size_t out_stride_bytes,
-        uint8_t p1_coeff_bytes,
         uint8_t r_coeff_bytes,
         uint8_t e_coeff_bytes,
         uint8_t z_coeff_bytes,
@@ -401,11 +397,11 @@ namespace
             if (row < top_rows && col < out_cols)
             {
                 acc = matrix_load_limb_u64(
-                    p1_base,
-                    row * p1_cols + col,
+                    out_base,
+                    row * out_cols + col,
                     coeff_idx,
-                    p1_stride_bytes,
-                    p1_coeff_bytes);
+                    out_stride_bytes,
+                    out_coeff_bytes);
             }
 
             for (size_t k0 = 0; k0 < inner; k0 += kPreimageTileK)
@@ -489,26 +485,22 @@ namespace
         }
     }
 
-    __global__ void matrix_preimage_assemble_bottom_kernel(
-        const uint8_t *p2_base,
+    __global__ void matrix_preimage_add_correction_bottom_kernel(
         const uint8_t *z_base,
         uint8_t *out_base,
-        size_t p1_rows,
-        size_t p2_rows,
-        size_t p2_cols,
+        size_t top_rows,
+        size_t z_rows,
         size_t z_cols,
         size_t out_cols,
         size_t n,
-        size_t p2_stride_bytes,
         size_t z_stride_bytes,
         size_t out_stride_bytes,
-        uint8_t p2_coeff_bytes,
         uint8_t z_coeff_bytes,
         uint8_t out_coeff_bytes,
         uint64_t modulus)
     {
         const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-        const size_t total = p2_rows * out_cols * n;
+        const size_t total = z_rows * out_cols * n;
         if (idx >= total)
         {
             return;
@@ -517,12 +509,13 @@ namespace
         const size_t out_poly_idx = idx / n;
         const size_t row = out_poly_idx / out_cols;
         const size_t col = out_poly_idx % out_cols;
-        const uint64_t p2_value = matrix_load_limb_u64(
-            p2_base,
-            row * p2_cols + col,
+        const size_t out_entry = top_rows * out_cols + out_poly_idx;
+        const uint64_t base_value = matrix_load_limb_u64(
+            out_base,
+            out_entry,
             coeff_idx,
-            p2_stride_bytes,
-            p2_coeff_bytes);
+            out_stride_bytes,
+            out_coeff_bytes);
         const uint64_t z_value = matrix_load_limb_u64(
             z_base,
             row * z_cols + col,
@@ -531,11 +524,11 @@ namespace
             z_coeff_bytes);
         matrix_store_limb_u64(
             out_base,
-            p1_rows * out_cols + out_poly_idx,
+            out_entry,
             coeff_idx,
             out_stride_bytes,
             out_coeff_bytes,
-            add_mod_u64(p2_value, z_value, modulus));
+            add_mod_u64(base_value, z_value, modulus));
     }
 
     int preimage_const_limb_view(
@@ -2519,39 +2512,35 @@ extern "C" int gpu_matrix_preimage_residual(
     return 0;
 }
 
-extern "C" int gpu_matrix_preimage_assemble(
+extern "C" int gpu_matrix_preimage_add_correction(
     GpuMatrix *out,
-    const GpuMatrix *p1,
-    const GpuMatrix *p2,
     const GpuMatrix *r,
     const GpuMatrix *e,
     const GpuMatrix *z)
 {
-    if (!out || !p1 || !p2 || !r || !e || !z)
+    if (!out || !r || !e || !z)
     {
-        return set_error("invalid gpu_matrix_preimage_assemble arguments");
+        return set_error("invalid gpu_matrix_preimage_add_correction arguments");
     }
-    if (p1->ctx != p2->ctx || p1->ctx != r->ctx || p1->ctx != e->ctx || p1->ctx != z->ctx ||
-        p1->ctx != out->ctx || p1->level != p2->level || p1->level != r->level ||
-        p1->level != e->level || p1->level != z->level || p1->level != out->level)
+    if (out->ctx != r->ctx || out->ctx != e->ctx || out->ctx != z->ctx ||
+        out->level != r->level || out->level != e->level || out->level != z->level)
     {
-        return set_error("context mismatch in gpu_matrix_preimage_assemble");
+        return set_error("context mismatch in gpu_matrix_preimage_add_correction");
     }
-    if (p1->format != GPU_POLY_FORMAT_EVAL || p2->format != GPU_POLY_FORMAT_EVAL ||
-        r->format != GPU_POLY_FORMAT_EVAL || e->format != GPU_POLY_FORMAT_EVAL ||
+    if (out->format != GPU_POLY_FORMAT_EVAL || r->format != GPU_POLY_FORMAT_EVAL ||
+        e->format != GPU_POLY_FORMAT_EVAL ||
         z->format != GPU_POLY_FORMAT_EVAL)
     {
-        return set_error("gpu_matrix_preimage_assemble requires Eval inputs");
+        return set_error("gpu_matrix_preimage_add_correction requires Eval inputs");
     }
-    if (r->rows != e->rows || r->cols != e->cols || p1->rows != r->rows + e->rows ||
-        p2->rows != z->rows || r->cols != z->rows || p1->cols != p2->cols ||
-        z->cols > p1->cols || out->rows != p1->rows + p2->rows || out->cols != z->cols)
+    if (r->rows != e->rows || r->cols != e->cols || r->cols != z->rows ||
+        out->rows != r->rows + e->rows + z->rows || out->cols != z->cols)
     {
-        return set_error("shape mismatch in gpu_matrix_preimage_assemble");
+        return set_error("shape mismatch in gpu_matrix_preimage_add_correction");
     }
-    if (!p1->ctx || p1->level < 0)
+    if (!out->ctx || out->level < 0)
     {
-        return set_error("invalid context in gpu_matrix_preimage_assemble");
+        return set_error("invalid context in gpu_matrix_preimage_add_correction");
     }
     if (out->rows == 0 || out->cols == 0)
     {
@@ -2559,22 +2548,22 @@ extern "C" int gpu_matrix_preimage_assemble(
         return 0;
     }
 
-    const size_t n = static_cast<size_t>(p1->ctx->N);
-    const size_t crt_depth = static_cast<size_t>(p1->level + 1);
-    if (p1->ctx->limb_gpu_ids.size() < crt_depth || p1->ctx->moduli.size() < crt_depth)
+    const size_t n = static_cast<size_t>(out->ctx->N);
+    const size_t crt_depth = static_cast<size_t>(out->level + 1);
+    if (out->ctx->limb_gpu_ids.size() < crt_depth || out->ctx->moduli.size() < crt_depth)
     {
-        return set_error("unexpected context size in gpu_matrix_preimage_assemble");
+        return set_error("unexpected context size in gpu_matrix_preimage_add_correction");
     }
 
     for (size_t limb = 0; limb < crt_depth; ++limb)
     {
-        const dim3 limb_id = p1->ctx->limb_gpu_ids[limb];
-        const GpuMatrix *inputs[] = {p1, p2, r, e, z};
-        const uint8_t *bases[5] = {};
-        size_t strides[5] = {};
-        uint8_t coeff_bytes[5] = {};
-        int devices[5] = {};
-        for (size_t input_idx = 0; input_idx < 5; ++input_idx)
+        const dim3 limb_id = out->ctx->limb_gpu_ids[limb];
+        const GpuMatrix *inputs[] = {r, e, z};
+        const uint8_t *bases[3] = {};
+        size_t strides[3] = {};
+        uint8_t coeff_bytes[3] = {};
+        int devices[3] = {};
+        for (size_t input_idx = 0; input_idx < 3; ++input_idx)
         {
             int status = preimage_const_limb_view(
                 inputs[input_idx],
@@ -2605,15 +2594,20 @@ extern "C" int gpu_matrix_preimage_assemble(
         {
             return status;
         }
-        for (size_t input_idx = 0; input_idx < 5; ++input_idx)
+        status = matrix_wait_limb_stream(out, limb_id, out_device, stream);
+        if (status != 0)
+        {
+            return status;
+        }
+        for (size_t input_idx = 0; input_idx < 3; ++input_idx)
         {
             if (devices[input_idx] != out_device)
             {
-                return set_error("device mismatch in gpu_matrix_preimage_assemble");
+                return set_error("device mismatch in gpu_matrix_preimage_add_correction");
             }
             if (coeff_bytes[input_idx] != out_coeff_bytes)
             {
-                return set_error("coefficient width mismatch in gpu_matrix_preimage_assemble");
+                return set_error("coefficient width mismatch in gpu_matrix_preimage_add_correction");
             }
             status = matrix_wait_limb_stream(inputs[input_idx], limb_id, out_device, stream);
             if (status != 0)
@@ -2630,58 +2624,51 @@ extern "C" int gpu_matrix_preimage_assemble(
         const dim3 top_threads(kPreimageTileN, kPreimageTileM);
         const dim3 top_blocks(
             static_cast<unsigned int>((out->cols + kPreimageTileN - 1) / kPreimageTileN),
-            static_cast<unsigned int>((p1->rows + kPreimageTileM - 1) / kPreimageTileM),
+            static_cast<unsigned int>(
+                (r->rows + e->rows + kPreimageTileM - 1) / kPreimageTileM),
             static_cast<unsigned int>(std::min<size_t>(n, 65535)));
-        matrix_preimage_assemble_top_kernel<<<top_blocks, top_threads, 0, stream>>>(
+        matrix_preimage_add_correction_top_kernel<<<top_blocks, top_threads, 0, stream>>>(
             bases[0],
+            bases[1],
             bases[2],
-            bases[3],
-            bases[4],
             out_base,
             r->rows,
             z->rows,
-            p1->cols,
             z->cols,
             out->cols,
             n,
             strides[0],
+            strides[1],
             strides[2],
-            strides[3],
-            strides[4],
             out_stride,
             coeff_bytes[0],
+            coeff_bytes[1],
             coeff_bytes[2],
-            coeff_bytes[3],
-            coeff_bytes[4],
             out_coeff_bytes,
-            p1->ctx->moduli[limb]);
+            out->ctx->moduli[limb]);
         err = cudaGetLastError();
         if (err != cudaSuccess)
         {
             return set_error(err);
         }
 
-        const size_t bottom_entry_count = p2->rows * out->cols * n;
+        const size_t bottom_entry_count = z->rows * out->cols * n;
         const int bottom_threads = 256;
         const unsigned int bottom_blocks =
             static_cast<unsigned int>((bottom_entry_count + bottom_threads - 1) / bottom_threads);
-        matrix_preimage_assemble_bottom_kernel<<<bottom_blocks, bottom_threads, 0, stream>>>(
-            bases[1],
-            bases[4],
+        matrix_preimage_add_correction_bottom_kernel<<<bottom_blocks, bottom_threads, 0, stream>>>(
+            bases[2],
             out_base,
-            p1->rows,
-            p2->rows,
-            p2->cols,
+            r->rows + e->rows,
+            z->rows,
             z->cols,
             out->cols,
             n,
-            strides[1],
-            strides[4],
+            strides[2],
             out_stride,
-            coeff_bytes[1],
-            coeff_bytes[4],
+            coeff_bytes[2],
             out_coeff_bytes,
-            p1->ctx->moduli[limb]);
+            out->ctx->moduli[limb]);
         err = cudaGetLastError();
         if (err != cudaSuccess)
         {

--- a/src/input_injector/bench_estimator.rs
+++ b/src/input_injector/bench_estimator.rs
@@ -1,4 +1,9 @@
-use std::{fs, hint::black_box, time::Instant};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    hint::black_box,
+    time::Instant,
+};
 
 use num_bigint::BigUint;
 use num_traits::Zero;
@@ -67,6 +72,9 @@ pub(crate) struct DiamondInputInjectionBenchUnitEstimates {
     pub(crate) online_rhs_chunk_read_decode: CircuitBenchEstimate,
     pub(crate) online_output_chunk_serialize: CircuitBenchEstimate,
     pub(crate) online_output_recompose: CircuitBenchEstimate,
+    pub(crate) checkpoint_matrix_compact_bytes: usize,
+    pub(crate) initial_state_compact_bytes: usize,
+    pub(crate) preimage_compact_bytes_by_width: BTreeMap<usize, usize>,
 }
 
 impl DiamondInputInjectionBenchShape {
@@ -182,6 +190,7 @@ impl DiamondInputInjectionBenchUnitEstimates {
         iterations: usize,
         state_row_size: usize,
         state_col_size: usize,
+        representative_preimage_widths: &[usize],
     ) -> Self
     where
         M: PolyMatrix + Send + Sync + 'static,
@@ -201,10 +210,50 @@ impl DiamondInputInjectionBenchUnitEstimates {
         let trap_sampler = TS::new(params, trapdoor_sigma);
         let (trapdoor, checkpoint_matrix) = trap_sampler.trapdoor(params, state_row_size);
         let checkpoint_matrix_bytes = checkpoint_matrix.to_compact_bytes();
+        let checkpoint_matrix_compact_bytes = checkpoint_matrix_bytes.len();
         let checkpoint_trapdoor_bytes = TS::trapdoor_to_bytes(&trapdoor);
-        let initial_state_bytes = M::zero(params, 1, state_col_size).to_compact_bytes();
-        let transition_preimage_bytes =
-            M::zero(params, state_col_size, transition_chunk_len).to_compact_bytes();
+        let initial_state_bytes =
+            US::new().sample_uniform(params, 1, state_col_size, DistType::FinRingDist);
+        let initial_state_bytes = initial_state_bytes.to_compact_bytes();
+        let initial_state_compact_bytes = initial_state_bytes.len();
+        let requested_total_widths =
+            representative_preimage_widths.iter().copied().collect::<BTreeSet<_>>();
+        let mut requested_total_widths = requested_total_widths;
+        requested_total_widths.insert(state_col_size);
+        assert!(
+            requested_total_widths.iter().all(|&width| width > 0),
+            "representative preimage widths must be positive"
+        );
+        // Encryption persists each auxiliary-sampling chunk as an independent compact matrix.
+        // Measure every distinct chunk width that can actually be written rather than
+        // materializing a potentially OOM-inducing full-width preimage or extrapolating across
+        // serializer-specific headers and coefficient widths.
+        let persisted_chunk_widths = requested_total_widths
+            .into_iter()
+            .flat_map(|total_width| {
+                (0..column_chunk_count(total_width))
+                    .map(move |chunk_idx| column_chunk_bounds(total_width, chunk_idx).1)
+            })
+            .collect::<BTreeSet<_>>();
+        let mut preimage_compact_bytes_by_width = BTreeMap::new();
+        let mut transition_preimage_bytes = None;
+        for width in persisted_chunk_widths {
+            let target = M::zero(params, state_row_size, width);
+            let bytes = trap_sampler
+                .preimage(params, &trapdoor, &checkpoint_matrix, &target)
+                .to_compact_bytes();
+            info!(
+                width,
+                compact_bytes = bytes.len(),
+                "measured representative Diamond preimage compact bytes"
+            );
+            preimage_compact_bytes_by_width.insert(width, bytes.len());
+            if width == transition_chunk_len {
+                transition_preimage_bytes = Some(bytes);
+            }
+        }
+        let transition_preimage_bytes = transition_preimage_bytes
+            .expect("transition preimage compact bytes must include the first chunk width");
         let output_chunk_bytes_by_col = (0..column_chunk_count(state_col_size))
             .map(|chunk_idx| {
                 let (_, col_len) = column_chunk_bounds(state_col_size, chunk_idx);
@@ -290,7 +339,26 @@ impl DiamondInputInjectionBenchUnitEstimates {
             online_rhs_chunk_read_decode,
             online_output_chunk_serialize,
             online_output_recompose,
+            checkpoint_matrix_compact_bytes,
+            initial_state_compact_bytes,
+            preimage_compact_bytes_by_width,
         }
+    }
+
+    pub(crate) fn preimage_compact_bytes(&self, width: usize) -> usize {
+        *self
+            .preimage_compact_bytes_by_width
+            .get(&width)
+            .unwrap_or_else(|| panic!("missing representative compact-byte size for width {width}"))
+    }
+
+    pub(crate) fn chunked_preimage_compact_bytes(&self, total_width: usize) -> usize {
+        (0..column_chunk_count(total_width))
+            .try_fold(0usize, |total, chunk_idx| {
+                let (_, chunk_width) = column_chunk_bounds(total_width, chunk_idx);
+                total.checked_add(self.preimage_compact_bytes(chunk_width))
+            })
+            .expect("chunked compact preimage byte count overflow")
     }
 
     pub(crate) fn estimate<NBE>(

--- a/src/io/diamond_io/bench_estimator.rs
+++ b/src/io/diamond_io/bench_estimator.rs
@@ -254,6 +254,7 @@ where
             iterations,
             state_row_size,
             shape.state_col_size,
+            &[],
         );
         let trapdoor_checkpoint = input_injection_units.trapdoor_checkpoint.clone();
         let trapdoor_preimage = input_injection_units.transition_preimage.clone();

--- a/src/matrix/gpu_dcrt_poly.rs
+++ b/src/matrix/gpu_dcrt_poly.rs
@@ -18,7 +18,7 @@ use crate::{
                 gpu_matrix_gauss_samp_gq_arb_base, gpu_matrix_intt_all,
                 gpu_matrix_load_compact_bytes, gpu_matrix_load_rns_batch, gpu_matrix_mul,
                 gpu_matrix_mul_scalar, gpu_matrix_mul_vertical_pair, gpu_matrix_ntt_all,
-                gpu_matrix_preimage_assemble, gpu_matrix_preimage_residual,
+                gpu_matrix_preimage_add_correction, gpu_matrix_preimage_residual,
                 gpu_matrix_sample_distribution, gpu_matrix_sample_distribution_columns,
                 gpu_matrix_sample_p1_full_cached, gpu_matrix_store_compact_bytes,
                 gpu_matrix_store_const_coeff_batch, gpu_matrix_store_rns_batch, gpu_matrix_sub,
@@ -638,34 +638,52 @@ impl GpuDCRTPolyMatrix {
         out
     }
 
-    pub(crate) fn preimage_assemble(p1: &Self, p2: &Self, r: &Self, e: &Self, z: &Self) -> Self {
+    pub(crate) fn preimage_output_from_perturbation(
+        p1: Self,
+        p2: Self,
+        target_cols: usize,
+    ) -> Self {
         debug_assert_eq!(p1.params, p2.params, "preimage assemble params mismatch");
-        debug_assert_eq!(p1.params, r.params, "preimage assemble r params mismatch");
-        debug_assert_eq!(p1.params, e.params, "preimage assemble e params mismatch");
-        debug_assert_eq!(p1.params, z.params, "preimage assemble z params mismatch");
-        debug_assert_eq!(r.nrow, e.nrow, "preimage assemble trapdoor row mismatch");
-        debug_assert_eq!(r.ncol, e.ncol, "preimage assemble trapdoor column mismatch");
-        debug_assert_eq!(p1.nrow, r.nrow + e.nrow, "preimage assemble p1 row mismatch");
-        debug_assert_eq!(p2.nrow, z.nrow, "preimage assemble p2/z row mismatch");
-        debug_assert_eq!(r.ncol, z.nrow, "preimage assemble correction mismatch");
         debug_assert_eq!(p1.ncol, p2.ncol, "preimage assemble p2 columns mismatch");
-        debug_assert!(z.ncol <= p1.ncol, "preimage assemble z columns mismatch");
+        debug_assert!(target_cols <= p1.ncol, "preimage assemble target columns mismatch");
         debug_assert_eq!(p1.level, p2.level, "preimage assemble p2 level mismatch");
-        debug_assert_eq!(p1.level, r.level, "preimage assemble r level mismatch");
-        debug_assert_eq!(p1.level, e.level, "preimage assemble e level mismatch");
-        debug_assert_eq!(p1.level, z.level, "preimage assemble z level mismatch");
-        debug_assert!(
-            p1.is_ntt && p2.is_ntt && r.is_ntt && e.is_ntt && z.is_ntt,
-            "preimage assemble requires Eval"
-        );
-        let out = Self::new_empty_with_state(&p1.params, p1.nrow + p2.nrow, z.ncol, p1.level, true);
-        if out.nrow == 0 || out.ncol == 0 {
-            return out;
+        debug_assert!(p1.is_ntt && p2.is_ntt, "preimage assemble requires Eval");
+        let p1_rows = p1.nrow;
+        let p2_rows = p2.nrow;
+        let mut out =
+            Self::new_empty_with_state(&p1.params, p1_rows + p2_rows, target_cols, p1.level, true);
+        if out.nrow != 0 && out.ncol != 0 {
+            out.copy_block_from(&p1, 0, 0, 0, 0, p1_rows, target_cols);
+            out.copy_block_from(&p2, p1_rows, 0, 0, 0, p2_rows, target_cols);
         }
-        let status =
-            unsafe { gpu_matrix_preimage_assemble(out.raw, p1.raw, p2.raw, r.raw, e.raw, z.raw) };
-        check_status(status, "gpu_matrix_preimage_assemble");
         out
+    }
+
+    pub(crate) fn preimage_add_correction(&mut self, r: &Self, e: &Self, z: &Self) {
+        debug_assert_eq!(self.params, r.params, "preimage correction r params mismatch");
+        debug_assert_eq!(self.params, e.params, "preimage correction e params mismatch");
+        debug_assert_eq!(self.params, z.params, "preimage correction z params mismatch");
+        debug_assert_eq!(r.nrow, e.nrow, "preimage correction trapdoor row mismatch");
+        debug_assert_eq!(r.ncol, e.ncol, "preimage correction trapdoor column mismatch");
+        debug_assert_eq!(r.ncol, z.nrow, "preimage correction inner dimension mismatch");
+        debug_assert_eq!(
+            self.nrow,
+            r.nrow + e.nrow + z.nrow,
+            "preimage correction output row mismatch"
+        );
+        debug_assert_eq!(self.ncol, z.ncol, "preimage correction output column mismatch");
+        debug_assert_eq!(self.level, r.level, "preimage correction r level mismatch");
+        debug_assert_eq!(self.level, e.level, "preimage correction e level mismatch");
+        debug_assert_eq!(self.level, z.level, "preimage correction z level mismatch");
+        debug_assert!(
+            self.is_ntt && r.is_ntt && e.is_ntt && z.is_ntt,
+            "preimage correction requires Eval"
+        );
+        if self.nrow == 0 || self.ncol == 0 {
+            return;
+        }
+        let status = unsafe { gpu_matrix_preimage_add_correction(self.raw, r.raw, e.raw, z.raw) };
+        check_status(status, "gpu_matrix_preimage_add_correction");
     }
 
     pub(crate) fn store_rns_bytes(&self, bytes_out: &mut [u8], bytes_per_poly: usize, format: i32) {
@@ -2111,7 +2129,9 @@ mod tests {
         let z = gpu_constant_matrix(&gpu_params, 3, cols, 370);
         let top_correction = (&r * &z).concat_rows(&[&(&e * &z)]);
         let expected_assembly = (&p1 + &top_correction).concat_rows(&[&(&p2 + &z)]);
-        let actual_assembly = GpuDCRTPolyMatrix::preimage_assemble(&p1, &p2, &r, &e, &z);
+        let mut actual_assembly =
+            GpuDCRTPolyMatrix::preimage_output_from_perturbation(p1.clone(), p2.clone(), cols);
+        actual_assembly.preimage_add_correction(&r, &e, &z);
         assert_eq!(actual_assembly, expected_assembly);
     }
 

--- a/src/matrix/gpu_dcrt_poly.rs
+++ b/src/matrix/gpu_dcrt_poly.rs
@@ -17,10 +17,11 @@ use crate::{
                 gpu_matrix_fill_small_decomposed_identity_chunk, gpu_matrix_fill_small_gadget,
                 gpu_matrix_gauss_samp_gq_arb_base, gpu_matrix_intt_all,
                 gpu_matrix_load_compact_bytes, gpu_matrix_load_rns_batch, gpu_matrix_mul,
-                gpu_matrix_mul_scalar, gpu_matrix_ntt_all, gpu_matrix_sample_distribution,
-                gpu_matrix_sample_distribution_columns, gpu_matrix_sample_p1_full_cached,
-                gpu_matrix_store_compact_bytes, gpu_matrix_store_const_coeff_batch,
-                gpu_matrix_store_rns_batch, gpu_matrix_sub,
+                gpu_matrix_mul_scalar, gpu_matrix_mul_vertical_pair, gpu_matrix_ntt_all,
+                gpu_matrix_preimage_assemble, gpu_matrix_preimage_residual,
+                gpu_matrix_sample_distribution, gpu_matrix_sample_distribution_columns,
+                gpu_matrix_sample_p1_full_cached, gpu_matrix_store_compact_bytes,
+                gpu_matrix_store_const_coeff_batch, gpu_matrix_store_rns_batch, gpu_matrix_sub,
             },
             params::DCRTPolyParams,
             poly::DCRTPoly,
@@ -570,6 +571,100 @@ impl GpuDCRTPolyMatrix {
         tp2.intt_all_in_place();
         let status = unsafe { gpu_matrix_sample_p1_full_cached(cache.raw, tp2.raw, seed, out.raw) };
         check_status(status, "gpu_matrix_sample_p1_full_cached");
+        out
+    }
+
+    pub(crate) fn mul_vertical_pair(top: &Self, bottom: &Self, rhs: &Self) -> Self {
+        debug_assert_eq!(top.params, bottom.params, "vertical pair params mismatch");
+        debug_assert_eq!(top.params, rhs.params, "vertical pair RHS params mismatch");
+        debug_assert_eq!(top.ncol, bottom.ncol, "vertical pair inner dimensions mismatch");
+        debug_assert_eq!(top.ncol, rhs.nrow, "vertical pair multiplication mismatch");
+        debug_assert_eq!(top.level, bottom.level, "vertical pair levels mismatch");
+        debug_assert_eq!(top.level, rhs.level, "vertical pair RHS level mismatch");
+        debug_assert!(top.is_ntt && bottom.is_ntt && rhs.is_ntt, "vertical pair requires Eval");
+        let out = Self::new_empty_with_state(
+            &top.params,
+            top.nrow + bottom.nrow,
+            rhs.ncol,
+            top.level,
+            true,
+        );
+        if out.nrow == 0 || out.ncol == 0 || top.ncol == 0 {
+            return out;
+        }
+        let status = unsafe { gpu_matrix_mul_vertical_pair(out.raw, top.raw, bottom.raw, rhs.raw) };
+        check_status(status, "gpu_matrix_mul_vertical_pair");
+        out
+    }
+
+    pub(crate) fn preimage_residual(
+        target: &Self,
+        public_matrix: &Self,
+        p1: &Self,
+        p2: &Self,
+    ) -> Self {
+        debug_assert_eq!(target.params, public_matrix.params, "preimage residual params mismatch");
+        debug_assert_eq!(target.params, p1.params, "preimage residual p1 params mismatch");
+        debug_assert_eq!(target.params, p2.params, "preimage residual p2 params mismatch");
+        debug_assert_eq!(target.nrow, public_matrix.nrow, "preimage residual row mismatch");
+        debug_assert!(target.ncol <= p1.ncol, "preimage residual p1 columns mismatch");
+        debug_assert!(target.ncol <= p2.ncol, "preimage residual p2 columns mismatch");
+        debug_assert_eq!(
+            public_matrix.ncol,
+            p1.nrow + p2.nrow,
+            "preimage residual inner dimensions mismatch"
+        );
+        debug_assert_eq!(target.level, public_matrix.level, "preimage residual level mismatch");
+        debug_assert_eq!(target.level, p1.level, "preimage residual p1 level mismatch");
+        debug_assert_eq!(target.level, p2.level, "preimage residual p2 level mismatch");
+        debug_assert!(
+            target.is_ntt && public_matrix.is_ntt && p1.is_ntt && p2.is_ntt,
+            "preimage residual requires Eval"
+        );
+        let out = Self::new_empty_with_state(
+            &target.params,
+            target.nrow,
+            target.ncol,
+            target.level,
+            true,
+        );
+        if out.nrow == 0 || out.ncol == 0 {
+            return out;
+        }
+        let status = unsafe {
+            gpu_matrix_preimage_residual(out.raw, target.raw, public_matrix.raw, p1.raw, p2.raw)
+        };
+        check_status(status, "gpu_matrix_preimage_residual");
+        out
+    }
+
+    pub(crate) fn preimage_assemble(p1: &Self, p2: &Self, r: &Self, e: &Self, z: &Self) -> Self {
+        debug_assert_eq!(p1.params, p2.params, "preimage assemble params mismatch");
+        debug_assert_eq!(p1.params, r.params, "preimage assemble r params mismatch");
+        debug_assert_eq!(p1.params, e.params, "preimage assemble e params mismatch");
+        debug_assert_eq!(p1.params, z.params, "preimage assemble z params mismatch");
+        debug_assert_eq!(r.nrow, e.nrow, "preimage assemble trapdoor row mismatch");
+        debug_assert_eq!(r.ncol, e.ncol, "preimage assemble trapdoor column mismatch");
+        debug_assert_eq!(p1.nrow, r.nrow + e.nrow, "preimage assemble p1 row mismatch");
+        debug_assert_eq!(p2.nrow, z.nrow, "preimage assemble p2/z row mismatch");
+        debug_assert_eq!(r.ncol, z.nrow, "preimage assemble correction mismatch");
+        debug_assert_eq!(p1.ncol, p2.ncol, "preimage assemble p2 columns mismatch");
+        debug_assert!(z.ncol <= p1.ncol, "preimage assemble z columns mismatch");
+        debug_assert_eq!(p1.level, p2.level, "preimage assemble p2 level mismatch");
+        debug_assert_eq!(p1.level, r.level, "preimage assemble r level mismatch");
+        debug_assert_eq!(p1.level, e.level, "preimage assemble e level mismatch");
+        debug_assert_eq!(p1.level, z.level, "preimage assemble z level mismatch");
+        debug_assert!(
+            p1.is_ntt && p2.is_ntt && r.is_ntt && e.is_ntt && z.is_ntt,
+            "preimage assemble requires Eval"
+        );
+        let out = Self::new_empty_with_state(&p1.params, p1.nrow + p2.nrow, z.ncol, p1.level, true);
+        if out.nrow == 0 || out.ncol == 0 {
+            return out;
+        }
+        let status =
+            unsafe { gpu_matrix_preimage_assemble(out.raw, p1.raw, p2.raw, r.raw, e.raw, z.raw) };
+        check_status(status, "gpu_matrix_preimage_assemble");
         out
     }
 
@@ -1960,6 +2055,64 @@ mod tests {
         let mut bytes = [0u8; 32];
         bytes[..8].copy_from_slice(&base.wrapping_add(offset).to_le_bytes());
         GpuRngSeed::from_bytes(bytes)
+    }
+
+    fn gpu_constant_matrix(
+        params: &GpuDCRTPolyParams,
+        nrow: usize,
+        ncol: usize,
+        offset: usize,
+    ) -> GpuDCRTPolyMatrix {
+        GpuDCRTPolyMatrix::from_poly_vec(
+            params,
+            (0..nrow)
+                .map(|row| {
+                    (0..ncol)
+                        .map(|col| {
+                            GpuDCRTPoly::from_usize_to_constant(
+                                params,
+                                offset + row * ncol + col + 1,
+                            )
+                        })
+                        .collect()
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    #[sequential]
+    fn test_gpu_preimage_fused_matrix_primitives_match_composition() {
+        gpu_device_sync();
+        let gpu_params = gpu_params_from_cpu(&gpu_test_params());
+        let cols = 5usize;
+
+        let top = gpu_constant_matrix(&gpu_params, 2, 3, 0);
+        let bottom = gpu_constant_matrix(&gpu_params, 1, 3, 20);
+        let rhs = gpu_constant_matrix(&gpu_params, 3, cols, 40);
+        let expected_pair = top.concat_rows(&[&bottom]) * &rhs;
+        let actual_pair = GpuDCRTPolyMatrix::mul_vertical_pair(&top, &bottom, &rhs);
+        assert_eq!(actual_pair, expected_pair);
+
+        let target = gpu_constant_matrix(&gpu_params, 2, cols, 70);
+        let public_matrix = gpu_constant_matrix(&gpu_params, 2, 5, 100);
+        let p1 = gpu_constant_matrix(&gpu_params, 2, cols, 130);
+        let p2 = gpu_constant_matrix(&gpu_params, 3, cols, 170);
+        let expected_residual = &(&target - &(&public_matrix.slice(0, 2, 0, 2) * &p1)) -
+            &(&public_matrix.slice(0, 2, 2, 5) * &p2);
+        let actual_residual =
+            GpuDCRTPolyMatrix::preimage_residual(&target, &public_matrix, &p1, &p2);
+        assert_eq!(actual_residual, expected_residual);
+
+        let p1 = gpu_constant_matrix(&gpu_params, 4, cols, 220);
+        let p2 = gpu_constant_matrix(&gpu_params, 3, cols, 280);
+        let r = gpu_constant_matrix(&gpu_params, 2, 3, 330);
+        let e = gpu_constant_matrix(&gpu_params, 2, 3, 350);
+        let z = gpu_constant_matrix(&gpu_params, 3, cols, 370);
+        let top_correction = (&r * &z).concat_rows(&[&(&e * &z)]);
+        let expected_assembly = (&p1 + &top_correction).concat_rows(&[&(&p2 + &z)]);
+        let actual_assembly = GpuDCRTPolyMatrix::preimage_assemble(&p1, &p2, &r, &e, &z);
+        assert_eq!(actual_assembly, expected_assembly);
     }
 
     #[test]

--- a/src/poly/dcrt/gpu.rs
+++ b/src/poly/dcrt/gpu.rs
@@ -226,10 +226,8 @@ unsafe extern "C" {
         p1: *const GpuMatrixOpaque,
         p2: *const GpuMatrixOpaque,
     ) -> c_int;
-    pub(crate) fn gpu_matrix_preimage_assemble(
+    pub(crate) fn gpu_matrix_preimage_add_correction(
         out: *mut GpuMatrixOpaque,
-        p1: *const GpuMatrixOpaque,
-        p2: *const GpuMatrixOpaque,
         r: *const GpuMatrixOpaque,
         e: *const GpuMatrixOpaque,
         z: *const GpuMatrixOpaque,

--- a/src/poly/dcrt/gpu.rs
+++ b/src/poly/dcrt/gpu.rs
@@ -213,6 +213,27 @@ unsafe extern "C" {
         seed: GpuRngSeed,
         out: *mut GpuMatrixOpaque,
     ) -> c_int;
+    pub(crate) fn gpu_matrix_mul_vertical_pair(
+        out: *mut GpuMatrixOpaque,
+        top: *const GpuMatrixOpaque,
+        bottom: *const GpuMatrixOpaque,
+        rhs: *const GpuMatrixOpaque,
+    ) -> c_int;
+    pub(crate) fn gpu_matrix_preimage_residual(
+        out: *mut GpuMatrixOpaque,
+        target: *const GpuMatrixOpaque,
+        public_matrix: *const GpuMatrixOpaque,
+        p1: *const GpuMatrixOpaque,
+        p2: *const GpuMatrixOpaque,
+    ) -> c_int;
+    pub(crate) fn gpu_matrix_preimage_assemble(
+        out: *mut GpuMatrixOpaque,
+        p1: *const GpuMatrixOpaque,
+        p2: *const GpuMatrixOpaque,
+        r: *const GpuMatrixOpaque,
+        e: *const GpuMatrixOpaque,
+        z: *const GpuMatrixOpaque,
+    ) -> c_int;
     pub(crate) fn gpu_matrix_sample_distribution(
         out: *mut GpuMatrixOpaque,
         dist_type: c_int,

--- a/src/sampler/trapdoor/gpu.rs
+++ b/src/sampler/trapdoor/gpu.rs
@@ -287,6 +287,9 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
             "gpu preimage: computed perturbed_syndrome"
         );
 
+        // Materialize the final layout before sampling z so p1/p2 can be released before the
+        // largest correction buffers are live. The correction itself remains one fused kernel.
+        let mut out = GpuDCRTPolyMatrix::preimage_output_from_perturbation(p1, p2, target_cols);
         let assemble_start = Instant::now();
         let gauss_start = Instant::now();
         let z_hat_mat =
@@ -296,8 +299,7 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
             "gpu preimage: sampled z_hat_mat with gauss_samp_gq_arb_base"
         );
 
-        let out =
-            GpuDCRTPolyMatrix::preimage_assemble(&p1, &p2, &trapdoor.r, &trapdoor.e, &z_hat_mat);
+        out.preimage_add_correction(&trapdoor.r, &trapdoor.e, &z_hat_mat);
         tracing::debug!(
             elapsed_ms = assemble_start.elapsed().as_secs_f64() * 1_000.0,
             "gpu preimage: assembled output matrix with fused correction"

--- a/src/sampler/trapdoor/gpu.rs
+++ b/src/sampler/trapdoor/gpu.rs
@@ -280,47 +280,14 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
             p1_rows + p2_rows,
             "public matrix columns must match perturbation rows",
         );
-        let mut perturbed_syndrome = target.clone();
-        {
-            let public_right = public_matrix.slice(0, d, p1_rows, p1_rows + p2_rows);
-            let right_image = &public_right * &p2;
-            let right_image = if right_image.col_size() == target_cols {
-                right_image
-            } else {
-                right_image.slice_columns(0, target_cols)
-            };
-            perturbed_syndrome.sub_in_place(&right_image);
-        }
-        {
-            let public_left = public_matrix.slice(0, d, 0, p1_rows);
-            let left_image = &public_left * &p1;
-            let left_image = if left_image.col_size() == target_cols {
-                left_image
-            } else {
-                left_image.slice_columns(0, target_cols)
-            };
-            perturbed_syndrome.sub_in_place(&left_image);
-        }
+        let perturbed_syndrome =
+            GpuDCRTPolyMatrix::preimage_residual(target, public_matrix, &p1, &p2);
         tracing::debug!(
             elapsed_ms = perturb_start.elapsed().as_secs_f64() * 1_000.0,
             "gpu preimage: computed perturbed_syndrome"
         );
 
         let assemble_start = Instant::now();
-        let p1_level = p1.level();
-        let p1_is_ntt = p1.is_ntt();
-        let mut out = GpuDCRTPolyMatrix::new_empty_with_state(
-            params,
-            p1_rows + p2_rows,
-            target_cols,
-            p1_level,
-            p1_is_ntt,
-        );
-        out.copy_block_from(&p1, 0, 0, 0, 0, p1_rows, target_cols);
-        out.copy_block_from(&p2, p1_rows, 0, 0, 0, p2_rows, target_cols);
-        drop(p1);
-        drop(p2);
-
         let gauss_start = Instant::now();
         let z_hat_mat =
             perturbed_syndrome.gauss_samp_gq_arb_base(self.c, self.sigma, random_gpu_rng_seed());
@@ -329,49 +296,11 @@ impl PolyTrapdoorSampler for GpuDCRTPolyTrapdoorSampler {
             "gpu preimage: sampled z_hat_mat with gauss_samp_gq_arb_base"
         );
 
-        let r_mul_start = Instant::now();
-        let r_z_hat = &trapdoor.r * &z_hat_mat;
-        tracing::debug!(
-            elapsed_ms = r_mul_start.elapsed().as_secs_f64() * 1_000.0,
-            "gpu preimage: computed r * z_hat"
-        );
-        out.add_block_from(&r_z_hat, 0, 0, 0, 0, r_z_hat.row_size(), target_cols);
+        let out =
+            GpuDCRTPolyMatrix::preimage_assemble(&p1, &p2, &trapdoor.r, &trapdoor.e, &z_hat_mat);
         tracing::debug!(
             elapsed_ms = assemble_start.elapsed().as_secs_f64() * 1_000.0,
-            row_start = 0usize,
-            rows = r_z_hat.row_size(),
-            step = "r_z_hat",
-            "gpu preimage: merged correction block"
-        );
-        drop(r_z_hat);
-
-        let e_mul_start = Instant::now();
-        let e_z_hat = &trapdoor.e * &z_hat_mat;
-        tracing::debug!(
-            elapsed_ms = e_mul_start.elapsed().as_secs_f64() * 1_000.0,
-            "gpu preimage: computed e * z_hat"
-        );
-        out.add_block_from(&e_z_hat, d, 0, 0, 0, e_z_hat.row_size(), target_cols);
-        tracing::debug!(
-            elapsed_ms = assemble_start.elapsed().as_secs_f64() * 1_000.0,
-            row_start = d,
-            rows = e_z_hat.row_size(),
-            step = "e_z_hat",
-            "gpu preimage: merged correction block"
-        );
-        drop(e_z_hat);
-
-        out.add_block_from(&z_hat_mat, 2 * d, 0, 0, 0, z_hat_mat.row_size(), target_cols);
-        tracing::debug!(
-            elapsed_ms = assemble_start.elapsed().as_secs_f64() * 1_000.0,
-            row_start = 2 * d,
-            rows = z_hat_mat.row_size(),
-            step = "z_hat_mat",
-            "gpu preimage: merged correction block"
-        );
-        tracing::debug!(
-            elapsed_ms = assemble_start.elapsed().as_secs_f64() * 1_000.0,
-            "gpu preimage: assembled output matrix"
+            "gpu preimage: assembled output matrix with fused correction"
         );
         tracing::debug!(
             elapsed_ms = preimage_start.elapsed().as_secs_f64() * 1_000.0,
@@ -464,7 +393,7 @@ fn sample_pert_square_mat_gpu_native_parts(
         DistType::GaussDist { sigma: sigma_large },
     );
     tracing::debug!("gpu preimage sample_pert: sampled p2");
-    let tp2 = trapdoor.r.concat_rows(&[&trapdoor.e]) * &p2;
+    let tp2 = GpuDCRTPolyMatrix::mul_vertical_pair(&trapdoor.r, &trapdoor.e, &p2);
     tracing::debug!("gpu preimage sample_pert: computed tp2");
 
     // Keep perturbation generation on device: this sampler uses the full
@@ -620,6 +549,30 @@ mod tests {
         let preimage = trapdoor_sampler.preimage(&params, &trapdoor, &public_matrix, &target);
         let product = &public_matrix * &preimage;
         assert_eq!(product, target);
+    }
+
+    #[test]
+    #[sequential]
+    fn test_gpu_preimage_generation_variable_chunk_widths() {
+        gpu_device_sync();
+        let size = 3usize;
+        let cpu_params = gpu_test_params();
+        let params = gpu_params_from_cpu(&cpu_params);
+        let trapdoor_sampler = GpuDCRTPolyTrapdoorSampler::new(&params, SIGMA);
+        let (trapdoor, public_matrix) = trapdoor_sampler.trapdoor(&params, size);
+        let uniform_sampler = GpuDCRTPolyUniformSampler::new();
+
+        for chunk_width in [1usize, 2, 3, 5, 8] {
+            let target =
+                uniform_sampler.sample_uniform(&params, size, chunk_width, DistType::FinRingDist);
+            let preimage = trapdoor_sampler.preimage(&params, &trapdoor, &public_matrix, &target);
+            assert_eq!(preimage.col_size(), chunk_width);
+            assert_eq!(
+                &public_matrix * &preimage,
+                target,
+                "fused preimage relation failed for runtime chunk width {chunk_width}"
+            );
+        }
     }
 
     #[test]

--- a/src/we/diamond_we/bench_estimator.rs
+++ b/src/we/diamond_we/bench_estimator.rs
@@ -360,9 +360,9 @@ where
 
     fn estimate_storage(&self, shape: DiamondWEBenchShape) -> DiamondWEStorageEstimate {
         let input_injection_metadata_and_seed_bytes =
-            shape.input_injection_metadata_and_seed_bytes();
-        let input_injection_bytes = shape.input_injection_bytes();
-        let we_preimage_bytes = shape.we_preimage_bytes();
+            shape.input_injection_metadata_and_seed_bytes(&self.input_injection_units);
+        let input_injection_bytes = shape.input_injection_bytes(&self.input_injection_units);
+        let we_preimage_bytes = shape.we_preimage_bytes(&self.input_injection_units);
         let total_bytes = input_injection_bytes.clone() + &we_preimage_bytes;
 
         debug!(
@@ -384,14 +384,11 @@ where
 
 #[derive(Debug, Clone)]
 struct DiamondWEBenchShape {
-    ring_dim: usize,
     witness_size: usize,
     instance_size: usize,
     modulus_digits: usize,
-    modulus_bits: u16,
     state_row_size: usize,
     state_col_size: usize,
-    b_public_col_size: usize,
     input_count: usize,
     branch_count: usize,
     input_injection_device_count: usize,
@@ -399,7 +396,6 @@ struct DiamondWEBenchShape {
     final_checkpoint_count: usize,
     transition_matrix_count: usize,
     transition_preimage_chunk_count: usize,
-    input_injection_transition_preimage_bytes: usize,
     online_level_state_counts: Vec<usize>,
     transition_chunk_col_lens: Vec<usize>,
     lookup_bridge_cols: Option<usize>,
@@ -437,12 +433,7 @@ impl DiamondWEBenchShape {
         };
         #[cfg(not(feature = "gpu"))]
         let input_injection_device_count = 1usize;
-        let ring_dim = params.ring_dimension() as usize;
         let modulus_digits = params.modulus_digits();
-        let modulus_bits = params
-            .modulus_bits()
-            .try_into()
-            .expect("DiamondWE modulus bits must fit in u16 for compact-byte estimates");
         let state_row_size =
             2usize.checked_mul(DIAMOND_SECRET_SIZE).expect("DiamondWE state row size overflow");
         let b_public_col_size = state_row_size
@@ -453,13 +444,6 @@ impl DiamondWEBenchShape {
         let transition_chunk_col_lens = (0..chunk_count)
             .map(|chunk_idx| column_chunk_bounds(state_col_size, chunk_idx).1)
             .collect::<Vec<_>>();
-        let transition_chunk_bytes = transition_chunk_col_lens
-            .iter()
-            .map(|&col_len| {
-                matrix_compact_bytes::<M>(params, state_col_size, col_len, modulus_bits)
-            })
-            .collect::<Vec<_>>();
-        let transition_preimage_bytes_per_matrix = transition_chunk_bytes.iter().sum::<usize>();
         let mut transition_matrix_count = 0usize;
         let mut transition_preimage_chunk_count = 0usize;
         let mut online_level_state_counts = Vec::with_capacity(diamond.injector.input_count);
@@ -491,9 +475,6 @@ impl DiamondWEBenchShape {
             .try_fold(0usize, |acc, count| acc.checked_add(count))
             .expect("DiamondWE checkpoint count overflow");
         let final_checkpoint_count = state_count_at_level(diamond, diamond.injector.input_count);
-        let input_injection_transition_preimage_bytes = transition_preimage_bytes_per_matrix
-            .checked_mul(transition_matrix_count)
-            .expect("DiamondWE transition preimage byte count overflow");
         let lookup_bridge_cols = diamond.enc_lookup_base_matrix.as_ref().map(PolyMatrix::col_size);
         assert!(
             diamond.enc_lookup_evaluator_factory.is_none() || lookup_bridge_cols.is_some(),
@@ -503,14 +484,11 @@ impl DiamondWEBenchShape {
             diamond.enc_lookup_evaluator_factory.as_ref().and(lookup_bridge_cols);
 
         Self {
-            ring_dim,
             witness_size: diamond.witness_size,
             instance_size: circuit.num_input() - diamond.witness_size,
             modulus_digits,
-            modulus_bits,
             state_row_size,
             state_col_size,
-            b_public_col_size,
             input_count: diamond.injector.input_count,
             branch_count: diamond.injector.base,
             input_injection_device_count,
@@ -518,7 +496,6 @@ impl DiamondWEBenchShape {
             final_checkpoint_count,
             transition_matrix_count,
             transition_preimage_chunk_count,
-            input_injection_transition_preimage_bytes,
             online_level_state_counts,
             transition_chunk_col_lens,
             lookup_bridge_cols,
@@ -530,57 +507,56 @@ impl DiamondWEBenchShape {
         1usize.checked_add(self.witness_size).expect("DiamondWE ordinary preimage count overflow")
     }
 
-    fn input_injection_metadata_and_seed_bytes(&self) -> BigUint {
+    fn input_injection_metadata_and_seed_bytes(
+        &self,
+        units: &DiamondInputInjectionBenchUnitEstimates,
+    ) -> BigUint {
         let metadata_estimate = 128usize;
-        let p_epsilon_bytes = matrix_compact_bytes_for_shape(
-            self.state_row_size / 2,
-            self.state_col_size,
-            self.ring_dim,
-            self.modulus_bits,
-        );
-        BigUint::from(metadata_estimate + p_epsilon_bytes)
-    }
-
-    fn input_injection_public_checkpoint_bytes(&self) -> usize {
-        matrix_compact_bytes_for_shape(
-            self.state_row_size,
-            self.b_public_col_size,
-            self.ring_dim,
-            self.modulus_bits,
+        BigUint::from(
+            metadata_estimate
+                .checked_add(units.initial_state_compact_bytes)
+                .expect("DiamondWE metadata and seed byte count overflow"),
         )
-        .checked_mul(self.final_checkpoint_count)
-        .expect("DiamondWE B checkpoint byte count overflow")
     }
 
-    fn input_injection_bytes(&self) -> BigUint {
-        self.input_injection_metadata_and_seed_bytes() +
-            BigUint::from(self.input_injection_public_checkpoint_bytes()) +
-            BigUint::from(self.input_injection_transition_preimage_bytes)
+    fn input_injection_public_checkpoint_bytes(
+        &self,
+        units: &DiamondInputInjectionBenchUnitEstimates,
+    ) -> usize {
+        units
+            .checkpoint_matrix_compact_bytes
+            .checked_mul(self.final_checkpoint_count)
+            .expect("DiamondWE B checkpoint byte count overflow")
     }
 
-    fn we_preimage_bytes(&self) -> BigUint {
-        let ordinary_preimage_bytes = matrix_compact_bytes_for_shape(
-            self.state_col_size,
-            self.modulus_digits,
-            self.ring_dim,
-            self.modulus_bits,
-        );
-        let scalar_preimage_bytes = matrix_compact_bytes_for_shape(
-            self.state_col_size,
-            1,
-            self.ring_dim,
-            self.modulus_bits,
-        );
+    fn input_injection_transition_preimage_bytes(
+        &self,
+        units: &DiamondInputInjectionBenchUnitEstimates,
+    ) -> usize {
+        let bytes_per_matrix = self
+            .transition_chunk_col_lens
+            .iter()
+            .try_fold(0usize, |total, &width| {
+                total.checked_add(units.preimage_compact_bytes(width))
+            })
+            .expect("DiamondWE transition preimage matrix byte count overflow");
+        bytes_per_matrix
+            .checked_mul(self.transition_matrix_count)
+            .expect("DiamondWE transition preimage byte count overflow")
+    }
+
+    fn input_injection_bytes(&self, units: &DiamondInputInjectionBenchUnitEstimates) -> BigUint {
+        self.input_injection_metadata_and_seed_bytes(units) +
+            BigUint::from(self.input_injection_public_checkpoint_bytes(units)) +
+            BigUint::from(self.input_injection_transition_preimage_bytes(units))
+    }
+
+    fn we_preimage_bytes(&self, units: &DiamondInputInjectionBenchUnitEstimates) -> BigUint {
+        let ordinary_preimage_bytes = units.chunked_preimage_compact_bytes(self.modulus_digits);
+        let scalar_preimage_bytes = units.chunked_preimage_compact_bytes(1);
         let lookup_preimage_bytes = self
             .lookup_bridge_cols
-            .map(|lookup_cols| {
-                matrix_compact_bytes_for_shape(
-                    self.state_col_size,
-                    lookup_cols,
-                    self.ring_dim,
-                    self.modulus_bits,
-                )
-            })
+            .map(|lookup_cols| units.chunked_preimage_compact_bytes(lookup_cols))
             .unwrap_or(0usize);
 
         BigUint::from(
@@ -662,6 +638,12 @@ impl DiamondWEBenchUnitEstimates {
         let state_col_size = state_row_size
             .checked_mul(modulus_digits + 2)
             .expect("DiamondWE benchmark state col overflow");
+        let mut representative_preimage_widths = vec![1, modulus_digits];
+        if let Some(lookup_width) =
+            diamond.enc_lookup_base_matrix.as_ref().map(PolyMatrix::col_size)
+        {
+            representative_preimage_widths.push(lookup_width);
+        }
         let input_injection_units = DiamondInputInjectionBenchUnitEstimates::benchmark::<M, US, TS>(
             params,
             diamond.injector.trapdoor_sigma,
@@ -669,6 +651,7 @@ impl DiamondWEBenchUnitEstimates {
             iterations,
             state_row_size,
             state_col_size,
+            &representative_preimage_widths,
         );
         let trapdoor_checkpoint = input_injection_units.trapdoor_checkpoint.clone();
         let transition_preimage = input_injection_units.transition_preimage.clone();
@@ -719,30 +702,6 @@ where
                 .expect("DiamondWE expanded state count overflow"),
         )
         .expect("DiamondWE expanded state count overflow")
-}
-
-fn matrix_compact_bytes<M>(
-    params: &<M::P as Poly>::Params,
-    nrow: usize,
-    ncol: usize,
-    modulus_bits: u16,
-) -> usize
-where
-    M: PolyMatrix,
-{
-    matrix_compact_bytes_for_shape(nrow, ncol, params.ring_dimension() as usize, modulus_bits)
-}
-
-fn matrix_compact_bytes_for_shape(
-    nrow: usize,
-    ncol: usize,
-    ring_dim: usize,
-    modulus_bits: u16,
-) -> usize {
-    let coeff_count =
-        nrow.checked_mul(ncol).and_then(|count| count.checked_mul(ring_dim)).unwrap_or(usize::MAX);
-    let payload = coeff_count.checked_mul(modulus_bits as usize).unwrap_or(usize::MAX).div_ceil(8);
-    payload + 128
 }
 
 fn bench_estimate<R, F>(iterations: usize, mut op: F) -> CircuitBenchEstimate
@@ -1034,6 +993,9 @@ mod tests {
             online_rhs_chunk_read_decode: small_input_injection_unit(),
             online_output_chunk_serialize: small_input_injection_unit(),
             online_output_recompose: small_input_injection_unit(),
+            checkpoint_matrix_compact_bytes: 1_000,
+            initial_state_compact_bytes: 500,
+            preimage_compact_bytes_by_width: (1..=256).map(|width| (width, width * 100)).collect(),
         };
         DiamondWEBenchEstimator {
             public_key_estimator: bgg,
@@ -1061,10 +1023,12 @@ mod tests {
         let params = DCRTPolyParams::default();
         let witness_size = 2;
         let we = diamond_we(params, witness_size);
+        let test_circuit = circuit(witness_size + 1);
         let bgg = DummyBggBenchEstimator;
         let native = DummyNativeBenchEstimator;
         let estimator = estimator(&bgg, &native);
-        let estimate = estimator.estimate(&we, &circuit(witness_size + 1));
+        let shape = DiamondWEBenchShape::from_diamond_and_circuit(&we, &test_circuit);
+        let estimate = estimator.estimate(&we, &test_circuit);
 
         assert!(!estimate.enc.total_time.is_zero());
         assert!(!estimate.dec.total_time.is_zero());
@@ -1077,6 +1041,16 @@ mod tests {
             estimate.ciphertext_bytes,
             estimate.input_injection_bytes.clone() + estimate.we_preimage_bytes.clone()
         );
+        let transition_bytes_per_matrix =
+            shape.transition_chunk_col_lens.iter().map(|width| width * 100).sum::<usize>();
+        let expected_input_injection_bytes = 128usize +
+            500 +
+            1_000 * shape.final_checkpoint_count +
+            transition_bytes_per_matrix * shape.transition_matrix_count;
+        let expected_we_preimage_bytes =
+            100 * shape.modulus_digits * shape.ordinary_preimage_count() + 2 * 100;
+        assert_eq!(estimate.input_injection_bytes, BigUint::from(expected_input_injection_bytes));
+        assert_eq!(estimate.we_preimage_bytes, BigUint::from(expected_we_preimage_bytes));
         assert!(!estimate.enc.max_parallelism.is_zero());
         assert!(!estimate.dec.max_parallelism.is_zero());
     }

--- a/tests/test_gpu_diamond_we.rs
+++ b/tests/test_gpu_diamond_we.rs
@@ -779,6 +779,13 @@ async fn test_gpu_diamond_we_error_search_bench_estimate_and_round_trip() {
     assert!(estimate.enc.total_time > BigUint::from(0u32));
     assert!(estimate.dec.total_time > BigUint::from(0u32));
     assert!(estimate.ciphertext_bytes > BigUint::from(0u32));
+    if env::var("DIAMOND_WE_GPU_BENCH_ESTIMATE_ONLY")
+        .ok()
+        .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+    {
+        info!("DiamondWE GPU estimate-only mode finished before round trip");
+        return;
+    }
 
     let witness = { vec![true; cfg.witness_size] };
     let instance = vec![true; cfg.instance_size()];


### PR DESCRIPTION
## Summary

- Fuse GPU trapdoor preimage sampling across CUDA and Rust layers.
- Update matrix trapdoor kernels, DCRT polynomial operations, and GPU sampler integration.
- Reduce intermediate data movement in the preimage sampling path.

## Testing

Not run (not requested).